### PR TITLE
Launch the Section 12 v2 concurrency patterns slice

### DIFF
--- a/12-concurrency-patterns/1-errgroup/main.go
+++ b/12-concurrency-patterns/1-errgroup/main.go
@@ -12,21 +12,21 @@ import (
 )
 
 // ============================================================================
-// Section 12: Concurrency Patterns � errgroup Basics
+// Section 12: Concurrency Patterns - errgroup Basics
 // Level: Intermediate
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
 //   - errgroup.Group: the idiomatic replacement for sync.WaitGroup when goroutines can fail
-//   - How errgroup collects errors without channels or mutexes
+//   - How errgroup collects errors without extra channels or mutexes
 //   - The difference between WaitGroup and errgroup
-//   - Go() vs TryGo(): bounded concurrency without a semaphore channel
+//   - Go vs TryGo and SetLimit for bounded concurrency
 //
 // ENGINEERING DEPTH:
 //   errgroup.Group stores exactly one error: the first non-nil error returned
 //   by any goroutine. All other errors are discarded. This is the right default
-//   because returning ALL errors is rarely useful � a single failed database
-//   connection explains the cascade of failures that follows it.
+//   because returning every error is rarely useful once one failed dependency
+//   already explains the cascade of failures that follows it.
 //
 // RUN: go run ./12-concurrency-patterns/1-errgroup
 // ============================================================================
