### PR TITLE
Launch the Section 11 v2 concurrency slice

### DIFF
--- a/11-concurrency/README.md
+++ b/11-concurrency/README.md
@@ -1,0 +1,113 @@
+# Section 11: Concurrency
+
+## Mission
+
+This section teaches you how Go coordinates work across goroutines, channels, contexts, and
+timers without hiding the costs and failure modes behind "just add concurrency" magic.
+
+By the end of the live v2 slice, you should be comfortable:
+
+- starting goroutines deliberately instead of sprinkling `go` blindly
+- coordinating work with `sync.WaitGroup` and channels
+- applying cancellation and deadlines with `context.Context`
+- using timers and tickers without leaking background work
+- building small concurrent tools that stay readable under load
+
+Section 11 still contains additional concurrency material beyond this live slice. Those surfaces
+remain available as legacy reference lessons while the first milestone path is migrated.
+
+## Who Should Start Here
+
+### Full Path
+
+Start here after completing Section 10 in order.
+
+### Bridge Path
+
+You can move faster if you already understand:
+
+- explicit error handling
+- methods, interfaces, and small packages
+- I/O surfaces like HTTP requests and file operations
+- why cleanup matters around resources and long-running work
+
+Even on the bridge path, do not skip the first lesson in any track.
+Those entry points establish the vocabulary the later exercises assume.
+
+### Targeted Path
+
+This section is the second multi-track pilot in v2.
+You can choose the track that matches your immediate goal:
+
+- Goroutines track for worker coordination and channel flow
+- Context track for cancellation and timeout control
+- Time track for timers, tickers, and reminder-style scheduling
+
+## Section Map
+
+| Track | Entry | Milestone | Focus |
+| --- | --- | --- | --- |
+| Goroutines | [GC.1 goroutines](./goroutines) | `GC.7` | goroutines, WaitGroups, channels, and a bounded downloader |
+| Context | [CT.1 background](./context) | `CT.5` | context roots, cancellation, timeouts, and timeout-aware HTTP calls |
+| Time & Scheduling | [TM.1 time basics](./time-and-scheduling) | `TM.7` | time values, formatting, timers, tickers, and a console reminder |
+
+## Suggested Order
+
+1. Complete the Goroutines track if you want the strongest concurrency foundations first.
+2. Complete the Context track if you work with HTTP, APIs, or long-running I/O.
+3. Complete the Time track if you want stronger deadline and scheduling intuition.
+4. Use the legacy reference lessons after the milestone path if you want deeper coverage in the same section.
+
+## Section Milestones
+
+This live v2 slice has three milestone surfaces:
+
+- `GC.7` concurrent downloader
+- `CT.5` timeout-aware API client
+- `TM.7` console reminder
+
+The following lessons remain available as legacy reference surfaces for later alpha work:
+
+- `GC.8` race conditions
+- `GC.9` select deep dive
+- `GC.10` sync primitives
+- `TM.4` random numbers
+- `TM.5` scheduler
+- `TM.6` timezones
+
+If you can complete the three milestone exercises and explain:
+
+- why goroutine fan-out still needs coordination boundaries
+- why request-scoped cancellation should reach the HTTP client layer
+- why timers and tickers need explicit lifecycle management
+
+then you are ready to move into the higher-order concurrency patterns in Section 12.
+
+## Pilot Role In V2
+
+This live v2 slice keeps the current `11-concurrency` layout intact while upgrading the learner-facing flow:
+
+- the section now has one top-level guide
+- each track has a clearer milestone path
+- the milestone exercises have explicit README contracts
+- only the first practical slice of each track is promoted into `curriculum.v2.json`
+
+That keeps Section 11 useful now without pretending the entire mega-section is fully migrated in one wave.
+
+## Legacy To Pilot Mapping
+
+- `GC.1` through `GC.7` stay in `11-concurrency/goroutines/*`
+- `CT.1` through `CT.5` stay in `11-concurrency/context/*`
+- `TM.1`, `TM.2`, `TM.3`, and `TM.7` stay in `11-concurrency/time-and-scheduling/*`
+- later goroutine and time lessons remain available, but they are not yet promoted into the live v2 graph
+
+## References
+
+1. [Effective Go: Concurrency](https://go.dev/doc/effective_go#concurrency)
+2. [Go Concurrency Patterns: Context](https://go.dev/blog/context)
+3. [Package time](https://pkg.go.dev/time)
+
+## Next Step
+
+After you finish the track or milestone you care about here, continue to
+[Section 12: Concurrency Patterns](../12-concurrency-patterns).

--- a/11-concurrency/context/4-with-value/main.go
+++ b/11-concurrency/context/4-with-value/main.go
@@ -10,28 +10,28 @@ import (
 )
 
 // ============================================================================
-// Section 11: Context — WithValue
+// Section 11: Context - WithValue
 // Level: Advanced
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
 //   - context.WithValue stores request-scoped data in the context
 //   - Using custom key types to prevent collisions
-//   - When to use (and NOT use) context values
+//   - When to use (and not use) context values
 //   - The request ID / user ID pattern used in production
 //
 // IMPORTANT RULE:
-//   Context values are for REQUEST-SCOPED data only.
-//   DO NOT use context to pass function parameters.
-//   Bad:  ctx = context.WithValue(ctx, "db", database)       ← Anti-pattern
-//   Good: ctx = context.WithValue(ctx, requestIDKey, "abc")  ← Request metadata
+//   Context values are for request-scoped data only.
+//   Do not use context to pass normal function parameters.
+//   Bad:  ctx = context.WithValue(ctx, "db", database)       // Anti-pattern
+//   Good: ctx = context.WithValue(ctx, requestIDKey, "abc")  // Request metadata
 //
 // ENGINEERING DEPTH:
 //   `WithValue` creates a `valueCtx` struct containing exactly one key-value pair
 //   and a pointer to its parent. Because Contexts are immutable, adding 5 values
 //   creates a chain of 5 nested Context wrappers. When you call `ctx.Value(key)`,
-//   Go walks UP the parent chain comparing keys until it finds a match or reaches
-//   the root. This is O(depth) — proportional to how many values were added.
+//   Go walks up the parent chain comparing keys until it finds a match or reaches
+//   the root. This is O(depth) - proportional to how many values were added.
 //
 // RUN: go run ./11-concurrency/context/4-with-value
 // ============================================================================
@@ -64,12 +64,12 @@ func main() {
 	fmt.Println()
 	fmt.Println("KEY TAKEAWAYS:")
 	fmt.Println("  1. Use custom key types (not strings) to prevent collisions")
-	fmt.Println("  2. Context values are for REQUEST-SCOPED metadata only")
+	fmt.Println("  2. Context values are for request-scoped metadata only")
 	fmt.Println("  3. Good uses: request ID, user ID, trace ID, auth token")
 	fmt.Println("  4. Bad uses: database connections, loggers, config (use DI instead)")
 	fmt.Println("  5. Values are inherited by child contexts automatically")
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("🚀 NEXT UP: TM.1 time basics")
+	fmt.Println("NEXT UP: CT.5 timeout-aware API client")
 	fmt.Println("   Current: CT.4 (WithValue)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/11-concurrency/context/5-timeout-client/README.md
+++ b/11-concurrency/context/5-timeout-client/README.md
@@ -1,0 +1,64 @@
+# CT.5 Timeout-Aware API Client
+
+## Mission
+
+Build a small HTTP client that uses `context.WithTimeout` to enforce deadlines and fails clearly
+when a request takes too long.
+
+This exercise is the Context track milestone for Section 11.
+
+## Prerequisites
+
+Complete these first:
+
+- `CT.1` background
+- `CT.2` with cancel
+- `CT.3` with timeout
+- `CT.4` with value
+
+## What You Will Build
+
+Implement a client that:
+
+1. creates a timeout-bound context for each outbound request
+2. attaches that context to the request with `http.NewRequestWithContext`
+3. returns a useful wrapped error when the deadline expires
+4. demonstrates both a successful request and a deliberately timed-out request
+
+## Files
+
+- [main.go](./main.go): complete solution with teaching comments
+- [_starter/main.go](./_starter/main.go): starter file with TODOs and requirements
+
+## Run Instructions
+
+Run the completed solution:
+
+```bash
+go run ./11-concurrency/context/5-timeout-client
+```
+
+Run the starter:
+
+```bash
+go run ./11-concurrency/context/5-timeout-client/_starter
+```
+
+## Success Criteria
+
+Your finished solution should:
+
+- use `context.WithTimeout` instead of making an unbounded HTTP call
+- attach the context to the request itself, not just the outer function
+- distinguish timeout failures from other request errors
+- keep the timeout behavior visible in runnable output
+
+## Note
+
+The current example makes live HTTP requests, so it expects network access when you run the full
+solution.
+
+## Next Step
+
+After you complete this exercise, continue back to the [Context track](../README.md) or the
+[Section 11 overview](../../README.md).

--- a/11-concurrency/context/README.md
+++ b/11-concurrency/context/README.md
@@ -1,78 +1,38 @@
-# Section 11: Context
+# Track B: Context
 
-## Learning Objectives
+## Mission
 
-`context.Context` is the backbone of production Go code that performs I/O. It carries cancellation
-signals, deadlines, and request-scoped values through function chains.
+This track teaches you how Go propagates cancellation, deadlines, and request-scoped metadata
+through function chains so I/O work can stop cleanly when the caller is done.
 
-By the end of this section, you should understand:
+## Track Map
 
-- what `context.Context` is and why it exists
-- `context.Background()` and `context.TODO()`
-- `context.WithCancel()` for manual cancellation
-- `context.WithTimeout()` and `context.WithDeadline()` for automatic deadlines
-- `context.WithValue()` for request-scoped data
-- how context propagates through function chains
-- how HTTP handlers use `r.Context()`
+| ID | Type | Surface | Why It Matters | Requires |
+| --- | --- | --- | --- | --- |
+| `CT.1` | Lesson | [background](./1-background) | Introduces root contexts and the `Context` interface. | entry |
+| `CT.2` | Lesson | [with cancel](./2-with-cancel) | Shows manual cancellation and goroutine cleanup. | `CT.1` |
+| `CT.3` | Lesson | [with timeout](./3-with-timeout) | Adds deadline-based cancellation for bounded work. | `CT.1`, `CT.2` |
+| `CT.4` | Lesson | [with value](./4-with-value) | Explains request-scoped metadata and the limits of context values. | `CT.1`, `CT.2`, `CT.3` |
+| `CT.5` | Exercise | [timeout-aware API client](./5-timeout-client) | Combines timeout control with a real HTTP request boundary. | `CT.1`, `CT.2`, `CT.3`, `CT.4` |
 
-## Beginner → Expert Mapping
+## Suggested Order
 
-| Topic | Level | Importance | Engineering Concept |
-| --- | --- | --- | --- |
-| Background & TODO | Beginner | High | Root context creation |
-| WithCancel | Intermediate | Critical | Manual cancellation propagation |
-| WithTimeout | Intermediate | Critical | Automatic deadline enforcement |
-| WithValue | Advanced | Medium | Request-scoped metadata |
-| HTTP Context | Advanced | Critical | Server request lifecycle |
+1. Work through `CT.1` to `CT.4` in order.
+2. Complete `CT.5` as the live context milestone.
 
-## Engineering Depth
+## Track Milestone
 
-Google's internal Go style guidance treats context as the first parameter of any function that does
-I/O or may run for a meaningful amount of time. The signature
-`func DoSomething(ctx context.Context, ...)` is not decoration — it is the contract that allows
-callers to stop downstream work cleanly.
+`CT.5` is the current context track milestone.
 
-Context solves the cancellation-propagation problem: if a user cancels an HTTP request, the
-database query, API call, and file write happening underneath it should stop too. Context creates a
-tree of cancellation signals that flows from parent to child automatically.
+If you can complete it and explain:
 
-## Contents
+- why `context.WithTimeout` should wrap outbound HTTP calls
+- why `http.NewRequestWithContext` is the real transport boundary
+- why context values should carry request metadata instead of general dependencies
 
-| Directory | Topic | Level |
-| --- | --- | --- |
-| `1-background/` | `context.Background()`, `context.TODO()` | Beginner |
-| `2-with-cancel/` | Manual cancellation with `context.WithCancel` | Intermediate |
-| `3-with-timeout/` | Automatic deadlines with `context.WithTimeout` | Intermediate |
-| `4-with-value/` | Request-scoped data with `context.WithValue` | Advanced |
+then the context part of Section 11 is doing its job.
 
-## How to Run
+## Next Step
 
-```bash
-go run ./11-concurrency/context/1-background
-go run ./11-concurrency/context/2-with-cancel
-go run ./11-concurrency/context/3-with-timeout
-go run ./11-concurrency/context/4-with-value
-```
-
-## Exercise: Timeout-Aware API Client (`5-timeout-client`)
-
-Build an HTTP client that uses `context.WithTimeout` to enforce request deadlines.
-
-```bash
-go run ./11-concurrency/context/5-timeout-client/_starter
-go run ./11-concurrency/context/5-timeout-client
-```
-
-## References
-
-- [Go Concurrency Patterns: Context](https://go.dev/blog/context)
-- [Package context documentation](https://pkg.go.dev/context)
-
-## Learning Path
-
-| ID | Lesson | Concept | Requires |
-| --- | --- | --- | --- |
-| CT.1 | [Background & TODO](./1-background) | Root context · Context interface (`Deadline`, `Done`, `Err`, `Value`) | entry |
-| CT.2 | [WithCancel](./2-with-cancel) | cancel func · `ctx.Done()` · goroutine leak prevention · tree propagation | CT.1 |
-| CT.3 | [WithTimeout](./3-with-timeout) | duration-based auto-cancel · `WithDeadline` · `DeadlineExceeded` | CT.1, CT.2 |
-| CT.4 | [WithValue](./4-with-value) | private key type · request-scoped metadata · `O(depth)` lookup | CT.1, CT.2, CT.3 |
+After `CT.5`, continue to the [Section 11 overview](../README.md) or move into the
+[Time and Scheduling track](../time-and-scheduling).

--- a/11-concurrency/goroutines/2-wait-group/main.go
+++ b/11-concurrency/goroutines/2-wait-group/main.go
@@ -12,22 +12,22 @@ import (
 )
 
 // ============================================================================
-// Section 11: Concurrency � WaitGroups
+// Section 11: Concurrency - WaitGroups
 // Level: Intermediate
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
 //   - sync.WaitGroup: the standard tool for waiting on goroutines
-//   - The 3-step pattern: Add ? go func { defer Done } ? Wait
-//   - Why you MUST pass WaitGroup by pointer (never by value)
-//   - Common mistakes: Add inside goroutine, forgetting Done, copy WaitGroup
+//   - The 3-step pattern: Add -> go func { defer Done() } -> Wait
+//   - Why you must pass WaitGroup by pointer (never by value)
+//   - Common mistakes: Add inside goroutine, forgetting Done, copying WaitGroup
 //   - Real-world example: concurrent health checks
 //
 // ANALOGY:
 //   WaitGroup is like a boarding pass counter at an airport gate.
-//     wg.Add(1)  = "One more passenger to board"
-//     wg.Done()  = "One passenger has boarded"
-//     wg.Wait()  = "Don't close the gate until all passengers are aboard"
+//     wg.Add(1) = "One more passenger to board"
+//     wg.Done() = "One passenger has boarded"
+//     wg.Wait() = "Do not close the gate until all passengers are aboard"
 //
 // RUN: go run ./11-concurrency/goroutines/2-wait-group
 // ============================================================================
@@ -68,7 +68,7 @@ func main() {
 
 	results := make(chan ServiceStatus, len(services))
 
-	fmt.Printf("?? Health checking %d services concurrently...\n\n", len(services))
+	fmt.Printf("[RUN] Health checking %d services concurrently...\n\n", len(services))
 
 	for _, svc := range services {
 		wg.Add(1)
@@ -80,9 +80,9 @@ func main() {
 
 	allHealthy := true
 	for status := range results {
-		icon := "?"
+		icon := "[OK]"
 		if !status.Healthy {
-			icon = "?"
+			icon = "[WARN]"
 			allHealthy = false
 		}
 		fmt.Printf("  %s %-20s latency: %v\n", icon, status.Name, status.Latency)
@@ -90,20 +90,20 @@ func main() {
 
 	fmt.Println()
 	if allHealthy {
-		fmt.Println("?? All services healthy!")
+		fmt.Println("[OK] All services healthy!")
 	} else {
-		fmt.Println("??  Some services are degraded � check logs!")
+		fmt.Println("[WARN] Some services are degraded - check logs!")
 	}
 
 	fmt.Println()
 	fmt.Println("=== Common WaitGroup Mistakes ===")
-	fmt.Println("  ? wg.Add(1) INSIDE the goroutine ? race condition")
-	fmt.Println("  ? Passing wg by VALUE (not &wg)  ? Done() on copy, main deadlocks")
-	fmt.Println("  ❌ Forgetting defer wg.Done()     → counter never reaches 0, deadlock")
-	fmt.Println("  ❌ Calling wg.Add() after Wait()  → panic (negative counter)")
-	fmt.Println("  ✅ ALWAYS: Add() before go, &wg as pointer, defer Done() first line")
+	fmt.Println("  - wg.Add(1) inside the goroutine -> race condition")
+	fmt.Println("  - Passing wg by value (not &wg)  -> Done() on a copy, main deadlocks")
+	fmt.Println("  - Forgetting defer wg.Done()     -> counter never reaches 0, deadlock")
+	fmt.Println("  - Calling wg.Add() after Wait()  -> panic (negative counter)")
+	fmt.Println("  - Always: Add() before go, pass &wg, and defer Done() first")
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("🚀 NEXT UP: GC.3 channels (unbuffered)")
+	fmt.Println("NEXT UP: GC.3 channels (unbuffered)")
 	fmt.Println("   Current: GC.2 (WaitGroups)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/11-concurrency/goroutines/3-channels/main.go
+++ b/11-concurrency/goroutines/3-channels/main.go
@@ -10,38 +10,37 @@ import (
 )
 
 // ============================================================================
-// Section 11: Concurrency � Channels
+// Section 11: Concurrency - Channels
 // Level: Intermediate
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
 //   - What channels are: typed communication pipes between goroutines
-//   - The channel axiom: "Don't communicate by sharing memory.
-//     Share memory by communicating."
+//   - The channel axiom: "Do not communicate by sharing memory. Share memory by communicating."
 //   - Sending and receiving: ch <- value (send), value := <-ch (receive)
 //   - Blocking behavior: unbuffered channels synchronize sender and receiver
 //   - Channel direction: send-only (chan<-) and receive-only (<-chan)
-//   - Practical patterns: result collection, fan-out
+//   - Practical patterns: result collection and fan-out
 //
 // ANALOGY:
 //   A channel is like a mailbox between two neighbors.
 //   - Neighbor A (sender) puts a letter in the mailbox: ch <- letter
 //   - Neighbor B (receiver) takes the letter out: letter := <-ch
 //
-//   With an UNBUFFERED channel (no mailbox space), A must WAIT at the
-//   mailbox until B arrives to take the letter. They synchronize.
+//   With an unbuffered channel (no mailbox space), A must wait at the mailbox
+//   until B arrives to take the letter. They synchronize.
 //
-//   With a BUFFERED channel (mailbox with slots), A can drop letters
-//   and leave � until the mailbox is full. Then A waits too.
+//   With a buffered channel (mailbox with slots), A can drop letters there
+//   until the mailbox is full. Then A waits too.
 //
 // ENGINEERING DEPTH:
 //   Channels are implemented as a struct (hchan) containing:
 //     - A circular buffer (for buffered channels)
 //     - A mutex for thread-safe access
 //     - Two wait queues: one for blocked senders, one for blocked receivers
-//   When a goroutine blocks on a channel, the Go scheduler parks it
-//   (removes it from the OS thread) and schedules another goroutine.
-//   This is a userspace context switch � ~10ns vs ~1�s for OS threads.
+//   When a goroutine blocks on a channel, the Go scheduler parks it and lets
+//   another goroutine run. This is a user-space context switch instead of a
+//   full OS-thread handoff.
 //
 // RUN: go run ./11-concurrency/goroutines/3-channels
 // ============================================================================
@@ -92,11 +91,11 @@ func main() {
 	for i := 0; i < len(portsToScan); i++ {
 		result := <-results
 
-		status := "? closed"
+		status := "[closed]"
 		if result.IsOpen {
-			status = "? OPEN"
+			status = "[OPEN]"
 		}
-		fmt.Printf("  %s:%d ? %s\n", result.Host, result.Port, status)
+		fmt.Printf("  %s:%d -> %s\n", result.Host, result.Port, status)
 	}
 
 	fmt.Println()
@@ -117,12 +116,12 @@ func main() {
 	fmt.Println("KEY TAKEAWAY:")
 	fmt.Println("  - Channels are typed pipes: make(chan string), make(chan int)")
 	fmt.Println("  - Send: ch <- value | Receive: value := <-ch")
-	fmt.Println("  - Unbuffered channels SYNCHRONIZE sender and receiver")
+	fmt.Println("  - Unbuffered channels synchronize sender and receiver")
 	fmt.Println("  - Use chan<- (send-only) and <-chan (receive-only) for safety")
 	fmt.Println("  - close(ch) signals all receivers that no more values are coming")
-	fmt.Println("  - Channels replace shared memory + mutexes for most use cases")
+	fmt.Println("  - Channels replace shared memory + mutexes for many coordination cases")
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("?? NEXT UP: GC.4 buffered channels")
+	fmt.Println("NEXT UP: GC.4 buffered channels")
 	fmt.Println("   Current: GC.3 (channels (unbuffered))")
 	fmt.Println("---------------------------------------------------")
 }

--- a/11-concurrency/goroutines/4-channels-buffered/main.go
+++ b/11-concurrency/goroutines/4-channels-buffered/main.go
@@ -10,30 +10,29 @@ import (
 )
 
 // ============================================================================
-// Section 11: Concurrency � Buffered Channels
+// Section 11: Concurrency - Buffered Channels
 // Level: Intermediate
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
-//   - Buffered vs unbuffered channels � the critical distinction
-//   - make(chan T, capacity) � creating a channel with buffer space
-//   - When buffered channels block (only when FULL or EMPTY)
+//   - Buffered vs unbuffered channels: the critical distinction
+//   - make(chan T, capacity): creating a channel with buffer space
+//   - When buffered channels block (only when full or empty)
 //   - Use cases: batch processing, rate limiting, producer-consumer
-//   - When to use buffered vs unbuffered
+//   - When to use buffered vs unbuffered channels
 //
 // ANALOGY:
-//   Unbuffered = a phone call. Both parties must be on the line at the
-//   same time. The sender WAITS until the receiver picks up.
+//   Unbuffered = a phone call. Both parties must be on the line at the same time.
+//   The sender waits until the receiver picks up.
 //
-//   Buffered = a mailbox with N slots. The sender can drop messages
-//   and keep going � until the mailbox is full. Then the sender waits.
-//   The receiver can pick up messages whenever ready.
+//   Buffered = a mailbox with N slots. The sender can drop messages and keep going
+//   until the mailbox is full. Then the sender waits.
 //
 // ENGINEERING DEPTH:
 //   Buffered channels use a circular ring buffer internally.
-//   - Send blocks only when the buffer is FULL
-//   - Receive blocks only when the buffer is EMPTY
-//   - Buffer size is set at creation and CANNOT be resized
+//   - Send blocks only when the buffer is full
+//   - Receive blocks only when the buffer is empty
+//   - Buffer size is set at creation and cannot be resized
 //   - cap(ch) returns the buffer capacity
 //   - len(ch) returns the number of items currently in the buffer
 //
@@ -53,23 +52,22 @@ func main() {
 	events <- logEvent{"INFO", "Server started on :8080"}
 	events <- logEvent{"INFO", "Connected to database"}
 	events <- logEvent{"WARN", "Cache miss rate above 50%"}
-	// events <- logEvent{"ERROR", "timeout"} ? This 4th send would BLOCK.
 
 	fmt.Printf("  Buffer: %d/%d items\n\n", len(events), cap(events))
 
-	fmt.Println("  1??  Basic Buffered Channel (capacity=3):")
+	fmt.Println("  1) Basic buffered channel (capacity=3):")
 	for i := 0; i < 3; i++ {
 		e := <-events
 		fmt.Printf("     [%s] %s\n", e.Level, e.Message)
 	}
 	fmt.Println()
 
-	fmt.Println("  2??  Producer-Consumer Pattern:")
+	fmt.Println("  2) Producer-consumer pattern:")
 	jobs := make(chan int, 5)
 
 	go func() {
 		for i := 1; i <= 8; i++ {
-			fmt.Printf("     ?? Producing job #%d\n", i)
+			fmt.Printf("     -> Producing job #%d\n", i)
 			jobs <- i
 		}
 		close(jobs)
@@ -77,31 +75,26 @@ func main() {
 
 	time.Sleep(50 * time.Millisecond)
 	for job := range jobs {
-		fmt.Printf("     ?? Processing job #%d\n", job)
+		fmt.Printf("     -> Processing job #%d\n", job)
 		time.Sleep(30 * time.Millisecond)
 	}
 	fmt.Println()
 
-	fmt.Println("  3??  Buffered vs Unbuffered:")
-	fmt.Println("     +--------------------------------------------------+")
-	fmt.Println("     �   Unbuffered    �         Buffered               �")
-	fmt.Println("     +-----------------+--------------------------------�")
-	fmt.Println("     � make(chan T)    � make(chan T, N)               �")
-	fmt.Println("     � Send blocks     � Send blocks only when FULL    �")
-	fmt.Println("     � until received  � Receive blocks only when EMPTY�")
-	fmt.Println("     � Synchronization � Async with bounded queue      �")
-	fmt.Println("     � Phone call      � Mailbox with N slots          �")
-	fmt.Println("     +--------------------------------------------------+")
+	fmt.Println("  3) Buffered vs unbuffered:")
+	fmt.Println("     - Unbuffered: make(chan T) -> sender waits for receiver")
+	fmt.Println("     - Buffered:   make(chan T, N) -> sender waits only when buffer is full")
+	fmt.Println("     - Unbuffered emphasizes synchronization")
+	fmt.Println("     - Buffered emphasizes bounded asynchronous flow")
 
 	fmt.Println()
 	fmt.Println("KEY TAKEAWAY:")
-	fmt.Println("  - Buffered: make(chan T, N) � N items can be sent without blocking")
-	fmt.Println("  - Unbuffered: make(chan T) � sender waits for receiver (synchronous)")
+	fmt.Println("  - Buffered: make(chan T, N) -> N items can be sent without blocking")
+	fmt.Println("  - Unbuffered: make(chan T) -> sender waits for receiver (synchronous)")
 	fmt.Println("  - Use buffered channels to decouple fast producers from slow consumers")
 	fmt.Println("  - Buffer size should be tuned based on throughput needs")
-	fmt.Println("  - When in doubt, start unbuffered � add buffer only for performance")
+	fmt.Println("  - When in doubt, start unbuffered -> add buffer only for performance")
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("?? NEXT UP: GC.5 closing channels")
+	fmt.Println("NEXT UP: GC.5 closing channels")
 	fmt.Println("   Current: GC.4 (buffered channels)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/11-concurrency/goroutines/5-channels-closing/main.go
+++ b/11-concurrency/goroutines/5-channels-closing/main.go
@@ -10,31 +10,29 @@ import (
 )
 
 // ============================================================================
-// Section 11: Concurrency � Closing Channels
+// Section 11: Concurrency - Closing Channels
 // Level: Intermediate
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
 //   - Why and when to close channels
 //   - The comma-ok pattern: value, ok := <-ch (detecting closed channels)
-//   - range over channels � automatically stops when channel closes
-//   - Rules: only the SENDER should close, never the receiver
-//   - What happens when you read from / write to a closed channel
-//   - Closing as a broadcast signal (notifying multiple goroutines)
+//   - range over channels: automatically stops when the channel closes
+//   - Rules: only the sender should close, never the receiver
+//   - What happens when you read from or write to a closed channel
+//   - Closing as a broadcast signal for multiple goroutines
 //
 // ANALOGY:
 //   A channel is like a conveyor belt in a factory.
-//   close(ch) is like hitting the "STOP" button on the belt.
-//   Workers downstream (receivers) see the belt stop and know
-//   no more items are coming. They finish processing what's left
-//   and go home.
+//   close(ch) is like hitting the STOP button on the belt.
+//   Workers downstream see the belt stop and know no more items are coming.
 //
 // CRITICAL RULES:
-//   1. ONLY the sender should close the channel
-//   2. Sending to a closed channel causes a PANIC
+//   1. Only the sender should close the channel
+//   2. Sending to a closed channel causes a panic
 //   3. Receiving from a closed channel returns zero values immediately
-//   4. Closing is optional � only needed when receivers must know "we're done"
-//   5. Closing a nil channel causes a PANIC
+//   4. Closing is optional unless receivers must know "we are done"
+//   5. Closing a nil channel causes a panic
 //
 // RUN: go run ./11-concurrency/goroutines/5-channels-closing
 // ============================================================================
@@ -43,7 +41,7 @@ func main() {
 	fmt.Println("=== Closing Channels ===")
 	fmt.Println()
 
-	fmt.Println("1??  range over channel:")
+	fmt.Println("1) range over channel:")
 	taskQueue := make(chan string, 5)
 
 	go func() {
@@ -62,13 +60,13 @@ func main() {
 
 	step := 1
 	for task := range taskQueue {
-		fmt.Printf("   Step %d: %s ?\n", step, task)
+		fmt.Printf("   Step %d: %s -> done\n", step, task)
 		step++
 	}
 	fmt.Println("   Pipeline complete!")
 	fmt.Println()
 
-	fmt.Println("2??  comma-ok pattern:")
+	fmt.Println("2) comma-ok pattern:")
 	signals := make(chan int)
 	go func() {
 		signals <- 42
@@ -79,14 +77,14 @@ func main() {
 	for {
 		value, ok := <-signals
 		if !ok {
-			fmt.Println("   Channel closed � no more data")
+			fmt.Println("   Channel closed - no more data")
 			break
 		}
 		fmt.Printf("   Received: %d (ok=%t)\n", value, ok)
 	}
 	fmt.Println()
 
-	fmt.Println("3??  close() as broadcast signal:")
+	fmt.Println("3) close() as broadcast signal:")
 	shutdown := make(chan struct{})
 	var wg sync.WaitGroup
 
@@ -96,7 +94,7 @@ func main() {
 			defer wg.Done()
 			fmt.Printf("   Worker %d: waiting for shutdown signal...\n", workerID)
 			<-shutdown
-			fmt.Printf("   Worker %d: received shutdown, cleaning up ?\n", workerID)
+			fmt.Printf("   Worker %d: received shutdown, cleaning up\n", workerID)
 		}(id)
 	}
 
@@ -111,11 +109,11 @@ func main() {
 	fmt.Println("  - close(ch) signals receivers that no more data is coming")
 	fmt.Println("  - range ch: reads until closed (cleanest consumer pattern)")
 	fmt.Println("  - v, ok := <-ch: ok=false means closed (manual detection)")
-	fmt.Println("  - close() wakes ALL blocked receivers (broadcast signal)")
-	fmt.Println("  - ONLY senders close channels � NEVER receivers")
-	fmt.Println("  - Sending to a closed channel = PANIC (unrecoverable)")
+	fmt.Println("  - close() wakes all blocked receivers (broadcast signal)")
+	fmt.Println("  - Only senders close channels - never receivers")
+	fmt.Println("  - Sending to a closed channel = panic (unrecoverable)")
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("?? NEXT UP: GC.6 pipeline project")
+	fmt.Println("NEXT UP: GC.6 pipeline project")
 	fmt.Println("   Current: GC.5 (closing channels)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/11-concurrency/goroutines/6-project-1/main.go
+++ b/11-concurrency/goroutines/6-project-1/main.go
@@ -5,7 +5,7 @@
 package main
 
 // ============================================================================
-// Section 11: Concurrency — Pipeline Project
+// Section 11: Concurrency - Pipeline Project
 // Level: Advanced
 // ============================================================================
 //
@@ -18,23 +18,23 @@ import (
 	"time"
 )
 
-// ping acts as a Goroutine "Actor" in an infinite loop.
+// ping acts as a goroutine "actor" in an infinite loop.
 // It shares the `ch` channel memory reference with the `pong` actor.
 func ping(ctx context.Context, ch chan string) {
 	for {
-		// 1. The Select Multiplexer
-		// `select` blocks the Goroutine until one of its cases becomes unblocked.
+		// 1. The select multiplexer
+		// `select` blocks the goroutine until one of its cases becomes unblocked.
 		// If both are unblocked, Go picks one randomly.
 		select {
 		case <-ctx.Done():
-			// 2. Context Cancellation
-			// If the parent calls `cancel()` or times out, the `Done()` channel
-			// is closed. Reading from a closed channel instantly returns, allowing
-			// this Goroutine to gracefully exit (preventing memory leaks).
+			// 2. Context cancellation
+			// If the parent calls cancel() or times out, the Done channel is closed.
+			// Reading from a closed channel instantly returns, allowing this
+			// goroutine to exit gracefully and avoid leaks.
 			return
 		case ch <- fmt.Sprintf("ping: %v", time.Now()):
-			// 3. Unbuffered Write Blocking
-			// Writing to `ch` BLOCKS this Goroutine until `main` reads from it!
+			// 3. Unbuffered write blocking
+			// Writing to `ch` blocks this goroutine until `main` reads from it.
 			// After the write succeeds, we sleep to throttle the output.
 			time.Sleep(1 * time.Second)
 		}
@@ -62,24 +62,20 @@ func main() {
 	go ping(ctx, pingerCh)
 	go pong(ctx, pingerCh)
 
-	// 4. Background Coordinator Goroutine
-	// This anonymous function spins up to coordinate the system's shutdown loop.
+	// 4. Background coordinator goroutine
 	go func() {
-		// time.After creates a hardware timer that fires a message into the channel
-		// after exactly 5 seconds.
+		// time.After creates a timer that delivers on its channel after 5 seconds.
 		timeout := time.After(5 * time.Second)
 		for {
 			select {
 			case <-timeout:
 				fmt.Println("operation completed")
-				// 5. Channel Teardown
-				// Context cancellation (cancel() above) handled shutdown gracefully.
-				// We DO NOT close pingerCh here to avoid data races and "send on closed channel" panics
-				// from ping/pong goroutines that are concurrently trying to write.
-				done <- struct{}{} // Signal the main thread we are finished
+				// 5. Channel teardown
+				// Context cancellation handles shutdown gracefully.
+				// We do not close pingerCh here to avoid send-on-closed-channel panics.
+				done <- struct{}{}
 				return
 			case msg := <-pingerCh:
-				// As long as `ping` and `pong` write to `pingerCh`, we print it here.
 				fmt.Println(msg)
 			}
 		}
@@ -88,7 +84,7 @@ func main() {
 	<-done
 	fmt.Println("done")
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("🚀 NEXT UP: ⭐ GC.8 race conditions")
+	fmt.Println("NEXT UP: GC.7 concurrent downloader")
 	fmt.Println("   Current: GC.6 (pipeline project)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/11-concurrency/goroutines/7-downloader/README.md
+++ b/11-concurrency/goroutines/7-downloader/README.md
@@ -1,0 +1,68 @@
+# GC.7 Concurrent Downloader
+
+## Mission
+
+Build a downloader that launches work concurrently, limits the number of active downloads, and
+reports results without sharing mutable state between workers.
+
+This exercise is the Goroutines track milestone for Section 11.
+
+## Prerequisites
+
+Complete these first:
+
+- `GC.1` goroutines
+- `GC.2` WaitGroups
+- `GC.3` channels
+- `GC.4` buffered channels
+- `GC.5` closing channels
+- `GC.6` pipeline project
+
+## What You Will Build
+
+Implement a downloader that:
+
+1. launches one goroutine per target URL
+2. uses a `sync.WaitGroup` to know when all workers are done
+3. limits active downloads with a buffered semaphore channel
+4. sends success and failure results back through one result channel
+5. writes downloaded files to disk and prints a summary at the end
+
+## Files
+
+- [main.go](./main.go): complete solution with teaching comments
+- [_starter/main.go](./_starter/main.go): starter file with TODOs and requirements
+
+## Run Instructions
+
+Run the completed solution:
+
+```bash
+go run ./11-concurrency/goroutines/7-downloader
+```
+
+Run the starter:
+
+```bash
+go run ./11-concurrency/goroutines/7-downloader/_starter
+```
+
+## Success Criteria
+
+Your finished solution should:
+
+- coordinate all downloads with a `sync.WaitGroup`
+- limit concurrency with a channel-based semaphore
+- aggregate results through a channel instead of shared global state
+- clean up partial files on failed downloads
+- report both successes and failures clearly
+
+## Note
+
+The current example uses real HTTP downloads, so it expects network access when you run the full
+solution.
+
+## Next Step
+
+After you complete this exercise, continue back to the [Goroutines track](../README.md) or the
+[Section 11 overview](../../README.md).

--- a/11-concurrency/goroutines/README.md
+++ b/11-concurrency/goroutines/README.md
@@ -1,49 +1,49 @@
-# Section 9: Concurrency
+# Track A: Goroutines
 
-## Beginner → Expert Mapping
+## Mission
 
-| Topic | Level | Importance | Engineering Concept |
-|-------|-------|------------|---------------------|
-| Goroutines | Beginner | High | Lightweight OS threads, M:N scheduler |
-| WaitGroups | Intermediate | High | Barrier synchronization |
-| Channels | Advanced | **Critical** | Communicating Sequential Processes (CSP) |
-| Select & Context | Advanced | **Critical** | Multiplexing, Cancellation, Timeouts |
-| Sync Primitives | Expert | Medium | Mutexes, concurrent map scaling |
+This track teaches you how Go schedules concurrent work and how to coordinate that work safely
+with WaitGroups and channels before moving into more advanced synchronization topics.
 
-## Engineering Depth
-Concurrency is Go's flagship feature. Go uses an M:N scheduler, multiplexing thousands of lightweight goroutines (starting at ~2KB memory) onto a handful of OS threads. 
-- **Channels:** Unbuffered channels are $O(1)$ synchronization points that *block* until both sender and receiver are ready. Buffered channels behave like blocking queues.
-- **Data Races:** Always compile with `-race` (`go test -race ./...`). If two goroutines access the same memory concurrently and at least one is a write, the program is critically compromised.
+## Track Map
 
-## References
-1. **[Go Blog]** [Share Memory By Communicating](https://go.dev/blog/codelab-share)
-2. **[Go Blog]** [Go Concurrency Patterns: Context](https://go.dev/blog/context)
-3. **[Effective Go]** [Concurrency](https://go.dev/doc/effective_go#concurrency)
+| ID | Type | Surface | Why It Matters | Requires |
+| --- | --- | --- | --- | --- |
+| `GC.1` | Lesson | [goroutines](./1-goroutine) | Introduces goroutines, scheduler basics, and closure-capture pitfalls. | entry |
+| `GC.2` | Lesson | [WaitGroups](./2-wait-group) | Teaches the standard barrier pattern for waiting on concurrent work. | `GC.1` |
+| `GC.3` | Lesson | [channels](./3-channels) | Introduces typed communication between goroutines. | `GC.1`, `GC.2` |
+| `GC.4` | Lesson | [buffered channels](./4-channels-buffered) | Explains queue-like channel behavior and bounded async flow. | `GC.3` |
+| `GC.5` | Lesson | [closing channels](./5-channels-closing) | Shows how receivers learn a producer is done. | `GC.3`, `GC.4` |
+| `GC.6` | Lesson | [pipeline project](./6-project-1) | Combines goroutines, channels, and cancellation into one mini flow. | `GC.3`, `GC.4`, `GC.5` |
+| `GC.7` | Exercise | [concurrent downloader](./7-downloader) | Applies coordination, fan-out, and bounded concurrency in one milestone. | `GC.1`, `GC.2`, `GC.3`, `GC.4`, `GC.5`, `GC.6` |
 
----
+## Suggested Order
 
-## 🏗 Exercise: Concurrent File Downloader (`7-downloader`)
+1. Work through `GC.1` to `GC.6` in order.
+2. Complete `GC.7` as the live goroutines milestone.
+3. Use the later goroutines lessons as legacy reference after the milestone if you want deeper coverage.
 
-This capstone teaches you the limits of goroutines when dealing with I/O and how to synchronize results.
+## Track Milestone
 
-### Step-by-Step Instructions & Hints
-1. **Define URL Target:** Create a slice of dummy API URLs.
-2. **Use an Unbuffered Channel:** Create a `results := make(chan string)` to capture download status.
-3. **Launch Goroutines:** Loop through the slice and spawn a generic func: `go download(url, results)`.
-4. **Wait for Results:** In your `main()` thread, loop the exact number of URLs to pull from the channel: `<-results`.
-   - *Hint:* If you loop infinitely, you will hit a `fatal error: all goroutines are asleep - deadlock!`. Channel receivers block until data exists!
+`GC.7` is the current goroutines track milestone.
 
+If you can complete it and explain:
 
-## Learning Path
+- why goroutines still need explicit coordination instead of "fire and forget"
+- why bounded concurrency is safer than launching unlimited work
+- why channel-based result aggregation is often cleaner than shared mutable state
 
-| ID | Lesson | Concept | Requires |
-| --- | --- | --- | --- |
-| GC.1 | [goroutines](./1-goroutine) | go keyword · M:N scheduler · 2KB stack · closure-capture bug | 🟢 entry |
-| GC.2 | [WaitGroups](./2-wait-group) | Add · defer Done · Wait · pass by pointer rule | GC.1 |
-| GC.3 | [channels (unbuffered)](./3-channels) | make(chan T) · send · receive · block-until-ready · chan&lt;- / &lt;-chan | GC.1, GC.2 |
-| GC.4 | [buffered channels](./4-channels-buffered) | make(chan T, N) · len vs cap · producer-consumer decoupling | GC.3 |
-| GC.5 | [closing channels](./5-channels-closing) | close() · range over channel · comma-ok · broadcast signal | GC.3, GC.4 |
-| GC.6 | [pipeline project](./6-project-1) | ping/pong actors · select on done channel · context cancel | GC.3, GC.4, GC.5 |
-| **GC.8** ⭐ | [race conditions](./8-race) | sync.Mutex · sync.RWMutex · sync/atomic · -race flag | GC.1, GC.3 |
-| GC.9 | [select deep dive](./9-select-deep-dive) | Multiplexing · timeout with time.After · non-blocking default · fan-in | GC.3, GC.4, GC.5 |
-| GC.10 | [sync primitives](./10-sync-primitives) | sync.Once singleton · sync.Map · when to use each | GC.8 |
+then the core goroutines part of Section 11 is doing its job.
+
+## Legacy Reference Surfaces
+
+These lessons remain available, but they are not part of the live v2 track map yet:
+
+- `GC.8` race conditions
+- `GC.9` select deep dive
+- `GC.10` sync primitives
+
+## Next Step
+
+After `GC.7`, continue to the [Section 11 overview](../README.md) or move into the
+[Context track](../context).

--- a/11-concurrency/time-and-scheduling/3-timer-and-ticker/main.go
+++ b/11-concurrency/time-and-scheduling/3-timer-and-ticker/main.go
@@ -5,24 +5,21 @@
 package main
 
 // ============================================================================
-// Section 11: Time & Scheduling — Timers & Tickers
+// Section 11: Time & Scheduling - Timers & Tickers
 // Level: Intermediate
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
 //   - `time.Timer` for one-off scheduled operations
 //   - `time.Ticker` for repeating background intervals
-//   - Listening to Timer channels `<-timer.C`
+//   - Listening to timer channels with `<-timer.C`
 //   - Resource cleanup using `ticker.Stop()`
 //
 // ENGINEERING DEPTH:
-//   A `Timer` or `Ticker` is essentially an OS-level thread sleep mapped to a Go
-//   Channel (`<-C`). The Go runtime maintains a global min-heap timer queue.
-//   When extreme accuracy is needed, the Go runtime automatically pushes the
-//   current `time.Time` into the channel `C` at the targeted hardware tick, unblocking
-//   your goroutine. ALWAYS `defer ticker.Stop()`, otherwise the Go Scheduler
-//   keeps it in the global min-heap forever, causing massive memory leaks in
-//   long-running daemons!
+//   A `Timer` or `Ticker` is backed by the Go runtime timer heap.
+//   When the target time arrives, the runtime delivers a value on the timer's
+//   channel and unblocks your goroutine. Always `defer ticker.Stop()`, or the
+//   runtime will keep the timer alive longer than necessary.
 //
 // RUN: go run ./11-concurrency/time-and-scheduling/3-timer-and-ticker
 // ============================================================================
@@ -40,22 +37,23 @@ func main() {
 	ticker := time.NewTicker(1 * time.Second)
 	counter := 0
 	defer ticker.Stop()
+
 	for range ticker.C {
 		counter++
 		fmt.Println("Tick")
 		if counter >= 5 {
 			fmt.Println("stopped")
-			return
+			break
 		}
 	}
+
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("🚀 NEXT UP: TM.5 scheduler")
+	fmt.Println("NEXT UP: TM.7 console reminder")
 	fmt.Println("   Current: TM.3 (timers & tickers)")
 	fmt.Println("---------------------------------------------------")
 }
 
 func timerExample() {
-
 	timer := time.NewTimer(5 * time.Second)
 
 	wg := sync.WaitGroup{}
@@ -64,7 +62,7 @@ func timerExample() {
 	go func() {
 		defer wg.Done()
 		<-timer.C
-		fmt.Println("After 1 second")
+		fmt.Println("After 5 seconds")
 	}()
 
 	fmt.Println("This is happening inside the main goroutine")

--- a/11-concurrency/time-and-scheduling/7-reminder/README.md
+++ b/11-concurrency/time-and-scheduling/7-reminder/README.md
@@ -1,0 +1,60 @@
+# TM.7 Console Reminder
+
+## Mission
+
+Build a small reminder app that counts down with a ticker and fires a one-shot reminder with
+`time.AfterFunc`.
+
+This exercise is the Time and Scheduling track milestone for Section 11.
+
+## Prerequisites
+
+Complete these first:
+
+- `TM.1` time basics
+- `TM.2` formatting
+- `TM.3` timers and tickers
+
+## What You Will Build
+
+Implement a reminder that:
+
+1. reads a duration and message from the command line
+2. schedules the reminder with `time.AfterFunc`
+3. displays a countdown with `time.NewTicker`
+4. stops the ticker cleanly when the reminder fires
+5. exits without leaving background timer resources running
+
+## Files
+
+- [main.go](./main.go): complete solution with teaching comments
+- [_starter/main.go](./_starter/main.go): starter file with TODOs and requirements
+
+## Run Instructions
+
+Run the completed solution:
+
+```bash
+go run ./11-concurrency/time-and-scheduling/7-reminder 5 "Take a break!"
+```
+
+Run the starter:
+
+```bash
+go run ./11-concurrency/time-and-scheduling/7-reminder/_starter 5 "Take a break!"
+```
+
+## Success Criteria
+
+Your finished solution should:
+
+- convert the CLI seconds argument into a `time.Duration`
+- use `time.AfterFunc` for the final reminder
+- use `time.NewTicker` for the countdown loop
+- stop the ticker cleanly to avoid leaks
+- keep the countdown and reminder messages readable
+
+## Next Step
+
+After you complete this exercise, continue back to the [Time and Scheduling track](../README.md)
+or the [Section 11 overview](../../README.md).

--- a/11-concurrency/time-and-scheduling/README.md
+++ b/11-concurrency/time-and-scheduling/README.md
@@ -1,40 +1,46 @@
-﻿# Section 15: Time & Scheduling
+# Track C: Time and Scheduling
 
-## Beginner ? Expert Mapping
+## Mission
 
-| Topic | Level | Importance | Engineering Concept |
-| --- | --- | --- | --- |
-| Timers | Beginner | High | Delayed execution |
-| Tickers | Intermediate | Medium | Scheduled recurrence |
-| Context | Advanced | Critical | Request-scoped deadlines |
+This track teaches you how Go models time values and timed events so you can build reminders,
+timeouts, and interval-based background work without leaking timers or tickers.
 
-## Engineering Depth
+## Track Map
 
-A common memory leak in Go is abandoning `time.Ticker` instances. The ticker uses a background
-goroutine to push to its channel. If you do not call `ticker.Stop()`, that goroutine lives forever.
-Contexts (`context.WithTimeout`) are the standard mechanism for passing scoped deadlines down call
-stacks without relying on global tickers.
+| ID | Type | Surface | Why It Matters | Requires |
+| --- | --- | --- | --- | --- |
+| `TM.1` | Lesson | [time basics](./1-time) | Introduces `time.Time`, `time.Duration`, and elapsed-time calculations. | entry |
+| `TM.2` | Lesson | [formatting](./2-formatting) | Teaches parsing and formatting with Go's reference-time model. | `TM.1` |
+| `TM.3` | Lesson | [timers and tickers](./3-timer-and-ticker) | Explains one-shot and repeating timed events plus cleanup rules. | `TM.1`, `TM.2` |
+| `TM.7` | Exercise | [console reminder](./7-reminder) | Combines timers, tickers, and command-line input in one runnable milestone. | `TM.1`, `TM.2`, `TM.3` |
 
-## References
+## Suggested Order
 
-1. [Package time](https://pkg.go.dev/time)
+1. Work through `TM.1` to `TM.3` in order.
+2. Complete `TM.7` as the live time-track milestone.
+3. Use the legacy reference lessons later if you want deeper scheduling coverage.
 
-## Exercise: Console Reminder (`7-reminder`)
+## Track Milestone
 
-Build a countdown reminder that uses `time.NewTicker` and `time.AfterFunc`.
+`TM.7` is the current time-and-scheduling track milestone.
 
-```bash
-go run ./11-concurrency/time-and-scheduling/7-reminder/_starter 5 "Break time!"
-go run ./11-concurrency/time-and-scheduling/7-reminder 5 "Break time!"
-```
+If you can complete it and explain:
 
-## Learning Path
+- why `time.NewTicker` needs `Stop()` cleanup
+- why `time.AfterFunc` is useful for one-shot delayed work
+- why timer-driven programs still need explicit exit signaling
 
-| ID | Lesson | Concept | Requires |
-| --- | --- | --- | --- |
-| TM.1 | [time basics](./1-time) | `time.Time` � `Duration` � `Add` � `Sub` � wall vs monotonic clock | entry |
-| TM.2 | [formatting](./2-formatting) | Reference Time `2006-01-02 15:04:05` � `Parse` � `RFC3339` | TM.1 |
-| TM.3 | [timers & tickers](./3-timer-and-ticker) | `time.NewTimer` � `time.NewTicker` � `<-C` � `ticker.Stop()` leak | TM.1, TM.2 |
-| TM.4 | [random numbers](./4-random) | `rand/v2` � `IntN` � `Shuffle` � `Perm` � seeded PCG | TM.1 |
-| TM.5 | [scheduler](./5-schedule) | actor model � `ScheduleOnce` � `ScheduleInterval` � `StopAll` drain | TM.3 |
-| TM.6 | [timezones](./6-timezone) | `time.LoadLocation` � IANA database � `In()` � always store UTC | TM.1, TM.2 |
+then the time part of Section 11 is doing its job.
+
+## Legacy Reference Surfaces
+
+These lessons remain available, but they are not part of the live v2 track map yet:
+
+- `TM.4` random numbers
+- `TM.5` scheduler
+- `TM.6` timezones
+
+## Next Step
+
+After `TM.7`, continue to the [Section 11 overview](../README.md) or move on to
+[Section 12: Concurrency Patterns](../../12-concurrency-patterns).

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -135,6 +135,29 @@
       "outputs": [
         "DB.6"
       ]
+    },
+    {
+      "id": "s11",
+      "number": "11",
+      "slug": "concurrency",
+      "title": "Concurrency",
+      "phase": "systems",
+      "summary": "Teach goroutines, context-based cancellation, and timer-driven workflows through three practical concurrency tracks while leaving deeper reference lessons available for later alpha work.",
+      "status": "pilot",
+      "prerequisites": [
+        "s10"
+      ],
+      "path_prefix": "11-concurrency",
+      "entry_points": [
+        "GC.1",
+        "CT.1",
+        "TM.1"
+      ],
+      "outputs": [
+        "GC.7",
+        "CT.5",
+        "TM.7"
+      ]
     }
   ],
   "items": [
@@ -1886,6 +1909,527 @@
         "database",
         "repository",
         "transactions"
+      ]
+    },
+    {
+      "id": "GC.1",
+      "section_id": "s11",
+      "slug": "goroutines",
+      "title": "Goroutines",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "foundation",
+      "verification_mode": "run",
+      "estimated_time": 25,
+      "summary": "Introduce goroutines, scheduler basics, and the closure-capture bug that surprises new concurrent code.",
+      "objectives": [
+        "Launch concurrent work with the go keyword",
+        "Explain why loop variables should be passed into goroutine closures explicitly"
+      ],
+      "prerequisites": [],
+      "production_relevance": "Every later Go concurrency pattern starts with goroutine lifecycle awareness and the cost of unmanaged background work.",
+      "path": "11-concurrency/goroutines/1-goroutine",
+      "run_command": "go run ./11-concurrency/goroutines/1-goroutine",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "GC.2"
+      ],
+      "tags": [
+        "concurrency",
+        "goroutines",
+        "scheduler"
+      ]
+    },
+    {
+      "id": "GC.2",
+      "section_id": "s11",
+      "slug": "wait-groups",
+      "title": "WaitGroups",
+      "type": "lesson",
+      "subtype": "pattern",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 30,
+      "summary": "Teach the standard Add, Done, and Wait coordination pattern for concurrent tasks.",
+      "objectives": [
+        "Use sync.WaitGroup to wait for a fixed set of goroutines",
+        "Explain why WaitGroup values should be passed by pointer"
+      ],
+      "prerequisites": [
+        "GC.1"
+      ],
+      "production_relevance": "Services often fan out work across goroutines and still need one explicit boundary before the request can finish.",
+      "path": "11-concurrency/goroutines/2-wait-group",
+      "run_command": "go run ./11-concurrency/goroutines/2-wait-group",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "GC.3"
+      ],
+      "tags": [
+        "concurrency",
+        "waitgroup",
+        "coordination"
+      ]
+    },
+    {
+      "id": "GC.3",
+      "section_id": "s11",
+      "slug": "channels",
+      "title": "Channels",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 35,
+      "summary": "Introduce typed communication channels and the blocking behavior that synchronizes concurrent work.",
+      "objectives": [
+        "Send and receive values across channels safely",
+        "Explain the difference between synchronization and buffering"
+      ],
+      "prerequisites": [
+        "GC.1",
+        "GC.2"
+      ],
+      "production_relevance": "Channels are the default coordination tool when goroutines need to hand work or results to each other without shared mutable state.",
+      "path": "11-concurrency/goroutines/3-channels",
+      "run_command": "go run ./11-concurrency/goroutines/3-channels",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "GC.4"
+      ],
+      "tags": [
+        "concurrency",
+        "channels",
+        "communication"
+      ]
+    },
+    {
+      "id": "GC.4",
+      "section_id": "s11",
+      "slug": "buffered-channels",
+      "title": "Buffered Channels",
+      "type": "lesson",
+      "subtype": "integration",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 30,
+      "summary": "Explain buffered channel capacity, bounded queues, and when asynchronous sends still block.",
+      "objectives": [
+        "Use buffered channels to decouple producers and consumers",
+        "Explain when buffered channels block on full or empty buffers"
+      ],
+      "prerequisites": [
+        "GC.3"
+      ],
+      "production_relevance": "Bounded channel buffers are a common backpressure tool when one stage of a pipeline is faster than another.",
+      "path": "11-concurrency/goroutines/4-channels-buffered",
+      "run_command": "go run ./11-concurrency/goroutines/4-channels-buffered",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "GC.5"
+      ],
+      "tags": [
+        "concurrency",
+        "channels",
+        "buffering"
+      ]
+    },
+    {
+      "id": "GC.5",
+      "section_id": "s11",
+      "slug": "closing-channels",
+      "title": "Closing Channels",
+      "type": "lesson",
+      "subtype": "pattern",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 30,
+      "summary": "Show how channel closure signals completion and why only senders should close channels.",
+      "objectives": [
+        "Use range and comma-ok patterns with closed channels",
+        "Explain why receivers should not close channels they do not own"
+      ],
+      "prerequisites": [
+        "GC.3",
+        "GC.4"
+      ],
+      "production_relevance": "Producer shutdown, worker drain logic, and broadcast completion all rely on clear channel ownership rules.",
+      "path": "11-concurrency/goroutines/5-channels-closing",
+      "run_command": "go run ./11-concurrency/goroutines/5-channels-closing",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "GC.6"
+      ],
+      "tags": [
+        "concurrency",
+        "channels",
+        "shutdown"
+      ]
+    },
+    {
+      "id": "GC.6",
+      "section_id": "s11",
+      "slug": "pipeline-project",
+      "title": "Pipeline Project",
+      "type": "lesson",
+      "subtype": "integration",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 40,
+      "summary": "Combine channel stages and cancellation into a small pipeline-shaped project.",
+      "objectives": [
+        "Coordinate multiple stages of work through channels",
+        "Use explicit cancellation boundaries to stop background work cleanly"
+      ],
+      "prerequisites": [
+        "GC.3",
+        "GC.4",
+        "GC.5"
+      ],
+      "production_relevance": "Real concurrent systems often look like pipelines with bounded stages, cancellation signals, and explicit hand-off points.",
+      "path": "11-concurrency/goroutines/6-project-1",
+      "run_command": "go run ./11-concurrency/goroutines/6-project-1",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "GC.7"
+      ],
+      "tags": [
+        "concurrency",
+        "pipeline",
+        "channels"
+      ]
+    },
+    {
+      "id": "GC.7",
+      "section_id": "s11",
+      "slug": "concurrent-downloader",
+      "title": "Concurrent Downloader",
+      "type": "exercise",
+      "subtype": "",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 90,
+      "summary": "Combine fan-out, result aggregation, and bounded concurrency in one downloader milestone.",
+      "objectives": [
+        "Coordinate one goroutine per download while keeping concurrency bounded",
+        "Aggregate download results without shared global state"
+      ],
+      "prerequisites": [
+        "GC.1",
+        "GC.2",
+        "GC.3",
+        "GC.4",
+        "GC.5",
+        "GC.6"
+      ],
+      "production_relevance": "Network-heavy tools need concurrency limits, explicit result aggregation, and graceful failure handling instead of unlimited fan-out.",
+      "path": "11-concurrency/goroutines/7-downloader",
+      "run_command": "go run ./11-concurrency/goroutines/7-downloader",
+      "test_command": "",
+      "starter_path": "11-concurrency/goroutines/7-downloader/_starter",
+      "next_items": [],
+      "tags": [
+        "exercise",
+        "concurrency",
+        "http",
+        "downloader"
+      ]
+    },
+    {
+      "id": "CT.1",
+      "section_id": "s11",
+      "slug": "background-and-todo",
+      "title": "Background and TODO",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "foundation",
+      "verification_mode": "run",
+      "estimated_time": 20,
+      "summary": "Introduce root contexts and the core methods that every context implementation exposes.",
+      "objectives": [
+        "Distinguish context.Background from context.TODO",
+        "Explain what Deadline, Done, Err, and Value represent"
+      ],
+      "prerequisites": [],
+      "production_relevance": "Context is the standard control surface for I/O cancellation and scoped metadata in production Go code.",
+      "path": "11-concurrency/context/1-background",
+      "run_command": "go run ./11-concurrency/context/1-background",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "CT.2"
+      ],
+      "tags": [
+        "context",
+        "cancellation",
+        "foundation"
+      ]
+    },
+    {
+      "id": "CT.2",
+      "section_id": "s11",
+      "slug": "with-cancel",
+      "title": "WithCancel",
+      "type": "lesson",
+      "subtype": "pattern",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 25,
+      "summary": "Show how cancellation signals propagate through context trees.",
+      "objectives": [
+        "Create and cancel child contexts manually",
+        "Explain how ctx.Done helps stop background work"
+      ],
+      "prerequisites": [
+        "CT.1"
+      ],
+      "production_relevance": "Cancellation propagation prevents leaked goroutines and wasted I/O work after the caller no longer cares about the result.",
+      "path": "11-concurrency/context/2-with-cancel",
+      "run_command": "go run ./11-concurrency/context/2-with-cancel",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "CT.3"
+      ],
+      "tags": [
+        "context",
+        "cancel",
+        "goroutine-lifecycle"
+      ]
+    },
+    {
+      "id": "CT.3",
+      "section_id": "s11",
+      "slug": "with-timeout",
+      "title": "WithTimeout and WithDeadline",
+      "type": "lesson",
+      "subtype": "pattern",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 30,
+      "summary": "Teach deadline-based cancellation for bounded work and outbound calls.",
+      "objectives": [
+        "Use context.WithTimeout and context.WithDeadline correctly",
+        "Recognize context.DeadlineExceeded as the timeout signal"
+      ],
+      "prerequisites": [
+        "CT.1",
+        "CT.2"
+      ],
+      "production_relevance": "Timeouts are the production guardrail that keeps one slow downstream dependency from holding everything hostage.",
+      "path": "11-concurrency/context/3-with-timeout",
+      "run_command": "go run ./11-concurrency/context/3-with-timeout",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "CT.4"
+      ],
+      "tags": [
+        "context",
+        "timeout",
+        "deadline"
+      ]
+    },
+    {
+      "id": "CT.4",
+      "section_id": "s11",
+      "slug": "with-value",
+      "title": "WithValue",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 25,
+      "summary": "Explain request-scoped metadata and the narrow role of context values.",
+      "objectives": [
+        "Store request metadata with custom key types safely",
+        "Explain why context values should not replace normal dependencies"
+      ],
+      "prerequisites": [
+        "CT.1",
+        "CT.2",
+        "CT.3"
+      ],
+      "production_relevance": "Trace IDs, request IDs, and auth metadata often need to flow with a request without turning function signatures into global bags of state.",
+      "path": "11-concurrency/context/4-with-value",
+      "run_command": "go run ./11-concurrency/context/4-with-value",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "CT.5"
+      ],
+      "tags": [
+        "context",
+        "metadata",
+        "request-scope"
+      ]
+    },
+    {
+      "id": "CT.5",
+      "section_id": "s11",
+      "slug": "timeout-aware-api-client",
+      "title": "Timeout-Aware API Client",
+      "type": "exercise",
+      "subtype": "",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 60,
+      "summary": "Apply timeout-bound contexts to outbound HTTP requests and surface useful failure behavior.",
+      "objectives": [
+        "Attach a timeout-bound context directly to an HTTP request",
+        "Recognize and report timeout failures clearly"
+      ],
+      "prerequisites": [
+        "CT.1",
+        "CT.2",
+        "CT.3",
+        "CT.4"
+      ],
+      "production_relevance": "Outbound HTTP clients need cancellation boundaries or they become a common source of stuck goroutines and cascading failures.",
+      "path": "11-concurrency/context/5-timeout-client",
+      "run_command": "go run ./11-concurrency/context/5-timeout-client",
+      "test_command": "",
+      "starter_path": "11-concurrency/context/5-timeout-client/_starter",
+      "next_items": [],
+      "tags": [
+        "exercise",
+        "context",
+        "http",
+        "timeout"
+      ]
+    },
+    {
+      "id": "TM.1",
+      "section_id": "s11",
+      "slug": "time-basics",
+      "title": "Time Basics",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "foundation",
+      "verification_mode": "run",
+      "estimated_time": 20,
+      "summary": "Introduce time values, durations, and elapsed-time calculations.",
+      "objectives": [
+        "Create and compare time.Time values safely",
+        "Use time.Duration for sleep and elapsed-time calculations"
+      ],
+      "prerequisites": [],
+      "production_relevance": "Correct time math underpins retries, deadlines, metrics, and any real program that measures work over time.",
+      "path": "11-concurrency/time-and-scheduling/1-time",
+      "run_command": "go run ./11-concurrency/time-and-scheduling/1-time",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "TM.2"
+      ],
+      "tags": [
+        "time",
+        "duration",
+        "elapsed-time"
+      ]
+    },
+    {
+      "id": "TM.2",
+      "section_id": "s11",
+      "slug": "time-formatting",
+      "title": "Time Formatting",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 25,
+      "summary": "Teach parsing and formatting with Go's reference-time layout model.",
+      "objectives": [
+        "Format time values with standard layouts and custom layouts",
+        "Parse time strings without guessing locale-specific formats"
+      ],
+      "prerequisites": [
+        "TM.1"
+      ],
+      "production_relevance": "APIs, logs, and schedulers all depend on predictable parse and format behavior across systems.",
+      "path": "11-concurrency/time-and-scheduling/2-formatting",
+      "run_command": "go run ./11-concurrency/time-and-scheduling/2-formatting",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "TM.3"
+      ],
+      "tags": [
+        "time",
+        "formatting",
+        "parsing"
+      ]
+    },
+    {
+      "id": "TM.3",
+      "section_id": "s11",
+      "slug": "timers-and-tickers",
+      "title": "Timers and Tickers",
+      "type": "lesson",
+      "subtype": "integration",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 30,
+      "summary": "Explain one-shot and repeating timed events plus the cleanup rules that keep them safe.",
+      "objectives": [
+        "Use time.Timer and time.Ticker for one-shot and repeating events",
+        "Explain why ticker.Stop is part of the contract"
+      ],
+      "prerequisites": [
+        "TM.1",
+        "TM.2"
+      ],
+      "production_relevance": "Timers and tickers are the foundation for retries, timeouts, reminders, and recurring background work.",
+      "path": "11-concurrency/time-and-scheduling/3-timer-and-ticker",
+      "run_command": "go run ./11-concurrency/time-and-scheduling/3-timer-and-ticker",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "TM.7"
+      ],
+      "tags": [
+        "time",
+        "timer",
+        "ticker"
+      ]
+    },
+    {
+      "id": "TM.7",
+      "section_id": "s11",
+      "slug": "console-reminder",
+      "title": "Console Reminder",
+      "type": "exercise",
+      "subtype": "",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 50,
+      "summary": "Combine timers, tickers, and command-line input in one small reminder milestone.",
+      "objectives": [
+        "Schedule a one-shot reminder with time.AfterFunc",
+        "Drive a countdown loop with time.NewTicker and explicit cleanup"
+      ],
+      "prerequisites": [
+        "TM.1",
+        "TM.2",
+        "TM.3"
+      ],
+      "production_relevance": "Timer-driven programs need the same lifecycle care as larger services: explicit cleanup, bounded loops, and predictable exit behavior.",
+      "path": "11-concurrency/time-and-scheduling/7-reminder",
+      "run_command": "go run ./11-concurrency/time-and-scheduling/7-reminder",
+      "test_command": "",
+      "starter_path": "11-concurrency/time-and-scheduling/7-reminder/_starter",
+      "next_items": [],
+      "tags": [
+        "exercise",
+        "time",
+        "ticker",
+        "reminder"
       ]
     }
   ]


### PR DESCRIPTION
## Description

This PR launches the live v2 Section 11 slice for concurrency.

It promotes the first practical milestone path for the three Section 11 tracks:
- goroutines: GC.1 through GC.7
- context: CT.1 through CT.5
- time and scheduling: TM.1, TM.2, TM.3, and TM.7

It also:
- adds Section 11 to curriculum.v2.json
- adds the new top-level Section 11 learner guide
- rewrites the three track READMEs into the v2 learner-facing format
- adds milestone READMEs for GC.7, CT.5, and TM.7
- repairs learner-flow footers for the promoted lesson path
- normalizes corrupted learner-facing text in the promoted goroutine/context/time lesson files

The deeper Section 11 reference surfaces remain available but are not yet promoted into the live v2 graph:
- GC.8 to GC.10
- TM.4 to TM.6

Closes #127
Closes #128

## Testing

- go run ./scripts/validate_curriculum.go
- go build ./11-concurrency/...
- go run ./11-concurrency/goroutines/7-downloader/_starter
- go run ./11-concurrency/context/5-timeout-client/_starter
- go run ./11-concurrency/time-and-scheduling/7-reminder/_starter 5 " Take a break!\
 --assignee rasel9t6