### PR TITLE
Fix: [BUG] Fix nil pointer dereference in slog.NewTextHandler (closes #39)

### DIFF
--- a/12-concurrency-patterns/2-errgroup-context/main.go
+++ b/12-concurrency-patterns/2-errgroup-context/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
+	"os"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -142,7 +143,7 @@ func resultCollector(ctx context.Context, results <-chan Result) error {
 }
 
 func main() {
-	slog.SetDefault(slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
 
 	fmt.Println("=== Fan-out pipeline with errgroup.WithContext ===")
 	start := time.Now()


### PR DESCRIPTION
This PR fixes a nil pointer dereference panic in the errgroup-context lesson by replacing a nil writer in slog.NewTextHandler with os.Stderr.