### PR TITLE
docs: announce public v2 planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format: **[Date] - Description**. Sections: `Added`, `Fixed`, `Changed`, `Remove
 
 ---
 
+## [2026-04-07] - Public v2 Planning Kickoff
+
+### Added
+
+- Created the public `planning/v2` branch for the v2 Bible, migration planning, and structural prototype specs.
+- Opened the first public v2 planning and prototype issues (#79-#88).
+- Created the public v2 GitHub Project for planning and execution tracking.
+
+### Changed
+
+- Updated learner-facing docs to explain the v1/v2 transition more clearly.
+- Clarified that `release/v1` remains the stable learner path while v2 is designed and rolled out incrementally.
+
+---
+
 ## [2026-04-06] - Long-Lived v1/v2 Branch Workflow
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ The repository now uses a long-lived branch model for the v1 to v2 transition:
 
 If you want the stable v1 curriculum, check out `release/v1` or a stable `v1.x.y` tag. If you want the newest v2 work as it lands section by section, stay on `main`.
 
+## V2 Update
+
+v2 planning is now happening in public.
+
+- If you want the most stable learner experience today, use `release/v1`.
+- If you want to follow the v2 redesign as it is being planned, see the [V2 Bible on `planning/v2`](https://github.com/rasel9t6/the-go-engineer/blob/planning/v2/docs/v2/BIBLE.md).
+- Public v2 planning work is tracked in the [V2 project board](https://github.com/users/rasel9t6/projects/2) and the initial planning issues [#79](https://github.com/rasel9t6/the-go-engineer/issues/79) through [#88](https://github.com/rasel9t6/the-go-engineer/issues/88).
+- No learner migration is required today. v1 remains supported while v2 is designed and rolled out incrementally.
+
+The short version: learn on `release/v1` if you want stability today, and watch `main` plus `planning/v2` if you want to follow the next version as it takes shape.
+
 ## Choose Your Learning Path
 
 New to Go? → **Start at [01-core-foundations](./01-core-foundations/)**  

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,16 @@ This document tracks what is built, what is in progress, and what is planned.
 - `release/v1` tracks stable v1 maintenance for current users.
 - `release/v2` will be cut from `main` when v2 reaches beta and feature freeze.
 
+## Current V2 Focus
+
+As of April 7, 2026, the v2 transition is in the public planning and prototype-design phase.
+
+- Stable learners should keep using `release/v1`.
+- Public v2 planning now lives on [`planning/v2`](https://github.com/rasel9t6/the-go-engineer/tree/planning/v2).
+- Design work is tracked in the [V2 project board](https://github.com/users/rasel9t6/projects/2).
+- Initial public planning issues are [#79](https://github.com/rasel9t6/the-go-engineer/issues/79) through [#88](https://github.com/rasel9t6/the-go-engineer/issues/88).
+- Broad content migration will not begin until the structural prototype is approved.
+
 ## Status Legend
 
 | Symbol | Meaning |


### PR DESCRIPTION
## Summary

Publishes the first learner-facing v2 status update on main.

This PR:
- adds a concise V2 Update section to the README
- adds a current v2 focus section to the roadmap
- records the public v2 planning kickoff in the changelog

## Public Links
- planning/v2: https://github.com/rasel9t6/the-go-engineer/tree/planning/v2
- V2 Bible: https://github.com/rasel9t6/the-go-engineer/blob/planning/v2/docs/v2/BIBLE.md
- V2 project: https://github.com/users/rasel9t6/projects/2
- Initial planning issues: #79-#88

## Notes
- This is a docs-only PR.
- The goal is to tell current users what v2 means right now without forcing any migration.