### PR TITLE
Launch the Section 05 v2 pilot slice

### DIFF
--- a/05-types-and-interfaces/6-payroll-processor/README.md
+++ b/05-types-and-interfaces/6-payroll-processor/README.md
@@ -1,0 +1,79 @@
+# TI.6 Payroll Processor Project
+
+## Mission
+
+Build a small payroll system that proves multiple concrete employee types can share one behavior
+contract through interfaces instead of inheritance.
+
+This exercise is the Section 05 milestone.
+It is where structs, methods, interfaces, and a small generic helper come together in one runnable
+artifact with tests.
+
+## Prerequisites
+
+Complete these first:
+
+- `TI.1` structs
+- `TI.2` methods
+- `TI.3` interfaces
+- `TI.4` Stringer
+- `TI.5` generics
+
+## What You Will Build
+
+Implement a small payroll processor that:
+
+1. defines a `Payable` interface with behavior contracts
+2. models multiple concrete employee types with structs
+3. attaches pay-calculation behavior through methods
+4. processes a mixed `[]Payable` collection polymorphically
+5. includes one small generic helper for reusable summary/report output
+6. verifies core pay calculations with tests
+
+## Files
+
+- [main.go](./main.go): complete solution with teaching comments
+- [payroll_test.go](./payroll_test.go): tests for the pay-calculation contract
+- [_starter/main.go](./_starter/main.go): starter file with TODOs and requirements
+
+## Run Instructions
+
+Run the completed solution:
+
+```bash
+go run ./05-types-and-interfaces/6-payroll-processor
+```
+
+Run the tests:
+
+```bash
+go test ./05-types-and-interfaces/6-payroll-processor
+```
+
+Run the starter:
+
+```bash
+go run ./05-types-and-interfaces/6-payroll-processor/_starter
+```
+
+## Success Criteria
+
+Your finished solution should:
+
+- use interfaces to describe the payroll behavior boundary
+- allow multiple employee types to satisfy the same contract cleanly
+- keep receiver choices intentional and easy to explain
+- include one small generic helper without turning the exercise into a generics showcase
+- pass the provided tests
+
+## Common Failure Modes
+
+- building separate payroll logic for each employee type instead of using one interface
+- using pointer receivers or value receivers without being able to explain why
+- treating generics as the main point of the exercise instead of a small reuse helper
+- tightly coupling `ProcessPayroll` to one concrete employee struct
+
+## Next Step
+
+After you complete this exercise, move to [TI.7 advanced generics](../7-advanced-generics) for a
+stretch lesson, or continue to [Section 06](../../06-composition) if you are ready to move on.

--- a/05-types-and-interfaces/6-payroll-processor/_starter/main.go
+++ b/05-types-and-interfaces/6-payroll-processor/_starter/main.go
@@ -20,11 +20,13 @@ import "fmt"
 //  4. [ ] Implement `CommissionEmployee` — pay = BaseSalary + (CommissionRate * SalesAmount)
 //  5. [ ] Create a `ProcessPayroll(employees []Payable)` function that prints each
 //         employee's info, monthly pay, and calculates the total payroll cost
+//  6. [ ] Add one small generic helper for reusable employee summary output
 //
 // HINTS:
 //   - Any type implementing CalculatePay() and String() satisfies Payable
 //   - Use fmt.Sprintf in String() to format employee details
 //   - Range over the []Payable slice to process all employees generically
+//   - A small generic helper can constrain on `fmt.Stringer`
 //
 // RUN: go run ./05-types-and-interfaces/6-payroll-processor/_starter
 // SOLUTION: See the main.go file in the parent directory

--- a/05-types-and-interfaces/README.md
+++ b/05-types-and-interfaces/README.md
@@ -1,47 +1,99 @@
-# Section 5: Types & Interfaces
+# Section 05: Types and Interfaces
 
-## Beginner → Expert Mapping
+## Mission
 
