### PR TITLE
Launch the Section 08 v2 pilot slice

### DIFF
--- a/08-modules-and-packages/1-module-basics/main.go
+++ b/08-modules-and-packages/1-module-basics/main.go
@@ -8,7 +8,7 @@ package main
 import "fmt"
 
 // ============================================================================
-// Section 8: Modules & Dependency Management — Module Basics
+// Section 08: Modules and Packages — Module Basics
 // Level: Beginner → Intermediate
 // ============================================================================
 //
@@ -32,7 +32,7 @@ import "fmt"
 //
 // File: go.mod
 //
-//	module github.com/rasel9t6/the-go-engineer ← Module path: the root import path for ALL packages
+//	module github.com/rasel9t6/the-go-engineer ← Module path: the root import path for all packages
 //	go 1.24                                    ← Minimum Go version required to build
 //
 //	require (
@@ -42,7 +42,7 @@ import "fmt"
 //	)
 //
 //	require (
-//	    github.com/davecgh/go-spew v1.1.1 // indirect ← Transitive dep (pulled by testify)
+//	    github.com/davecgh/go-spew v1.1.1 // indirect ← Transitive dependency
 //	    github.com/stretchr/objx v0.5.2 // indirect   ← Pulled by testify/mock
 //	)
 //
@@ -62,21 +62,19 @@ import "fmt"
 //    - ALWAYS commit go.sum to version control
 //
 // 4. // indirect means YOUR code doesn't import it directly.
