### PR TITLE
Fix: [CRITICAL] Fix enterprise capstone Docker setup paths (closes #37)

### DIFF
--- a/14-application-architecture/enterprise-capstone/Dockerfile
+++ b/14-application-architecture/enterprise-capstone/Dockerfile
@@ -16,7 +16,7 @@ RUN go mod download
 COPY . .
 
 # Build the binary explicitly from the capstone api entrypoint
-RUN CGO_ENABLED=0 GOOS=linux go build -o api-binary ./22-enterprise-capstone/cmd/api
+RUN CGO_ENABLED=0 GOOS=linux go build -o api-binary ./14-application-architecture/enterprise-capstone/cmd/api
 
 
 # STAGE 2: Runner

--- a/14-application-architecture/enterprise-capstone/docker-compose.yml
+++ b/14-application-architecture/enterprise-capstone/docker-compose.yml
@@ -39,8 +39,8 @@ services:
   api:
     build:
       # Context is the root repo so Docker can access go.mod and parent folders
-      context: .. 
-      dockerfile: 22-enterprise-capstone/Dockerfile
+      context: ../../ 
+      dockerfile: 14-application-architecture/enterprise-capstone/Dockerfile
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
This PR fixes the incorrect build context and Dockerfile paths in the enterprise capstone project, which were causing build failures.