-| Topic | Level | Importance | Engineering Concept |
-|-------|-------|------------|---------------------|
-| Structs | Beginner | High | Data encapsulation without classes |
-| Methods | Intermediate | High | Value vs Pointer Receivers |
-| Interfaces | Intermediate | **Critical** | Duck typing, dependency inversion |
-| Generics | Advanced | Medium | Type parameters, constraints |
+This section teaches you to model data with structs, attach behavior with methods, and define
+behavior contracts with interfaces instead of inheritance.
 
-## Engineering Depth
+By the end of Section 05, you should be comfortable reading and writing:
 
-Go is not a traditional Object-Oriented language; it lacks inheritance (`extends`). Instead, it uses strictly composition and **implicit interfaces** (duck typing).
+- structs that model real domain data
+- methods with clear receiver intent
+- interfaces that describe behavior boundaries
+- small generic helpers built on interface-aware constraints
+- polymorphic code that works across multiple concrete types
 
-- **Memory mechanics:** When defining methods, using a pointer receiver `func (u *User) Login()` passes the memory address (8 bytes). Using a value receiver `func (u User) Login()` creates a copy of the entire struct on the stack. Large structs should always use pointer receivers.
-- **Interfaces:** Interfaces in Go are stored as a two-word internal structure combining a pointer to the type information and a pointer to the underlying data.
+## Who Should Start Here
+
+### Full Path
+
+Start here after completing Section 04 in order.
+
+### Bridge Path
+
+You can move faster if you already understand:
+
+- functions and multiple return values
+- explicit error handling
+- basic pointer usage
+- slices and maps
+
+Even on the bridge path, do not skip `TI.3` through `TI.6`.
+Those lessons carry the main engineering value of the section.
+
+### Targeted Path
+
+If you are here mainly for interfaces and polymorphism, review these first:
+
+- `TI.1` structs
+- `TI.2` methods
+
+## Section Map
+
+| ID | Type | Surface | Why It Matters | Requires |
+| --- | --- | --- | --- | --- |
+| `TI.1` | Lesson | [structs](./1-struct) | Introduces Go's main data-modeling tool without hidden class behavior. | entry |
+| `TI.2` | Lesson | [methods](./2-methods) | Shows how behavior attaches to types and why receiver choice matters. | `TI.1` |
+| `TI.3` | Lesson | [interfaces](./3-interfaces) | Teaches implicit contracts and polymorphism without inheritance. | `TI.1`, `TI.2` |
+| `TI.4` | Lesson | [Stringer](./4-stringer) | Connects custom types to a standard-library interface in a practical way. | `TI.2`, `TI.3` |
+| `TI.5` | Lesson | [generics](./5-generics) | Introduces reusable, type-safe helper patterns built on constraints. | `TI.3`, `TI.4` |
+| `TI.6` | Exercise | [payroll processor project](./6-payroll-processor) | Combines structs, methods, interfaces, and a small generic helper into one milestone. | `TI.1`, `TI.2`, `TI.3`, `TI.4`, `TI.5` |
+| `TI.7` | Stretch Lesson | [advanced generics](./7-advanced-generics) | Pushes generic collection helpers further once the core section feels solid. | `TI.5` |
+
+## Suggested Order
+
+1. Work through `TI.1` to `TI.5` in order.
+2. Complete `TI.6` without copying the finished solution line by line.
+3. Use `TI.7` as a stretch lesson before moving to the next section.
+
+## Section Milestone
+
+`TI.6` is the current live milestone for this pilot section.
+
+If you can complete it and explain:
+
+- why structs and methods replace class-style design in Go
+- why interfaces describe behavior better than inheritance hierarchies
+- why a small generic helper can improve reuse without making the API harder to read
+
+then you are ready to move into composition and embedding in Section 06.
+
+## Pilot Role In V2
+
+This live v2 slice keeps the current Section 05 paths and `TI.*` ids stable while upgrading the
+learner-facing structure:
+
+- `TI.1` through `TI.5` are the core lessons
+- `TI.6` is the milestone exercise
+- `TI.7` is an optional stretch lesson
+
+That keeps the section useful for current learners while the broader v2 migration continues.
+
+## Legacy To Pilot Mapping
+
+This pilot intentionally avoids breaking the current Section 05 filesystem layout.
+
+- `TI.1` through `TI.5` keep their existing lesson directories
+- `TI.6` stays at `05-types-and-interfaces/6-payroll-processor`, now treated as the section
+  milestone surface
+- `TI.7` stays at `05-types-and-interfaces/7-advanced-generics` as an optional stretch lesson
 
 ## References
 