-//    - A dependency of one of your dependencies.
+//    - It came from one of your dependencies.
 //    - go mod tidy adds this annotation automatically.
 
 func main() {
 	fmt.Println("=== Go Module Basics ===")
 	fmt.Println()
 
-	// Demonstrate how import paths map to module structure
 	fmt.Println("Module path: github.com/rasel9t6/the-go-engineer")
-	fmt.Println("This means all packages in this repo are importable as:")
+	fmt.Println("This means packages in this repo are importable as:")
 	fmt.Println("  github.com/rasel9t6/the-go-engineer/10-web-and-database/databases/6-repository/models")
 	fmt.Println("  github.com/rasel9t6/the-go-engineer/10-web-and-database/databases/6-repository/repository")
 	fmt.Println()
 
-	// Show the essential commands
 	commands := []struct {
 		cmd  string
 		desc string
@@ -97,6 +95,7 @@ func main() {
 	for _, c := range commands {
 		fmt.Printf("  %-32s — %s\n", c.cmd, c.desc)
 	}
+
 	fmt.Println("\n---------------------------------------------------")
 	fmt.Println("🚀 NEXT UP: MP.2 managing deps")
 	fmt.Println("   Current: MP.1 (module basics)")

--- a/08-modules-and-packages/2-managing-deps/main.go
+++ b/08-modules-and-packages/2-managing-deps/main.go
@@ -2,15 +2,8 @@
 // Licensed under The Go Engineer License v1.0
 // Commercial use is prohibited without permission.
 
-package main
-
-// ============================================================================
-// Section 8: Modules & Dependencies — Managing Dependencies
-// Level: Intermediate
-// ============================================================================
-//
 // RUN: go run ./08-modules-and-packages/2-managing-deps
-// ============================================================================
+package main
 
 import (
 	"fmt"
@@ -19,11 +12,11 @@ import (
 )
 
 // ============================================================================
-// Section 8: Managing Dependencies
+// Section 08: Modules and Packages — Managing Dependencies
 // Level: Intermediate
 // ============================================================================
 //
-// This file demonstrates dependency management workflows.
+// This file demonstrates dependency-management workflows.
 // Run the commands below in a terminal to see them in action.
 //
 // ADDING DEPENDENCIES:
@@ -50,14 +43,13 @@ func main() {
 	fmt.Println("=== Managing Dependencies ===")
 	fmt.Println()
 
-	// Run "go list -m all" to show current dependencies
 	fmt.Println("Current module dependencies:")
 	fmt.Println(strings.Repeat("-", 60))
 
 	out, err := exec.Command("go", "list", "-m", "all").Output()
 	if err != nil {
 		fmt.Printf("Error running 'go list -m all': %v\n", err)
-		fmt.Println("(This is expected if CGO is not available for sqlite3)")
+		fmt.Println("(This can happen if CGO-backed dependencies are unavailable.)")
 		return
 	}
 
@@ -66,24 +58,23 @@ func main() {
 		if line == "" {
 			continue
 		}
-		// Classify as direct or indirect
 		if strings.Contains(line, "the-go-engineer") {
-			fmt.Printf("  [ROOT]     %s\n", line)
-		} else {
-			fmt.Printf("  [DEP]      %s\n", line)
+			fmt.Printf("  [ROOT] %s\n", line)
+			continue
 		}
+		fmt.Printf("  [DEP]  %s\n", line)
 	}
 
 	fmt.Println()
 	fmt.Println(strings.Repeat("-", 60))
-
-	// Show why a specific indirect dependency exists
 	fmt.Println("\nWhy do we have github.com/stretchr/objx?")
+
 	whyOut, err := exec.Command("go", "mod", "why", "github.com/stretchr/objx").Output()
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
 	}
+
 	fmt.Println(string(whyOut))
 	fmt.Println("\n---------------------------------------------------")
 	fmt.Println("🚀 NEXT UP: MP.3 versioning")

--- a/08-modules-and-packages/3-versioning/README.md
+++ b/08-modules-and-packages/3-versioning/README.md
@@ -1,0 +1,77 @@
+# MP.3 Versioning Workshop
+
+## Mission
+
+Build a small semantic-versioning and module-policy demo that makes Go's version rules concrete.
+
+This exercise is the Section 08 milestone.
+It is where module identity, compatibility boundaries, and `replace` reasoning come together in
+one runnable artifact with tests.
+
+## Prerequisites
+
+Complete these first:
+
+- `MP.1` module basics
+- `MP.2` managing dependencies
+
+## What You Will Build
+
+Implement a small versioning helper that:
+
+1. models semantic versions with a `Version` struct
+2. formats versions consistently as `vMAJOR.MINOR.PATCH`
+3. detects compatibility based on the major version boundary
+4. compares versions to decide which one is newer
+5. prints a clear explanation of the `/v2` import-path rule
+6. passes the provided unit tests
+
+## Files
+
+- [main.go](./main.go): complete solution with teaching comments
+- [version_test.go](./version_test.go): tests for the version helper behavior
+- [_starter/main.go](./_starter/main.go): starter file with TODOs and requirements
+
+## Run Instructions
+
+Run the completed solution:
+
+```bash
+go run ./08-modules-and-packages/3-versioning
+```
+
+Run the tests:
+
+```bash
+go test ./08-modules-and-packages/3-versioning
+```
+
+Run the starter:
+
+```bash
+go run ./08-modules-and-packages/3-versioning/_starter
+```
+
+## Success Criteria
+
+Your finished solution should:
+
+- return versions in the `vX.Y.Z` format
+- treat matching major versions as compatible
+- compare major, then minor, then patch when deciding which version is newer
+- explain why v2+ modules require a new import path
+- explain when `replace` helps and when it should be used carefully
+- pass the provided tests
+
+## Common Failure Modes
+
+- treating minor or patch bumps as breaking changes
+- comparing versions lexicographically instead of numerically
+- forgetting that a v2 module needs `/v2` in the import path
+- using `replace` as a permanent escape hatch instead of a deliberate local-development tool
+
+## Next Step
+
+After you complete this exercise, continue to [Section 09](../../09-io-and-cli) if you are ready
+to move on.
+If you want one more stretch lesson first, visit [`MP.4` build tags](../4-build-tags).

--- a/08-modules-and-packages/3-versioning/_starter/main.go
+++ b/08-modules-and-packages/3-versioning/_starter/main.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Rasel Hossen
+// Licensed under The Go Engineer License v1.0
+// Commercial use is prohibited without permission.
+
+// RUN: go run ./08-modules-and-packages/3-versioning/_starter
+package main
+
+import "fmt"
+
+// ============================================================================
+// MP.3 Starter: Versioning Workshop
+// ============================================================================
+//
+// TODO:
+// 1. Implement String so versions print as vMAJOR.MINOR.PATCH.
+// 2. Implement IsCompatible using the major-version rule.
+// 3. Implement IsNewer by comparing major, then minor, then patch.
+// 4. Read version_test.go and make all tests pass.
+// 5. Keep the printed guidance about /v2 imports and replace clear and accurate.
+// ============================================================================
+
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func (v Version) String() string {
+	return "TODO"
+}
+
+func (v Version) IsCompatible(other Version) bool {
+	return false
+}
+
+func (v Version) IsNewer(other Version) bool {
+	return false
+}
+
+func main() {
+	versions := []Version{
+		{1, 0, 0},
+		{1, 1, 0},
+		{1, 1, 1},
+		{2, 0, 0},
+	}
+
+	fmt.Println("=== Versioning Workshop Starter ===")
+	fmt.Println()
+
+	for i, v := range versions {
+		if i == 0 {
+			continue
+		}
+
+		prev := versions[i-1]
+		status := "TODO: decide compatibility"
+		if v.IsCompatible(prev) {
+			status = "compatible"
+		}
+
+		fmt.Printf("  %s -> %s  %s\n", prev, v, status)
+	}
+
+	fmt.Println()
+	fmt.Println("Explain in your final solution:")
+	fmt.Println("  - why v2+ modules require /v2 in the import path")
+	fmt.Println("  - when replace is useful in local development")
+}

--- a/08-modules-and-packages/3-versioning/main.go
+++ b/08-modules-and-packages/3-versioning/main.go
@@ -8,7 +8,7 @@ package main
 import "fmt"
 
 // ============================================================================
-// Section 8: Semantic Versioning & Replace Directive
+// Section 08: Modules and Packages — Versioning Workshop
 // Level: Intermediate → Advanced
 // ============================================================================
 //
@@ -18,7 +18,7 @@ import "fmt"
 //   │ │ │
 //   │ │ └── PATCH: bug fixes (backward compatible)
 //   │ └──── MINOR: new features (backward compatible)
-//   └────── MAJOR: breaking changes (NOT backward compatible)
+//   └────── MAJOR: breaking changes (not backward compatible)
 //
 // MAJOR VERSION RULE (v2+):
 //   When a module reaches v2, the import path MUST include /v2:
@@ -36,24 +36,15 @@ import "fmt"
 //     replace github.com/original/pkg => github.com/myfork/pkg v1.0.0
 //
 // THE EXCLUDE DIRECTIVE:
-//   Block specific versions (e.g., known buggy releases):
+//   Block specific versions (for example, known buggy releases):
 //     exclude github.com/some/pkg v1.2.3
 //
 // VENDORING:
 //   go mod vendor        — copy all dependencies into ./vendor/
 //   go build -mod=vendor — build using vendored dependencies only
-//
-//   Use Cases:
-//   - Air-gapped environments (no internet access)
-//   - Reproducible builds without relying on module proxy
-//   - Some CI/CD pipelines require vendoring
-//
-// REFERENCES:
-//   - https://go.dev/doc/modules/version-numbers
-//   - https://semver.org/
 // ============================================================================
 
-// Version represents a semantic version
+// Version represents a semantic version.
 type Version struct {
 	Major int
 	Minor int
@@ -64,12 +55,12 @@ func (v Version) String() string {
 	return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
 }
 
-// IsCompatible checks if two versions are compatible (same major version)
+// IsCompatible checks whether two versions share the same major version.
 func (v Version) IsCompatible(other Version) bool {
 	return v.Major == other.Major
 }
 
-// IsNewer checks if v is newer than other
+// IsNewer compares major, then minor, then patch.
 func (v Version) IsNewer(other Version) bool {
 	if v.Major != other.Major {
 		return v.Major > other.Major
@@ -86,23 +77,25 @@ func main() {
 
 	versions := []Version{
 		{1, 0, 0},
-		{1, 1, 0}, // Minor bump: new features, backward compatible
-		{1, 1, 1}, // Patch bump: bug fix
-		{2, 0, 0}, // Major bump: BREAKING CHANGE
+		{1, 1, 0},
+		{1, 1, 1},
+		{2, 0, 0},
 		{2, 1, 0},
 	}
 
 	fmt.Println("Version history:")
 	for i, v := range versions {
-		if i > 0 {
-			prev := versions[i-1]
-			compatible := v.IsCompatible(prev)
-			emoji := "✅"
-			if !compatible {
-				emoji = "⚠️  BREAKING"
-			}
-			fmt.Printf("  %s → %s  %s\n", prev, v, emoji)
+		if i == 0 {
+			continue
 		}
+
+		prev := versions[i-1]
+		status := "✅ compatible"
+		if !v.IsCompatible(prev) {
+			status = "⚠️  BREAKING"
+		}
+
+		fmt.Printf("  %s → %s  %s\n", prev, v, status)
 	}
 
 	fmt.Println()
@@ -112,8 +105,12 @@ func main() {
 	fmt.Println()
 	fmt.Println("  import \"github.com/example/pkg\"    ← v0.x or v1.x")
 	fmt.Println("  import \"github.com/example/pkg/v2\" ← v2.x")
+	fmt.Println()
+	fmt.Println("Replace is most useful during local development or controlled fork testing.")
+	fmt.Println("It should clarify dependency resolution, not hide long-term version problems.")
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("🚀 NEXT UP: FS.1 files")
-	fmt.Println("   Current: MP.3 (versioning)")
+	fmt.Println("NEXT STEP: Optional MP.4 build tags")
+	fmt.Println("Then continue to Section 09 when you're ready.")
+	fmt.Println("Current: MP.3 (versioning workshop)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/08-modules-and-packages/3-versioning/version_test.go
+++ b/08-modules-and-packages/3-versioning/version_test.go
@@ -1,0 +1,92 @@
+package main
+
+import "testing"
+
+func TestVersionString(t *testing.T) {
+	t.Parallel()
+
+	v := Version{Major: 2, Minor: 3, Patch: 4}
+	if got, want := v.String(), "v2.3.4"; got != want {
+		t.Fatalf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestVersionIsCompatible(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		left  Version
+		right Version
+		want  bool
+	}{
+		{
+			name:  "same major is compatible",
+			left:  Version{Major: 1, Minor: 2, Patch: 0},
+			right: Version{Major: 1, Minor: 9, Patch: 9},
+			want:  true,
+		},
+		{
+			name:  "different major is breaking",
+			left:  Version{Major: 2, Minor: 0, Patch: 0},
+			right: Version{Major: 1, Minor: 9, Patch: 9},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.left.IsCompatible(tt.right); got != tt.want {
+				t.Fatalf("IsCompatible() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionIsNewer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		left  Version
+		right Version
+		want  bool
+	}{
+		{
+			name:  "major version wins first",
+			left:  Version{Major: 2, Minor: 0, Patch: 0},
+			right: Version{Major: 1, Minor: 99, Patch: 99},
+			want:  true,
+		},
+		{
+			name:  "minor version breaks tie",
+			left:  Version{Major: 1, Minor: 2, Patch: 0},
+			right: Version{Major: 1, Minor: 1, Patch: 9},
+			want:  true,
+		},
+		{
+			name:  "patch version breaks final tie",
+			left:  Version{Major: 1, Minor: 1, Patch: 2},
+			right: Version{Major: 1, Minor: 1, Patch: 1},
+			want:  true,
+		},
+		{
+			name:  "older version is not newer",
+			left:  Version{Major: 1, Minor: 0, Patch: 0},
+			right: Version{Major: 1, Minor: 0, Patch: 1},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.left.IsNewer(tt.right); got != tt.want {
+				t.Fatalf("IsNewer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/08-modules-and-packages/README.md
+++ b/08-modules-and-packages/README.md
@@ -1,47 +1,97 @@
-# Section 8: Modules & Dependency Management
+# Section 08: Modules and Packages
 
-## Learning Objectives
+## Mission
 
-By the end of this section, you will understand:
+This section teaches you how Go modules define package boundaries, dependency resolution, versioned
+imports, and controlled build surfaces.
 
-- How Go modules work and what `go.mod`/`go.sum` contain
-- How to add, update, and remove dependencies
-- Semantic versioning and the major version import rule
-- The `replace` directive for local development
-- Multi-module workspaces with `go.work`
+By the end of Section 08, you should be comfortable reading and writing:
 
-## Contents
+- `go.mod` and `go.sum` with confidence instead of treating them as magic files
+- dependency-management workflows using `go get`, `go mod tidy`, `go list`, and `go mod why`
+- semantic-versioning decisions, especially the `/v2` import-path rule
+- local override workflows with `replace`
+- optional platform and test surfaces through build tags
 
-| Directory | Topic | Level |
-| --- | --- | --- |
-| `1-module-basics/` | `go.mod` anatomy, import paths, essential commands | Beginner |
-| `2-managing-deps/` | Adding/removing/inspecting dependencies | Intermediate |
-| `3-versioning/` | Semantic versioning, `replace`, `exclude`, vendoring | Intermediate |
+## Who Should Start Here
 
-## How to Run
+### Full Path
 
-```bash
-go run ./08-modules-and-packages/1-module-basics
-go run ./08-modules-and-packages/2-managing-deps
-go run ./08-modules-and-packages/3-versioning
-```
+Start here after completing Section 07 in order.
 
-## Exercises
+### Bridge Path
 
-1. Create a separate Go module in `/tmp/mathlib` with `Add()` and `Multiply()` functions
-2. Use `replace` to import it locally into this project
-3. Remove the `replace` directive and discuss what would happen if you tried to build
+You can move faster if you already understand:
+
+- how Go import paths map to package directories
+- basic command-line use of the `go` tool
+- semantic-versioning vocabulary like major, minor, and patch
+
+Even on the bridge path, do not skip `MP.1`.
+It removes a lot of mystery from the rest of the section.
+
+### Targeted Path
+
+If you are here mainly for dependency hygiene and versioned module behavior, review these first:
+
+- `MP.1` module basics
+- `MP.2` managing dependencies
+
+## Section Map
+
+| ID | Type | Surface | Why It Matters | Requires |
+| --- | --- | --- | --- | --- |
+| `MP.1` | Lesson | [module basics](./1-module-basics) | Explains what `go.mod` and `go.sum` actually do so dependency work stops feeling magical. | entry |
+| `MP.2` | Lesson | [managing deps](./2-managing-deps) | Shows how to add, inspect, trim, and explain dependencies using the Go toolchain. | `MP.1` |
+| `MP.3` | Exercise | [versioning workshop](./3-versioning) | Combines semantic versioning, `/v2` imports, and `replace` reasoning into one milestone. | `MP.1`, `MP.2` |
+| `MP.4` | Stretch Lesson | [build tags](./4-build-tags) | Adds conditional compilation and tagged tests once the core module workflow is solid. | `MP.1`, `MP.2` |
+
+## Suggested Order
+
+1. Work through `MP.1` and `MP.2` in order.
+2. Complete `MP.3` without copying the finished solution line by line.
+3. Use `MP.4` as an optional stretch lesson before moving to the next section.
+
+## Section Milestone
+
+`MP.3` is the current live milestone for this pilot section.
+
+If you can complete it and explain:
+
+- why `go.mod` and `go.sum` are part of the build contract, not random generated clutter
+- why a module that reaches v2 must change its import path
+- why `replace` is useful in local development but should be used deliberately
+
+then you are ready to move into file I/O and CLI tooling in Section 09.
+
+## Pilot Role In V2
+
+This live v2 slice keeps the current Section 08 paths and `MP.*` ids stable while upgrading the
+learner-facing structure:
+
+- `MP.1` and `MP.2` are the core lessons
+- `MP.3` is the milestone exercise
+- `MP.4` is an optional stretch lesson
+
+That keeps the section useful for current learners while the broader v2 migration continues.
+
+## Legacy To Pilot Mapping
+
+This pilot intentionally avoids breaking the current Section 08 filesystem layout.
+
+- `MP.1` stays at `08-modules-and-packages/1-module-basics`
+- `MP.2` stays at `08-modules-and-packages/2-managing-deps`
+- `MP.3` stays at `08-modules-and-packages/3-versioning`, now treated as the section milestone
+  surface with a starter and tests
+- `MP.4` stays at `08-modules-and-packages/4-build-tags` as an optional stretch lesson
 
 ## References
 
-- [Using Go Modules](https://go.dev/blog/using-go-modules)
-- [Go Modules Reference](https://go.dev/ref/mod)
-- [Module version numbering](https://go.dev/doc/modules/version-numbers)
+1. [Using Go Modules](https://go.dev/blog/using-go-modules)
+2. [Go Modules Reference](https://go.dev/ref/mod)
+3. [Module version numbering](https://go.dev/doc/modules/version-numbers)
 
-## Learning Path
+## Next Step
 
-| ID | Lesson | Concept | Requires |
-| --- | --- | --- | --- |
-| MP.1 | [module basics](./1-module-basics) | go.mod anatomy · module path · go.sum checksums | 🟢 entry |
-| MP.2 | [managing deps](./2-managing-deps) | go get · go mod tidy · go list · go mod why | MP.1 |
-| MP.3 | [versioning](./3-versioning) | semver · v2 import path rule · replace · exclude · vendoring | MP.1, MP.2 |
+After `MP.3`, continue to [Section 09: I/O and CLI Tools](../09-io-and-cli).
+If you want one more stretch lesson before moving on, finish `MP.4` first.

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -74,6 +74,25 @@
       "outputs": [
         "ST.6"
       ]
+    },
+    {
+      "id": "s08",
+      "number": "08",
+      "slug": "modules-and-packages",
+      "title": "Modules and Packages",
+      "phase": "foundations",
+      "summary": "Teach learners how Go modules define package boundaries, dependency resolution, versioned imports, and optional build surfaces.",
+      "status": "pilot",
+      "prerequisites": [
+        "s07"
+      ],
+      "path_prefix": "08-modules-and-packages",
+      "entry_points": [
+        "MP.1"
+      ],
+      "outputs": [
+        "MP.3"
+      ]
     }
   ],
   "items": [
@@ -921,6 +940,131 @@
         "strings",
         "regex",
         "templates"
+      ]
+    },
+    {
+      "id": "MP.1",
+      "section_id": "s08",
+      "slug": "module-basics",
+      "title": "Module Basics",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "foundation",
+      "verification_mode": "run",
+      "estimated_time": 30,
+      "summary": "Explain what go.mod and go.sum do, how module paths identify code, and which commands keep module metadata healthy.",
+      "objectives": [
+        "Explain the roles of go.mod and go.sum without treating them as mysterious generated files",
+        "Use core module commands like go mod tidy and go list to inspect and maintain dependency state"
+      ],
+      "prerequisites": [],
+      "production_relevance": "Every Go service, library, and CLI depends on module metadata being correct, reproducible, and understandable during local development and CI.",
+      "path": "08-modules-and-packages/1-module-basics",
+      "run_command": "go run ./08-modules-and-packages/1-module-basics",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "MP.2"
+      ],
+      "tags": [
+        "modules",
+        "go.mod",
+        "go.sum"
+      ]
+    },
+    {
+      "id": "MP.2",
+      "section_id": "s08",
+      "slug": "managing-dependencies",
+      "title": "Managing Dependencies",
+      "type": "lesson",
+      "subtype": "integration",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 35,
+      "summary": "Show how to add, inspect, trim, and explain dependencies with the Go toolchain instead of editing module files by hand.",
+      "objectives": [
+        "Use go get, go mod tidy, and go list intentionally when dependency state changes",
+        "Explain direct versus indirect dependencies and trace why a package is present"
+      ],
+      "prerequisites": [
+        "MP.1"
+      ],
+      "production_relevance": "Dependency drift, unexpected indirect packages, and confused upgrade paths are normal engineering problems, so teams need repeatable module workflows.",
+      "path": "08-modules-and-packages/2-managing-deps",
+      "run_command": "go run ./08-modules-and-packages/2-managing-deps",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "MP.3"
+      ],
+      "tags": [
+        "dependencies",
+        "go-get",
+        "tidy"
+      ]
+    },
+    {
+      "id": "MP.3",
+      "section_id": "s08",
+      "slug": "versioning-workshop",
+      "title": "Versioning Workshop",
+      "type": "exercise",
+      "subtype": "",
+      "level": "core",
+      "verification_mode": "mixed",
+      "estimated_time": 75,
+      "summary": "Combine semantic versioning, the v2 import-path rule, and replace-directive reasoning in one runnable milestone with tests.",
+      "objectives": [
+        "Model semantic versions and compare compatibility boundaries using the major-version rule",
+        "Explain why Go treats v2+ modules differently and when replace is useful during local development"
+      ],
+      "prerequisites": [
+        "MP.1",
+        "MP.2"
+      ],
+      "production_relevance": "Version boundaries and local overrides shape library upgrades, internal modules, and release safety in real Go codebases.",
+      "path": "08-modules-and-packages/3-versioning",
+      "run_command": "go run ./08-modules-and-packages/3-versioning",
+      "test_command": "go test ./08-modules-and-packages/3-versioning",
+      "starter_path": "08-modules-and-packages/3-versioning/_starter",
+      "next_items": [],
+      "tags": [
+        "exercise",
+        "versioning",
+        "modules",
+        "replace"
+      ]
+    },
+    {
+      "id": "MP.4",
+      "section_id": "s08",
+      "slug": "build-tags",
+      "title": "Build Tags",
+      "type": "lesson",
+      "subtype": "pattern",
+      "level": "stretch",
+      "verification_mode": "run",
+      "estimated_time": 25,
+      "summary": "Introduce conditional compilation and tagged tests for platform-specific code and optional integration surfaces.",
+      "objectives": [
+        "Use //go:build constraints to separate platform-specific files cleanly",
+        "Explain why slow integration tests are often hidden behind opt-in tags"
+      ],
+      "prerequisites": [
+        "MP.1",
+        "MP.2"
+      ],
+      "production_relevance": "Build tags show up in cross-platform tools, optional integrations, and test suites that need fast defaults with explicit opt-in for heavy checks.",
+      "path": "08-modules-and-packages/4-build-tags",
+      "run_command": "go run ./08-modules-and-packages/4-build-tags",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [],
+      "tags": [
+        "build-tags",
+        "integration-tests",
+        "platforms"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- add the Section 08 pilot slice to curriculum.v2.json
- rewrite the Section 08 learner-facing README into the v2 format
- turn MP.3 versioning into the live milestone with a README, starter, and tests
- clean the Section 08 lesson text and navigation flow

## Verification
- go run ./08-modules-and-packages/1-module-basics
- go run ./08-modules-and-packages/2-managing-deps
- go run ./08-modules-and-packages/3-versioning
- go run ./08-modules-and-packages/3-versioning/_starter
- go test ./08-modules-and-packages/3-versioning
- go run ./scripts/validate_curriculum.go
- go build ./...
- go vet ./...
- go test ./...

Closes #115
Closes #116
Closes #117