@@ -70,9 +70,9 @@ func main() {
 	}
 
 	if err := g.Wait(); err != nil {
-		fmt.Printf("? Health check failed (%.0fms): %v\n", float64(time.Since(start).Milliseconds()), err)
+		fmt.Printf("[FAIL] Health check failed (%dms): %v\n", time.Since(start).Milliseconds(), err)
 	} else {
-		fmt.Printf("? All services healthy (%.0fms)\n", float64(time.Since(start).Milliseconds()))
+		fmt.Printf("[OK] All services healthy (%dms)\n", time.Since(start).Milliseconds())
 		for _, r := range results {
 			if r != nil {
 				fmt.Printf("   %-20s latency: %v\n", r.Name, r.Latency)
@@ -129,7 +129,7 @@ func main() {
 	g3.Wait()
 
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("?? NEXT UP: CP.2 errgroup + context")
+	fmt.Println("NEXT UP: CP.2 errgroup + context")
 	fmt.Println("   Current: CP.1 (errgroup basics)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/12-concurrency-patterns/2-errgroup-context/main.go
+++ b/12-concurrency-patterns/2-errgroup-context/main.go
@@ -15,20 +15,19 @@ import (
 )
 
 // ============================================================================
-// Section 12: Concurrency Patterns � errgroup with Context Cancellation
+// Section 12: Concurrency Patterns - errgroup with Context Cancellation
 // Level: Advanced
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
 //   - errgroup.WithContext: automatic cancellation on first error
 //   - How to implement a fan-out/fan-in pipeline with errgroup
-//   - Producer + multiple consumers pattern (parallel processing pipeline)
+//   - Producer plus multiple consumers as a bounded processing pattern
 //
 // ENGINEERING DEPTH:
 //   errgroup.WithContext creates a context that is cancelled automatically
 //   the moment any goroutine returns a non-nil error. This is the answer to
-//   the "I launched 10 goroutines but one failed � how do I stop the other 9?"
-//   problem.
+//   "I launched 10 goroutines but one failed - how do I stop the other 9?"
 //
 // RUN: go run ./12-concurrency-patterns/2-errgroup-context
 // ============================================================================
@@ -98,27 +97,6 @@ func consumer(ctx context.Context, id int, jobs <-chan WorkItem, results chan<- 
 	}
 }
 
-func resultCollector(ctx context.Context, results <-chan Result) error {
-	var count int
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case r, ok := <-results:
-			if !ok {
-				slog.Info("collection complete", "count", count)
-				return nil
-			}
-			count++
-			status := "?"
-			if !r.StatusOK {
-				status = "?"
-			}
-			slog.Info("result", "status", status, "url", r.URL, "latency", r.Latency.Round(time.Millisecond))
-		}
-	}
-}
-
 func main() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
 
@@ -129,6 +107,7 @@ func main() {
 
 	jobs := make(chan WorkItem, 10)
 	results := make(chan Result, 10)
+	errCh := make(chan error, 1)
 
 	g.Go(func() error {
 		return producer(ctx, jobs)
@@ -142,24 +121,29 @@ func main() {
 	}
 
 	go func() {
-		g.Wait()
+		errCh <- g.Wait()
 		close(results)
 	}()
 
 	var totalResults int
 	for r := range results {
 		totalResults++
-		_ = r
+		status := "[OK]"
+		if !r.StatusOK {
+			status = "[FAIL]"
+		}
+		slog.Info("result", "status", status, "url", r.URL, "latency", r.Latency.Round(time.Millisecond))
 	}
 
-	if err := g.Wait(); err != nil && err != context.Canceled {
-		fmt.Printf("? Pipeline failed: %v\n", err)
+	if err := <-errCh; err != nil && err != context.Canceled {
+		fmt.Printf("[FAIL] Pipeline failed: %v\n", err)
 	} else {
-		fmt.Printf("? Pipeline complete: %d results in %v\n", totalResults, time.Since(start).Round(time.Millisecond))
+		slog.Info("collection complete", "count", totalResults)
+		fmt.Printf("[OK] Pipeline complete: %d results in %v\n", totalResults, time.Since(start).Round(time.Millisecond))
 	}
 
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("?? NEXT UP: CP.3 sync.Pool")
+	fmt.Println("NEXT UP: CP.3 sync.Pool")
 	fmt.Println("   Current: CP.2 (errgroup + context)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/12-concurrency-patterns/3-sync-pool/main.go
+++ b/12-concurrency-patterns/3-sync-pool/main.go
@@ -10,34 +10,27 @@ import (
 )
 
 // ============================================================================
-// Section 12: Concurrency Patterns � sync.Pool
+// Section 12: Concurrency Patterns - sync.Pool
 // Level: Advanced
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
 //   - sync.Pool: reuse temporary objects to reduce GC pressure
-//   - The correct Get() ? use ? reset ? Put() lifecycle
-//   - Why you MUST reset objects before Put()
-//   - Building a production-grade byte buffer pool (used by fmt, json, http)
+//   - The correct Get -> use -> Reset -> Put lifecycle
+//   - Why you must reset objects before Put
+//   - Building a byte-buffer pool similar to real standard-library patterns
 //   - How to benchmark pool impact with testing.B
 //
 // ENGINEERING DEPTH:
 //   Go's garbage collector runs when allocated heap exceeds a threshold.
-//   A service processing 10,000 requests/sec may allocate 10,000 * 4096 bytes
-//   = 40MB per second just for temporary buffers. When GC runs to reclaim this
-//   memory, every goroutine in the program is paused for microseconds (STW:
-//   Stop The World). At 99th percentile this becomes your latency spike.
+//   A service processing 10,000 requests per second may allocate tens of MB per
+//   second just for temporary buffers. When GC runs to reclaim this memory, you
+//   pay extra latency. sync.Pool reduces that churn by recycling short-lived
+//   objects between GC cycles.
 //
-//   sync.Pool solves this by keeping a set of pooled objects. Between GC cycles,
-//   Get() returns a recycled object and Put() returns it. During GC, the pool
-//   is cleared (the GC intentionally evicts pools to prevent memory leaks from
-//   objects that should have been freed). Objects MUST therefore be treated as
-//   temporary � never assume an object from the pool is clean or that a Put()
-//   object will be returned by the next Get().
-//
-//   PRODUCTION RULE: Reset the object (buf.Reset(), clear the struct) before
-//   Put(). Otherwise the next caller gets stale data � a serious security bug
-//   if the buffer contains HTTP headers or auth tokens.
+//   Pools are intentionally cleared during GC, so you must treat pooled objects
+//   as temporary. Never assume the next Get returns your previous Put, and
+//   always reset the object before handing it back.
 //
 // RUN: go run ./12-concurrency-patterns/3-sync-pool
 // ============================================================================
@@ -131,7 +124,7 @@ func main() {
 	fmt.Println("Processed:", processRequest("usr_99", "req_002"))
 
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("?? NEXT UP: TE.1 unit testing")
+	fmt.Println("NEXT UP: CP.4 bounded pipeline exercise")
 	fmt.Println("   Current: CP.3 (sync.Pool)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/12-concurrency-patterns/4-bounded-pipeline-exercise/README.md
+++ b/12-concurrency-patterns/4-bounded-pipeline-exercise/README.md
@@ -1,0 +1,58 @@
+# CP.4 Bounded Pipeline Exercise
+
+## Mission
+
+Build a bounded concurrent pipeline that stops on the first failure and reuses large temporary
+buffers instead of allocating a fresh one for every work item.
+
+This exercise is the first promoted exercise surface for Section 12.
+
+## Prerequisites
+
+Complete these first:
+
+- `CP.1` errgroup basics
+- `CP.2` errgroup with context cancellation
+- `CP.3` sync.Pool
+
+## What You Will Build
+
+Implement an image-processing style batch job that:
+
+1. launches one unit of work per image ID
+2. caps concurrency with `g.SetLimit(4)`
+3. cancels the remaining work on the first failure
+4. reuses large `bytes.Buffer` instances through a `sync.Pool`
+
+## Files
+
+- [main.go](./main.go): complete solution with teaching comments
+- [_starter/main.go](./_starter/main.go): starter file with TODOs and requirements
+
+## Run Instructions
+
+Run the completed solution:
+
+```bash
+go run ./12-concurrency-patterns/4-bounded-pipeline-exercise
+```
+
+Run the starter:
+
+```bash
+go run ./12-concurrency-patterns/4-bounded-pipeline-exercise/_starter
+```
+
+## Success Criteria
+
+Your finished solution should:
+
+- use `errgroup.WithContext` instead of raw goroutine launch loops
+- bound concurrency with `SetLimit`
+- stop sibling work quickly when one image fails
+- return pooled buffers cleanly without leaking stale data
+
+## Next Step
+
+After you complete this exercise, continue to [CP.5 URL Health Checker](../5-url-checker-exercise)
+or back to the [Section 12 overview](../README.md).

--- a/12-concurrency-patterns/4-bounded-pipeline-exercise/_starter/main.go
+++ b/12-concurrency-patterns/4-bounded-pipeline-exercise/_starter/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ============================================================================
-// Section 12: Concurrency Patterns — Exercise: Image Resizer
+// Section 12: Concurrency Patterns - Exercise: Image Resizer
 // Level: Intermediate/Advanced
 // ============================================================================
 //
@@ -22,23 +22,22 @@ import (
 // You are building an image processing pipeline. You receive a list of image
 // IDs that need to be fetched, resized, and saved.
 //
-// Because image buffers are large (e.g., 2MB each), allocating a new buffer
-// for every image will crash the server under load or cause massive GC spikes.
-// Because the server has limited CPU cores, you cannot process all 20 images
-// simultaneously.
+// Because image buffers are large (for example, 2MB each), allocating a new
+// buffer for every image will crash the server under load or cause large GC spikes.
+// Because the server has limited CPU cores, you cannot process all images at once.
 //
 // REQUIREMENTS:
 // 1. Process all image IDs concurrently using errgroup.
-// 2. Limit the concurrency so NO MORE than 4 images are processed at the same time.
-//    (HINT: Use g.SetLimit).
-// 3. Stop early if ANY processing fails.
-//    (HINT: Use errgroup.WithContext, and trigger a context cancellation).
-// 4. Use a `sync.Pool` to recycle the `*bytes.Buffer` used for the payload.
+// 2. Limit concurrency so no more than 4 images are processed at the same time.
+//    (Hint: use g.SetLimit).
+// 3. Stop early if any processing fails.
+//    (Hint: use errgroup.WithContext and return the error).
+// 4. Use a sync.Pool to recycle the *bytes.Buffer used for the payload.
 //
 // RUN: go run ./12-concurrency-patterns/4-bounded-pipeline-exercise/_starter
 // ============================================================================
 
-// TODO 1: Create a sync.Pool for *bytes.Buffer. Ensure you allocate enough capacity (e.g. 2MB).
+// TODO 1: Create a sync.Pool for *bytes.Buffer. Ensure you allocate enough capacity (for example, 2MB).
 // var bufPool = sync.Pool{ ... }
 
 func main() {
@@ -47,47 +46,44 @@ func main() {
 	fmt.Println("Starting batch job...")
 	start := time.Now()
 
-	// TODO 2: Initialize an errgroup.WithContext
+	// TODO 2: Initialize errgroup.WithContext
 	// g, ctx := ...
 	var g errgroup.Group
 
-	// TODO 3: Limit the concurrency to 4
+	// TODO 3: Limit concurrency to 4
 	// g.SetLimit(4)
 
 	for _, id := range imageIDs {
-		id := id // Capture loop variable
+		id := id
 
-		// TODO 4: Launch the processing inside the errgroup
-		// g.Go(func() error { ... return processImage(ctx, id) })
+		// TODO 4: Launch the processing inside the errgroup.
+		// g.Go(func() error { return processImage(ctx, id) })
 		_ = id
 	}
 
-	// TODO 5: Wait for the group to finish and check for errors
+	// TODO 5: Wait for the group to finish and check for errors.
 	if err := g.Wait(); err != nil {
-		fmt.Printf("âŒ Batch job failed: %v\n", err)
+		fmt.Printf("[FAIL] Batch job failed: %v\n", err)
 	} else {
-		fmt.Printf("âœ… Batch job completed successfully in %v\n", time.Since(start))
+		fmt.Printf("[OK] Batch job completed successfully in %v\n", time.Since(start))
 	}
 }
 
-// processImage simulates processing an image.
 func processImage(ctx context.Context, id string) error {
-	// First check if the context is cancelled before starting heavy work
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
 
-	// TODO 6: Get a buffer from the pool, use it, and defer putting it back
+	// TODO 6: Get a buffer from the pool, use it, and defer putting it back.
 	// buf := bufPool.Get().(*bytes.Buffer)
 	// defer ...
 	// buf.Reset()
 	var buf *bytes.Buffer = bytes.NewBuffer(make([]byte, 0, 2*1024*1024)) // REMOVE THIS LINE and use the pool
 
-	// Simulate heavy work
 	buf.WriteString("simulated image data for " + id)
-	time.Sleep(100 * time.Millisecond) // Simulate processing time
+	time.Sleep(100 * time.Millisecond)
 
 	if id == "imgError" {
 		return fmt.Errorf("corrupt image data for %s", id)

--- a/12-concurrency-patterns/4-bounded-pipeline-exercise/main.go
+++ b/12-concurrency-patterns/4-bounded-pipeline-exercise/main.go
@@ -16,13 +16,11 @@ import (
 )
 
 // ============================================================================
-// Section 12: Concurrency Patterns — Exercise: Image Resizer SOLUTION
+// Section 12: Concurrency Patterns - Exercise: Image Resizer Solution
 // ============================================================================
 
-// 1. Create the sync.Pool
 var bufPool = sync.Pool{
 	New: func() any {
-		// Pre-allocate 2MB capacity per buffer
 		return bytes.NewBuffer(make([]byte, 0, 2*1024*1024))
 	},
 }
@@ -33,47 +31,38 @@ func main() {
 	fmt.Println("Starting batch job...")
 	start := time.Now()
 
-	// 2. Initialize errgroup.WithContext
 	g, ctx := errgroup.WithContext(context.Background())
-
-	// 3. Limit concurrency to 4
 	g.SetLimit(4)
 
 	for _, id := range imageIDs {
-		id := id // Capture loop variable
-
-		// 4. Launch the job via g.Go
+		id := id
 		g.Go(func() error {
 			return processImage(ctx, id)
 		})
 	}
 
-	// 5. Wait for the group to finish
 	if err := g.Wait(); err != nil {
-		fmt.Printf("âŒ Batch job failed: %v\n", err)
+		fmt.Printf("[FAIL] Batch job failed: %v\n", err)
 	} else {
-		fmt.Printf("âœ… Batch job completed successfully in %v\n", time.Since(start))
+		fmt.Printf("[OK] Batch job completed successfully in %v\n", time.Since(start))
 	}
 }
 
 func processImage(ctx context.Context, id string) error {
-	// Respect cancellation
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
 
-	// 6. Get a buffer from the pool and ensure it returns
 	buf := bufPool.Get().(*bytes.Buffer)
 	defer func() {
 		buf.Reset()
 		bufPool.Put(buf)
 	}()
 
-	// Simulate heavy work
 	buf.WriteString("simulated image data for " + id)
-	time.Sleep(100 * time.Millisecond) // Simulate processing time
+	time.Sleep(100 * time.Millisecond)
 
 	if id == "imgError" {
 		return fmt.Errorf("corrupt image data for %s", id)

--- a/12-concurrency-patterns/5-url-checker-exercise/README.md
+++ b/12-concurrency-patterns/5-url-checker-exercise/README.md
@@ -1,0 +1,65 @@
+# CP.5 URL Health Checker
+
+## Mission
+
+Build a concurrent URL checker that caps request fan-out, keeps request latency visible, and
+reuses HTTP clients safely.
+
+This exercise is the live capstone surface for Section 12.
+
+## Prerequisites
+
+Complete these first:
+
+- `CP.1` errgroup basics
+- `CP.2` errgroup with context cancellation
+- `CP.3` sync.Pool
+- `CP.4` bounded pipeline exercise
+
+## What You Will Build
+
+Implement a health checker that:
+
+1. issues concurrent HTTP HEAD requests with `errgroup.WithContext`
+2. caps active checks with `SetLimit`
+3. collects the result for each URL, including status and latency
+4. sorts results by latency for a stable final report
+5. reuses HTTP clients through a `sync.Pool`
+
+## Files
+
+- [main.go](./main.go): complete solution with teaching comments
+- [_starter/main.go](./_starter/main.go): starter file with TODOs and requirements
+
+## Run Instructions
+
+Run the completed solution:
+
+```bash
+go run ./12-concurrency-patterns/5-url-checker-exercise
+```
+
+Run the starter:
+
+```bash
+go run ./12-concurrency-patterns/5-url-checker-exercise/_starter
+```
+
+## Success Criteria
+
+Your finished solution should:
+
+- bound concurrent HTTP checks instead of launching them without limits
+- keep request construction context-aware
+- sort output by latency instead of emitting random goroutine order
+- reuse pooled clients safely without carrying stale state between checks
+
+## Note
+
+The current example uses live HTTP endpoints, so it expects network access when you run the full
+solution.
+
+## Next Step
+
+After you complete this exercise, continue to the [Section 12 overview](../README.md) or move to
+[Section 13: Quality and Performance](../../13-quality-and-performance).

--- a/12-concurrency-patterns/5-url-checker-exercise/main.go
+++ b/12-concurrency-patterns/5-url-checker-exercise/main.go
@@ -15,14 +15,13 @@ import (
 )
 
 // ============================================================================
-// Section 12: Concurrency Patterns — URL Health Checker (Exercise Solution)
+// Section 12: Concurrency Patterns - URL Health Checker (Exercise Solution)
 // Level: Advanced
 // ============================================================================
 //
 // RUN: go run ./12-concurrency-patterns/5-url-checker-exercise
 // ============================================================================
 
-// CheckResult holds the outcome of a single URL health check.
 type CheckResult struct {
 	URL        string
 	StatusCode int
@@ -30,9 +29,6 @@ type CheckResult struct {
 	Error      error
 }
 
-// clientPool reuses HTTP clients to avoid allocating a new one per request.
-// http.Client is safe for concurrent use — we pool it to avoid allocation,
-// NOT to avoid data races.
 var clientPool = sync.Pool{
 	New: func() any {
 		return &http.Client{
@@ -44,8 +40,6 @@ var clientPool = sync.Pool{
 	},
 }
 
-// checkURL performs a single HTTP HEAD request to url and returns the result.
-// It uses the pooled client and respects context cancellation.
 func checkURL(ctx context.Context, url string) CheckResult {
 	start := time.Now()
 
@@ -86,13 +80,13 @@ func main() {
 	results := make([]CheckResult, len(urls))
 
 	g, ctx := errgroup.WithContext(context.Background())
-	g.SetLimit(5) // Maximum 5 concurrent requests
+	g.SetLimit(5)
 
 	for i, url := range urls {
 		i, url := i, url
 		g.Go(func() error {
 			results[i] = checkURL(ctx, url)
-			return nil // We collect errors in CheckResult, not via errgroup
+			return nil
 		})
 	}
 
@@ -101,25 +95,24 @@ func main() {
 		return
 	}
 
-	// Sort by latency (fastest first)
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].Latency < results[j].Latency
 	})
 
-	fmt.Printf("%-45s %-8s %s\n", "URL", "STATUS", "LATENCY")
-	fmt.Printf("%-45s %-8s %s\n", "---", "------", "-------")
+	fmt.Printf("%-7s %-45s %-8s %s\n", "RESULT", "URL", "STATUS", "LATENCY")
+	fmt.Printf("%-7s %-45s %-8s %s\n", "------", "---", "------", "-------")
 
 	for _, r := range results {
 		if r.Error != nil {
-			fmt.Printf("%-45s %-8s %s\n", r.URL, "ERROR", r.Error)
+			fmt.Printf("%-7s %-45s %-8s %s\n", "ERROR", r.URL, "-", r.Error)
 			continue
 		}
-		status := fmt.Sprintf("%d", r.StatusCode)
-		icon := "✅"
+
+		result := "OK"
 		if r.StatusCode >= 400 {
-			icon = "❌"
+			result = "FAIL"
 		}
-		fmt.Printf("%s %-43s %-8s %v\n", icon, r.URL, status, r.Latency.Round(time.Millisecond))
+		fmt.Printf("%-7s %-45s %-8d %v\n", result, r.URL, r.StatusCode, r.Latency.Round(time.Millisecond))
 	}
 
 	fmt.Printf("\nTotal time: %v (would be %v sequential)\n",

--- a/12-concurrency-patterns/README.md
+++ b/12-concurrency-patterns/README.md
@@ -1,44 +1,80 @@
-# Section 12: Concurrency Patterns (errgroup & sync.Pool)
+# Section 12: Concurrency Patterns
 
-## Beginner → Expert Mapping
+## Mission
 
-| Topic | Level | Importance | Engineering Concept |
-| --- | --- | --- | --- |
-| `errgroup.Group` | Intermediate | **Critical** | Concurrent error collection, idiomatic WaitGroup replacement |
-| `errgroup` + context | Advanced | **Critical** | Automatic cancellation on first error |
-| `sync.Pool` | Advanced | High | Object reuse, GC pressure reduction |
-| Bounded worker pool | Expert | High | Semaphore + errgroup, back-pressure |
+This section teaches you the first production-shaped concurrency patterns that sit on top of the
+goroutine and context fundamentals from Section 11.
 
-## Engineering Depth
+By the end of the live v2 slice, you should be comfortable:
 
-`errgroup` is the missing piece between WaitGroup and channels. WaitGroup tells you *when* goroutines finish but discards their errors. Channels collect errors but require manual synchronization. `errgroup.Group` does both: it waits for all goroutines and returns the first non-nil error, cancelling all remaining work via context.
+- replacing bare `sync.WaitGroup` coordination with `errgroup` when work can fail
+- using `errgroup.WithContext` to cancel sibling work on the first failure
+- using `sync.Pool` deliberately when short-lived allocations become a real hotspot
+- building bounded concurrent pipelines instead of launching unbounded background work
+- combining concurrency control and operational safety in small real exercises
 
-`sync.Pool` is the most impactful memory optimization available in Go. A pool holds recycled objects. Instead of `make([]byte, 4096)` on every request (triggering GC), you `Get()` a pre-allocated buffer, use it, and `Put()` it back. The standard library uses pools everywhere: `fmt`, `encoding/json`, `net/http` all have internal pools.
+## Who Should Start Here
 
-**When to use sync.Pool:**
+### Full Path
 
-- Object allocation appears in pprof heap profile hot path
-- Objects are temporary: used briefly, then discarded
-- Object size is non-trivial: byte buffers, structs with multiple fields
+Start here after completing Section 11 in order.
 
-**When NOT to use sync.Pool:**
+### Bridge Path
 
-- Objects hold state between requests (race condition)
-- Allocation is not the bottleneck (profile first!)
-- Objects outlive the goroutine that created them
+You can move faster if you already understand:
+
+- goroutines, channels, and WaitGroups
+- context cancellation and timeouts
+- why temporary allocations can pressure the garbage collector
+
+Even on the bridge path, do not skip `CP.1` or `CP.2`.
+They establish the control-flow model the exercises rely on.
+
+## Current Section Map
+
+| Surface | Status | Entry | Milestone | Focus |
+| --- | --- | --- | --- | --- |
+| errgroup path | Live v2 slice | `CP.1` | `CP.5` | errgroup, cancellation, sync.Pool, and bounded concurrency |
+| Worker pool reference | Legacy reference | `6-worker-pool/` | `6-worker-pool/` | robust worker-pool design and shutdown boundaries |
+
+## Suggested Order
+
+1. Work through `CP.1`, `CP.2`, and `CP.3` in order.
+2. Complete `CP.4` as the first bounded-concurrency exercise.
+3. Complete `CP.5` as the live section capstone exercise.
+4. Use `6-worker-pool` as legacy reference material after the live slice.
+
+## Section Milestones
+
+This live v2 slice has two promoted exercise surfaces:
+
+- `CP.4` bounded pipeline exercise
+- `CP.5` URL health checker
+
+If you can complete them and explain:
+
+- why `errgroup` is safer than a bare WaitGroup when goroutines can fail
+- why `errgroup.WithContext` is the clean stop signal for sibling work
+- why `sync.Pool` only makes sense after you can explain the allocation problem it solves
+- why bounded concurrency is a systems-design choice, not just a syntax trick
+
+then you are ready to move into testing, quality, and performance work in Section 13.
+
+## Pilot Role In V2
+
+This live v2 slice keeps the current `12-concurrency-patterns` layout intact while promoting the
+main errgroup and pool path into the public curriculum graph:
+
+- `CP.1` through `CP.3` are the core lessons
+- `CP.4` and `CP.5` are the live exercises
+- `6-worker-pool` remains a legacy reference surface for later alpha work
 
 ## References
 
-- [golang.org/x/sync/errgroup](https://pkg.go.dev/golang.org/x/sync/errgroup)
-- [sync.Pool](https://pkg.go.dev/sync#Pool)
-- [Go Blog: Profiling Go Programs](https://go.dev/blog/pprof)
+1. [golang.org/x/sync/errgroup](https://pkg.go.dev/golang.org/x/sync/errgroup)
+2. [Package sync](https://pkg.go.dev/sync)
+3. [Go Blog: Profiling Go Programs](https://go.dev/blog/pprof)
 
-## Learning Path
+## Next Step
 
-| ID | Lesson | Concept | Requires |
-| --- | --- | --- | --- |
-| CP.1 | [errgroup basics](./1-errgroup) | errgroup.Group · g.Go · g.Wait · first-error semantics | 🟢 entry |
-| CP.2 | [errgroup + context](./2-errgroup-context) | WithContext · auto-cancel on first error · fan-out pipeline | CP.1 |
-| CP.3 | [sync.Pool](./3-sync-pool) | Get → use → Reset → Put · GC eviction · zero-alloc buffers | 🟢 entry |
-| CP.4 | [bounded pipeline](./4-bounded-pipeline-exercise) | Semaphore + errgroup · backpressure · production-grade pipeline | CP.1, CP.2 |
-| CP.5 | [url checker](./5-url-checker-exercise) | Practical exercise combining errgroup and context | CP.1, CP.2 |
+After `CP.5`, continue to [Section 13: Quality and Performance](../13-quality-and-performance).

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -158,6 +158,26 @@
         "CT.5",
         "TM.7"
       ]
+    },
+    {
+      "id": "s12",
+      "number": "12",
+      "slug": "concurrency-patterns",
+      "title": "Concurrency Patterns",
+      "phase": "systems",
+      "summary": "Teach errgroup, context-driven cancellation, and deliberate sync.Pool usage through bounded concurrency exercises while leaving the worker-pool reference surface available for later alpha work.",
+      "status": "pilot",
+      "prerequisites": [
+        "s11"
+      ],
+      "path_prefix": "12-concurrency-patterns",
+      "entry_points": [
+        "CP.1"
+      ],
+      "outputs": [
+        "CP.4",
+        "CP.5"
+      ]
     }
   ],
   "items": [
@@ -2430,6 +2450,170 @@
         "time",
         "ticker",
         "reminder"
+      ]
+    },
+    {
+      "id": "CP.1",
+      "section_id": "s12",
+      "slug": "errgroup-basics",
+      "title": "errgroup Basics",
+      "type": "lesson",
+      "subtype": "pattern",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 30,
+      "summary": "Introduce errgroup as the safer coordination tool when concurrent work can fail.",
+      "objectives": [
+        "Use errgroup.Group to launch concurrent work that can return errors",
+        "Explain how errgroup differs from a bare sync.WaitGroup"
+      ],
+      "prerequisites": [],
+      "production_relevance": "Concurrent service startup and fan-out flows often need one coordination point that can surface failure instead of silently discarding it.",
+      "path": "12-concurrency-patterns/1-errgroup",
+      "run_command": "go run ./12-concurrency-patterns/1-errgroup",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "CP.2"
+      ],
+      "tags": [
+        "concurrency",
+        "errgroup",
+        "errors"
+      ]
+    },
+    {
+      "id": "CP.2",
+      "section_id": "s12",
+      "slug": "errgroup-with-context",
+      "title": "errgroup with Context Cancellation",
+      "type": "lesson",
+      "subtype": "integration",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 35,
+      "summary": "Teach automatic sibling cancellation with errgroup.WithContext in fan-out workflows.",
+      "objectives": [
+        "Use errgroup.WithContext to stop sibling goroutines on the first failure",
+        "Explain how context cancellation propagates through the worker pipeline"
+      ],
+      "prerequisites": [
+        "CP.1"
+      ],
+      "production_relevance": "Service fan-out paths need automatic stop signals or they keep wasting work after a failure already decided the outcome.",
+      "path": "12-concurrency-patterns/2-errgroup-context",
+      "run_command": "go run ./12-concurrency-patterns/2-errgroup-context",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "CP.3"
+      ],
+      "tags": [
+        "concurrency",
+        "errgroup",
+        "context"
+      ]
+    },
+    {
+      "id": "CP.3",
+      "section_id": "s12",
+      "slug": "sync-pool",
+      "title": "sync.Pool",
+      "type": "lesson",
+      "subtype": "pattern",
+      "level": "core",
+      "verification_mode": "mixed",
+      "estimated_time": 35,
+      "summary": "Introduce sync.Pool for short-lived object reuse and the reset discipline it requires.",
+      "objectives": [
+        "Use Get, Reset, and Put safely with temporary pooled objects",
+        "Explain why sync.Pool is for measured allocation pressure, not default design"
+      ],
+      "prerequisites": [
+        "CP.1",
+        "CP.2"
+      ],
+      "production_relevance": "Pools help reduce allocation churn in hot paths, but only when used deliberately and reset correctly to avoid stale-data bugs.",
+      "path": "12-concurrency-patterns/3-sync-pool",
+      "run_command": "go run ./12-concurrency-patterns/3-sync-pool",
+      "test_command": "go test ./12-concurrency-patterns/3-sync-pool",
+      "starter_path": "",
+      "next_items": [
+        "CP.4"
+      ],
+      "tags": [
+        "concurrency",
+        "sync.Pool",
+        "memory"
+      ]
+    },
+    {
+      "id": "CP.4",
+      "section_id": "s12",
+      "slug": "bounded-pipeline-exercise",
+      "title": "Bounded Pipeline Exercise",
+      "type": "exercise",
+      "subtype": "",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 75,
+      "summary": "Combine errgroup, cancellation, SetLimit, and sync.Pool in one bounded-concurrency exercise.",
+      "objectives": [
+        "Build a bounded concurrent pipeline that stops on the first failure",
+        "Reuse large temporary buffers instead of allocating one per work item"
+      ],
+      "prerequisites": [
+        "CP.1",
+        "CP.2",
+        "CP.3"
+      ],
+      "production_relevance": "Bounded fan-out plus buffer reuse is a common production pattern when throughput matters more than launching unlimited parallel work.",
+      "path": "12-concurrency-patterns/4-bounded-pipeline-exercise",
+      "run_command": "go run ./12-concurrency-patterns/4-bounded-pipeline-exercise",
+      "test_command": "",
+      "starter_path": "12-concurrency-patterns/4-bounded-pipeline-exercise/_starter",
+      "next_items": [
+        "CP.5"
+      ],
+      "tags": [
+        "exercise",
+        "concurrency",
+        "errgroup",
+        "sync.Pool"
+      ]
+    },
+    {
+      "id": "CP.5",
+      "section_id": "s12",
+      "slug": "url-health-checker",
+      "title": "URL Health Checker",
+      "type": "exercise",
+      "subtype": "",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 80,
+      "summary": "Build a latency-aware URL checker with bounded fan-out and pooled clients.",
+      "objectives": [
+        "Run concurrent HTTP checks with errgroup and bounded fan-out",
+        "Collect stable, latency-sorted results without losing per-request detail"
+      ],
+      "prerequisites": [
+        "CP.1",
+        "CP.2",
+        "CP.3",
+        "CP.4"
+      ],
+      "production_relevance": "Health checks and outbound service probes are a real concurrency workload: they need limits, cancellation, and predictable result handling.",
+      "path": "12-concurrency-patterns/5-url-checker-exercise",
+      "run_command": "go run ./12-concurrency-patterns/5-url-checker-exercise",
+      "test_command": "",
+      "starter_path": "12-concurrency-patterns/5-url-checker-exercise/_starter",
+      "next_items": [],
+      "tags": [
+        "exercise",
+        "concurrency",
+        "http",
+        "health-check"
       ]
     }
   ]


### PR DESCRIPTION
## Description

This PR launches the live v2 Section 12 slice for concurrency patterns.

It promotes the main public Section 12 path:
- CP.1 errgroup basics
- CP.2 errgroup with context cancellation
- CP.3 sync.Pool
- CP.4 bounded pipeline exercise
- CP.5 URL health checker

It also:
- adds Section 12 to curriculum.v2.json
- rewrites the top-level Section 12 guide into the v2 learner-facing format
- adds milestone README contracts for CP.4 and CP.5
- repairs the promoted lesson headers and next-step flow
- normalizes learner-facing text in the promoted concurrency-pattern files

6-worker-pool remains available as a legacy reference surface and is not yet promoted into the live v2 graph.

Closes #143
Closes #145

## Testing

- go run ./scripts/validate_curriculum.go
- go build ./12-concurrency-patterns/...
- go test ./12-concurrency-patterns/3-sync-pool
- go run ./12-concurrency-patterns/4-bounded-pipeline-exercise/_starter
- go run ./12-concurrency-patterns/5-url-checker-exercise/_starter