-1. **[Effective Go]** [Interfaces and other types](https://go.dev/doc/effective_go#interfaces_and_types)
-2. **[Go Blog]** [An Introduction to Generics](https://go.dev/blog/intro-generics)
+1. [Interfaces and other types](https://go.dev/doc/effective_go#interfaces_and_types)
+2. [An Introduction to Generics](https://go.dev/blog/intro-generics)
 
----
+## Next Step
 
-## 🏗 Exercise: Payroll Processor (`6-payroll-processor`)
-
-This capstone requires leveraging Interfaces to build polymorphic systems without inheritance.
-
-### Step-by-Step Instructions & Hints
-
-1. **Define the interface:** Create an `Employee` interface with a `CalculatePay() float64` method.
-2. **Build implementations:** Create `FullTime` (Base Salary) and `Contractor` (Hourly * Hours) structs.
-3. **Implement methods:** Attach the `CalculatePay()` method to both structs using value receivers (since the calculation shouldn't modify the struct state).
-4. **Process Payroll:** Create a `ProcessPayroll(employees []Employee)` function that iterates the slice, calls the method, and prints a total.
-   - *Hint:* Because both structs implement the interface method, the slice can hold mixed types perfectly!
-
-
-## Learning Path
-
-| ID | Lesson | Concept | Requires |
-| --- | --- | --- | --- |
-| TI.1 | [structs](./1-struct) | Field layout · constructor pattern · value vs pointer copy | 🟢 entry |
-| TI.2 | [methods](./2-methods) | Value receiver vs pointer receiver · method sets | TI.1 |
-| TI.3 | [interfaces](./3-interfaces) | Implicit satisfaction · polymorphism · type assertions | TI.1, TI.2 |
-| TI.4 | [Stringer](./4-stringer) | fmt.Stringer · named type on int · custom Weekday | TI.2, TI.3 |
-| TI.5 | [generics](./5-generics) | [T constraint] · comparable · union constraints · Map/Filter | TI.3, TI.4 |
+After `TI.6`, continue to [Section 06: Composition](../06-composition).
+If you want one more stretch lesson before moving on, finish `TI.7` first.

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -17,6 +17,25 @@
       "outputs": [
         "FE.9"
       ]
+    },
+    {
+      "id": "s05",
+      "number": "05",
+      "slug": "types-and-interfaces",
+      "title": "Types and Interfaces",
+      "phase": "foundations",
+      "summary": "Teach learners to model data with structs, attach behavior with methods, and rely on interfaces and generics to build reusable contracts.",
+      "status": "pilot",
+      "prerequisites": [
+        "s04"
+      ],
+      "path_prefix": "05-types-and-interfaces",
+      "entry_points": [
+        "TI.1"
+      ],
+      "outputs": [
+        "TI.6"
+      ]
     }
   ],
   "items": [
@@ -344,6 +363,234 @@
         "patterns",
         "configuration",
         "api-design"
+      ]
+    },
+    {
+      "id": "TI.1",
+      "section_id": "s05",
+      "slug": "structs",
+      "title": "Structs",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "foundation",
+      "verification_mode": "run",
+      "estimated_time": 30,
+      "summary": "Introduce structs as Go's core data-modeling tool without inheritance or hidden class behavior.",
+      "objectives": [
+        "Define structs that group related data into readable shapes",
+        "Explain when passing a struct by value copies data and when a pointer avoids that cost"
+      ],
+      "prerequisites": [],
+      "production_relevance": "Struct design is the basis for every later Go model, request payload, configuration shape, and domain type.",
+      "path": "05-types-and-interfaces/1-struct",
+      "run_command": "go run ./05-types-and-interfaces/1-struct",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "TI.2"
+      ],
+      "tags": [
+        "structs",
+        "data-modeling",
+        "foundations"
+      ]
+    },
+    {
+      "id": "TI.2",
+      "section_id": "s05",
+      "slug": "methods",
+      "title": "Methods",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 30,
+      "summary": "Show how methods attach behavior to types and why receiver choice affects semantics and performance.",
+      "objectives": [
+        "Define methods on concrete types with clear receiver intent",
+        "Explain the tradeoff between value receivers and pointer receivers"
+      ],
+      "prerequisites": [
+        "TI.1"
+      ],
+      "production_relevance": "Receiver choice affects mutability, method sets, and copy costs in real Go APIs, not just toy examples.",
+      "path": "05-types-and-interfaces/2-methods",
+      "run_command": "go run ./05-types-and-interfaces/2-methods",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "TI.3"
+      ],
+      "tags": [
+        "methods",
+        "receivers",
+        "semantics"
+      ]
+    },
+    {
+      "id": "TI.3",
+      "section_id": "s05",
+      "slug": "interfaces",
+      "title": "Interfaces",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 40,
+      "summary": "Teach interface contracts, implicit satisfaction, and how Go achieves polymorphism without inheritance.",
+      "objectives": [
+        "Explain implicit interface satisfaction without relying on class-style inheritance",
+        "Use interfaces to describe behavior boundaries instead of concrete implementation details"
+      ],
+      "prerequisites": [
+        "TI.1",
+        "TI.2"
+      ],
+      "production_relevance": "Interfaces define seams for testing, package boundaries, and flexible architecture in production Go systems.",
+      "path": "05-types-and-interfaces/3-interfaces",
+      "run_command": "go run ./05-types-and-interfaces/3-interfaces",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "TI.4"
+      ],
+      "tags": [
+        "interfaces",
+        "contracts",
+        "polymorphism"
+      ]
+    },
+    {
+      "id": "TI.4",
+      "section_id": "s05",
+      "slug": "stringer",
+      "title": "Stringer",
+      "type": "lesson",
+      "subtype": "integration",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 25,
+      "summary": "Use fmt.Stringer as the first standard-library interface integration point for custom types.",
+      "objectives": [
+        "Implement fmt.Stringer to give custom values readable string output",
+        "Connect concrete type methods to a standard-library interface contract"
+      ],
+      "prerequisites": [
+        "TI.2",
+        "TI.3"
+      ],
+      "production_relevance": "Readable String methods improve logs, debug output, and CLI feedback without scattering formatting logic everywhere.",
+      "path": "05-types-and-interfaces/4-stringer",
+      "run_command": "go run ./05-types-and-interfaces/4-stringer",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "TI.5"
+      ],
+      "tags": [
+        "interfaces",
+        "stringer",
+        "standard-library"
+      ]
+    },
+    {
+      "id": "TI.5",
+      "section_id": "s05",
+      "slug": "generics",
+      "title": "Generics",
+      "type": "lesson",
+      "subtype": "pattern",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 40,
+      "summary": "Introduce type parameters and constraints as a way to write reusable, type-safe helpers without reflection.",
+      "objectives": [
+        "Use type parameters and constraints to generalize helper logic safely",
+        "Recognize when generics improve reuse and when a concrete function is clearer"
+      ],
+      "prerequisites": [
+        "TI.3",
+        "TI.4"
+      ],
+      "production_relevance": "Generics help remove duplicate collection helpers and reusable utilities while preserving compile-time type safety.",
+      "path": "05-types-and-interfaces/5-generics",
+      "run_command": "go run ./05-types-and-interfaces/5-generics",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "TI.6"
+      ],
+      "tags": [
+        "generics",
+        "constraints",
+        "reuse"
+      ]
+    },
+    {
+      "id": "TI.6",
+      "section_id": "s05",
+      "slug": "payroll-processor-project",
+      "title": "Payroll Processor Project",
+      "type": "exercise",
+      "subtype": "",
+      "level": "core",
+      "verification_mode": "mixed",
+      "estimated_time": 75,
+      "summary": "Combine structs, methods, interfaces, and a small generic helper into one polymorphic payroll exercise.",
+      "objectives": [
+        "Build a small payroll domain that relies on interface contracts instead of inheritance",
+        "Show that multiple concrete employee types can be processed through one common behavior boundary"
+      ],
+      "prerequisites": [
+        "TI.1",
+        "TI.2",
+        "TI.3",
+        "TI.4",
+        "TI.5"
+      ],
+      "production_relevance": "Real Go services often model multiple concrete types behind shared interfaces, especially in payment, billing, and reporting flows.",
+      "path": "05-types-and-interfaces/6-payroll-processor",
+      "run_command": "go run ./05-types-and-interfaces/6-payroll-processor",
+      "test_command": "go test ./05-types-and-interfaces/6-payroll-processor",
+      "starter_path": "05-types-and-interfaces/6-payroll-processor/_starter",
+      "next_items": [
+        "TI.7"
+      ],
+      "tags": [
+        "exercise",
+        "interfaces",
+        "polymorphism",
+        "generics"
+      ]
+    },
+    {
+      "id": "TI.7",
+      "section_id": "s05",
+      "slug": "advanced-generics",
+      "title": "Advanced Generics",
+      "type": "lesson",
+      "subtype": "pattern",
+      "level": "stretch",
+      "verification_mode": "run",
+      "estimated_time": 35,
+      "summary": "Push generics further with reusable collection operators and a clearer understanding of type inference limits.",
+      "objectives": [
+        "Use generic collection helpers like map and filter without losing type clarity",
+        "Explain where type inference helps and where generic APIs become too clever"
+      ],
+      "prerequisites": [
+        "TI.5"
+      ],
+      "production_relevance": "Advanced generic helpers can reduce repetition in utility layers, but they only help when the resulting API stays readable for teams.",
+      "path": "05-types-and-interfaces/7-advanced-generics",
+      "run_command": "go run ./05-types-and-interfaces/7-advanced-generics",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [],
+      "tags": [
+        "generics",
+        "advanced",
+        "collections"
       ]
     }
   ]


### PR DESCRIPTION
## Description

This PR launches the second live v2 pilot slice by extending the additive migration pattern from Section 04 into Section 05.

It does four connected things:
- adds the first Section 05 slice to `curriculum.v2.json`
- keeps the current `TI.*` ids and filesystem paths stable while introducing typed v2 metadata
- upgrades the learner-facing Section 05 README into the v2 pilot shape
- adds a dedicated README for the `TI.6` payroll milestone and aligns the starter requirements with the real solution contract

Like the Section 04 pilot, this PR intentionally improves structure without forcing an early path rewrite.

Closes #102
Closes #103
Closes #104

## What Changed

- added the Section 05 v2 metadata slice to `curriculum.v2.json`
- rewrote `05-types-and-interfaces/README.md` into the learner-facing v2 pilot format
- added `05-types-and-interfaces/6-payroll-processor/README.md`
- updated `05-types-and-interfaces/6-payroll-processor/_starter/main.go` so the milestone contract explicitly includes the small generic helper already present in the solution

## Why

Section 04 proved the first live v2 slice can land on `main`. This PR proves the same migration pattern scales into the next adjacent learner section without breaking the current repo layout.

## Validation

- `go run ./scripts/validate_curriculum.go`
- `go run ./05-types-and-interfaces/6-payroll-processor`
- `go test ./05-types-and-interfaces/6-payroll-processor`
- `go run ./05-types-and-interfaces/6-payroll-processor/_starter`
- `go build ./...`
- `go vet ./...`
- `go test ./...`

Note: in this Windows environment these commands were run with a workspace-local `GOCACHE` to avoid OS-level cache permission issues outside the repo.