### PR TITLE
Create beta stage entry docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,52 +40,44 @@ go run ./01-core-foundations/getting-started/2-hello-world
 ## Beta Public Curriculum
 
 The beta curriculum is organized by engineering stage.
-Until dedicated stage entry docs land, use the current source-section links listed beside each
-stage.
+Each stage now has a dedicated public entry page under [docs/stages](./docs/stages/README.md).
 
 | Beta stage | Focus | Current source content |
 | --- | --- | --- |
-| `0 Foundation` | tools, execution, terminal confidence, first-run mental models | [01-core-foundations/getting-started](./01-core-foundations/getting-started/) |
-| `1 Language Fundamentals` | syntax, control flow, data structures, functions, errors | [01-core-foundations/language-basics](./01-core-foundations/language-basics/), [02-control-flow](./02-control-flow/), [03-data-structures](./03-data-structures/), [04-functions-and-errors](./04-functions-and-errors/) |
-| `2 Types and Design` | structs, interfaces, composition, text and data modeling | [05-types-and-interfaces](./05-types-and-interfaces/), [06-composition](./06-composition/), [07-strings-and-text](./07-strings-and-text/) |
-| `3 Modules and IO` | packages, modules, encoding, filesystems, CLI boundaries | [08-modules-and-packages](./08-modules-and-packages/), [09-io-and-cli](./09-io-and-cli/) |
-| `4 Backend Engineering` | HTTP, databases, handlers, application boundaries | [10-web-and-database](./10-web-and-database/) |
-| `5 Concurrency System` | goroutines, context, scheduling, bounded patterns | [11-concurrency](./11-concurrency/), [12-concurrency-patterns](./12-concurrency-patterns/) |
-| `6 Quality and Performance` | testing, benchmarking, profiling, trust in code | [13-quality-and-performance](./13-quality-and-performance/) |
-| `7 Architecture` | package design, service structure, system boundaries | [14-application-architecture/package-design](./14-application-architecture/package-design/), [14-application-architecture/grpc](./14-application-architecture/grpc/) |
-| `8 Production Engineering` | logging, shutdown, deployment, operating software | [14-application-architecture/structured-logging](./14-application-architecture/structured-logging/), [14-application-architecture/graceful-shutdown](./14-application-architecture/graceful-shutdown/), [14-application-architecture/docker-and-deployment](./14-application-architecture/docker-and-deployment/) |
-| `9 Expert Layer` | review, diagnosis, anti-patterns, trade-offs | beta additions planned |
-| `10 Flagship Project` | one long-running proof-of-skill product spine | [14-application-architecture/enterprise-capstone](./14-application-architecture/enterprise-capstone/) plus milestone projects across the repo |
-| `11 Code Generation` | generation after understanding the code it produces | [15-code-generation](./15-code-generation/) |
+| [0 Foundation](./docs/stages/00-foundation.md) | tools, execution, terminal confidence, first-run mental models | [01-core-foundations/getting-started](./01-core-foundations/getting-started/) |
+| [1 Language Fundamentals](./docs/stages/01-language-fundamentals.md) | syntax, control flow, data structures, functions, errors | [01-core-foundations/language-basics](./01-core-foundations/language-basics/), [02-control-flow](./02-control-flow/), [03-data-structures](./03-data-structures/), [04-functions-and-errors](./04-functions-and-errors/) |
+| [2 Types and Design](./docs/stages/02-types-and-design.md) | structs, interfaces, composition, text and data modeling | [05-types-and-interfaces](./05-types-and-interfaces/), [06-composition](./06-composition/), [07-strings-and-text](./07-strings-and-text/) |
+| [3 Modules and IO](./docs/stages/03-modules-and-io.md) | packages, modules, encoding, filesystems, CLI boundaries | [08-modules-and-packages](./08-modules-and-packages/), [09-io-and-cli](./09-io-and-cli/) |
+| [4 Backend Engineering](./docs/stages/04-backend-engineering.md) | HTTP, databases, handlers, application boundaries | [10-web-and-database](./10-web-and-database/) |
+| [5 Concurrency System](./docs/stages/05-concurrency-system.md) | goroutines, context, scheduling, bounded patterns | [11-concurrency](./11-concurrency/), [12-concurrency-patterns](./12-concurrency-patterns/) |
+| [6 Quality and Performance](./docs/stages/06-quality-and-performance.md) | testing, benchmarking, profiling, trust in code | [13-quality-and-performance](./13-quality-and-performance/) |
+| [7 Architecture](./docs/stages/07-architecture.md) | package design, service structure, system boundaries | [14-application-architecture/package-design](./14-application-architecture/package-design/), [14-application-architecture/grpc](./14-application-architecture/grpc/) |
+| [8 Production Engineering](./docs/stages/08-production-engineering.md) | logging, shutdown, deployment, operating software | [14-application-architecture/structured-logging](./14-application-architecture/structured-logging/), [14-application-architecture/graceful-shutdown](./14-application-architecture/graceful-shutdown/), [14-application-architecture/docker-and-deployment](./14-application-architecture/docker-and-deployment/) |
+| [9 Expert Layer](./docs/stages/09-expert-layer.md) | review, diagnosis, anti-patterns, trade-offs | beta additions planned |
+| [10 Flagship Project](./docs/stages/10-flagship-project.md) | one long-running proof-of-skill product spine | [14-application-architecture/enterprise-capstone](./14-application-architecture/enterprise-capstone/) plus milestone projects across the repo |
+| [11 Code Generation](./docs/stages/11-code-generation.md) | generation after understanding the code it produces | [15-code-generation](./15-code-generation/) |
 
 ## Best Entry Point By Learner Type
 
 ### Complete beginner
 
-Start at [01-core-foundations/getting-started](./01-core-foundations/getting-started/).
-That is the current source surface for `0 Foundation`.
+Start at [0 Foundation](./docs/stages/00-foundation.md).
+That stage page points to the current source surface for beginner setup and first-run work.
 
 ### Experienced programmer new to Go
 
-Skim:
-
-- [01-core-foundations/getting-started](./01-core-foundations/getting-started/)
-- [01-core-foundations/language-basics](./01-core-foundations/language-basics/)
-
-Then go deep on:
-
-- [02-control-flow](./02-control-flow/)
-- [03-data-structures](./03-data-structures/)
-- [04-functions-and-errors](./04-functions-and-errors/)
-- [05-types-and-interfaces](./05-types-and-interfaces/)
+Start at [1 Language Fundamentals](./docs/stages/01-language-fundamentals.md).
+If you want a faster ramp, skim [0 Foundation](./docs/stages/00-foundation.md) first and then use
+the stage page to jump into the current source sections.
 
 ### Experienced Go developer
 
 Jump to the stage you want to strengthen:
 
-- concurrency: [11-concurrency](./11-concurrency/) and [12-concurrency-patterns](./12-concurrency-patterns/)
-- quality and performance: [13-quality-and-performance](./13-quality-and-performance/)
-- architecture and operations: [14-application-architecture](./14-application-architecture/)
+- concurrency: [5 Concurrency System](./docs/stages/05-concurrency-system.md)
+- quality and performance: [6 Quality and Performance](./docs/stages/06-quality-and-performance.md)
+- architecture: [7 Architecture](./docs/stages/07-architecture.md)
+- production and operations: [8 Production Engineering](./docs/stages/08-production-engineering.md)
 
 ## What You Will Build
 
@@ -105,6 +97,7 @@ These docs are still useful during the beta shell rollout:
 | Document | Purpose |
 | --- | --- |
 | [LEARNING-PATH.md](./LEARNING-PATH.md) | current learning guide during the beta routing transition |
+| [docs/stages/README.md](./docs/stages/README.md) | beta stage entry index and stage-by-stage public routing |
 | [docs/curriculum/README.md](./docs/curriculum/README.md) | alpha source inventory and section-by-section curriculum map |
 | [COMMON-MISTAKES.md](./COMMON-MISTAKES.md) | common Go bugs and fixes |
 | [ROADMAP.md](./ROADMAP.md) | public roadmap and release direction |

--- a/docs/stages/00-foundation.md
+++ b/docs/stages/00-foundation.md
@@ -1,0 +1,47 @@
+# 0 Foundation
+
+## Purpose
+
+`0 Foundation` is the real beginner on-ramp.
+It exists to lower fear before syntax-heavy learning begins.
+
+## Who This Is For
+
+- complete beginners
+- learners who are not comfortable with terminals, files, folders, or editors yet
+- learners who need a calm first-run experience before moving into language-heavy lessons
+
+## Mental Model
+
+This stage is about learning how code becomes execution.
+The goal is not to memorize Go quickly.
+The goal is to understand what the terminal, files, folders, and tools are doing when you run code.
+
+## What You Should Learn Here
+
+- how to install and verify Go
+- how to use the terminal without fear
+- how files and folders relate to a runnable program
+- how to run simple programs and read the output
+- the first mental models for state, input, and execution flow
+
+## Current Source Content
+
+- [01-core-foundations/getting-started](../../01-core-foundations/getting-started/)
+
+Beta additions planned:
+
+- pre-Go mental-model notes
+- first-run validation guidance
+- workflow confidence checks for beginners
+
+## Finish This Stage When
+
+- you can clone the repo and run lessons successfully
+- you understand what `go run` is doing at a high level
+- you can move through files and folders comfortably
+- you can fix simple environment mistakes without panic
+
+## Next Stage
+
+Move to [1 Language Fundamentals](./01-language-fundamentals.md).

--- a/docs/stages/01-language-fundamentals.md
+++ b/docs/stages/01-language-fundamentals.md
@@ -1,0 +1,42 @@
+# 1 Language Fundamentals
+
+## Purpose
+
+`1 Language Fundamentals` turns first contact with Go into actual programming fluency.
+
+## Who This Is For
+
+- beginners who finished `0 Foundation`
+- experienced developers who want a disciplined Go fundamentals pass
+
+## Mental Model
+
+This stage teaches the building blocks of code and control.
+You are learning how values move, how decisions are made, how collections are shaped, and how
+functions and errors create boundaries.
+
+## What You Should Learn Here
+
+- variables, values, and basic expressions
+- branching and loops
+- arrays, slices, maps, and pointer-aware mutation
+- function design and parameter/result thinking
+- errors as explicit control flow instead of hidden failure
+
+## Current Source Content
+
+- [01-core-foundations/language-basics](../../01-core-foundations/language-basics/)
+- [02-control-flow](../../02-control-flow/)
+- [03-data-structures](../../03-data-structures/)
+- [04-functions-and-errors](../../04-functions-and-errors/)
+
+## Finish This Stage When
+
+- you can read and write small Go programs without copying line by line
+- you understand how control flow and data structures interact
+- you can design simple functions with clear error behavior
+- you can complete beginner milestone exercises without guessing
+
+## Next Stage
+
+Move to [2 Types and Design](./02-types-and-design.md).

--- a/docs/stages/02-types-and-design.md
+++ b/docs/stages/02-types-and-design.md
@@ -1,0 +1,41 @@
+# 2 Types and Design
+
+## Purpose
+
+`2 Types and Design` moves learners from syntax into modeling.
+
+## Who This Is For
+
+- learners who already understand basic Go flow and data handling
+- developers who want better instincts for structs, interfaces, composition, and data modeling
+
+## Mental Model
+
+This stage is about choosing shapes, not just writing lines.
+Good Go design comes from representing data clearly and choosing boundaries that stay simple under
+change.
+
+## What You Should Learn Here
+
+- structs, methods, and interfaces
+- composition over inheritance-style thinking
+- text and data transformation
+- type choices that support maintainability
+- design trade-offs in small systems
+
+## Current Source Content
+
+- [05-types-and-interfaces](../../05-types-and-interfaces/)
+- [06-composition](../../06-composition/)
+- [07-strings-and-text](../../07-strings-and-text/)
+
+## Finish This Stage When
+
+- you can model a small domain with structs and interfaces honestly
+- you know when composition helps more than clever abstraction
+- you can transform and validate text or record-style data cleanly
+- your type choices feel intentional instead of accidental
+
+## Next Stage
+
+Move to [3 Modules and IO](./03-modules-and-io.md).

--- a/docs/stages/03-modules-and-io.md
+++ b/docs/stages/03-modules-and-io.md
@@ -1,0 +1,43 @@
+# 3 Modules and IO
+
+## Purpose
+
+`3 Modules and IO` teaches how Go code crosses package, process, encoding, and filesystem
+boundaries.
+
+## Who This Is For
+
+- learners who understand core language and type design
+- developers who want more confidence with real file, CLI, and serialization work
+
+## Mental Model
+
+Software becomes useful when it can cross boundaries safely.
+This stage teaches how code interacts with modules, command-line input, encoded data, and the local
+filesystem without becoming messy.
+
+## What You Should Learn Here
+
+- module and package boundaries
+- dependency management basics
+- command-line tool patterns
+- JSON and other encoding workflows
+- filesystem operations, temporary files, and file-search style tasks
+
+## Current Source Content
+
+- [08-modules-and-packages](../../08-modules-and-packages/)
+- [09-io-and-cli/cli-tools](../../09-io-and-cli/cli-tools/)
+- [09-io-and-cli/encoding](../../09-io-and-cli/encoding/)
+- [09-io-and-cli/filesystem](../../09-io-and-cli/filesystem/)
+
+## Finish This Stage When
+
+- you can explain what modules and packages are doing in the repo
+- you can build small CLI and file-processing tools without getting lost
+- you can serialize and deserialize data confidently
+- you understand practical input/output boundaries in Go programs
+
+## Next Stage
+
+Move to [4 Backend Engineering](./04-backend-engineering.md).

--- a/docs/stages/04-backend-engineering.md
+++ b/docs/stages/04-backend-engineering.md
@@ -1,0 +1,42 @@
+# 4 Backend Engineering
+
+## Purpose
+
+`4 Backend Engineering` is where the curriculum becomes application-shaped.
+
+## Who This Is For
+
+- learners who can already work with packages, files, CLI tools, and encoded data
+- developers who want to move into HTTP, persistence, and service-style boundaries
+
+## Mental Model
+
+Backend work is request flow plus data flow.
+This stage teaches how requests enter a system, how state is persisted, and how boundaries keep the
+application understandable.
+
+## What You Should Learn Here
+
+- HTTP client and server basics
+- handlers and request/response flow
+- SQL-backed persistence and repository boundaries
+- transaction thinking
+- migration-aware schema change workflows
+
+## Current Source Content
+
+- [10-web-and-database/http-client](../../10-web-and-database/http-client/)
+- [10-web-and-database/web-masterclass](../../10-web-and-database/web-masterclass/)
+- [10-web-and-database/databases](../../10-web-and-database/databases/)
+- [10-web-and-database/database-migrations](../../10-web-and-database/database-migrations/)
+
+## Finish This Stage When
+
+- you can build and explain a small backend flow end to end
+- you understand how handlers, data access, and transactions connect
+- you can reason about schema change and persistence boundaries
+- you can debug common request/data flow mistakes without panic
+
+## Next Stage
+
+Move to [5 Concurrency System](./05-concurrency-system.md).

--- a/docs/stages/05-concurrency-system.md
+++ b/docs/stages/05-concurrency-system.md
@@ -1,0 +1,43 @@
+# 5 Concurrency System
+
+## Purpose
+
+`5 Concurrency System` teaches how to think about concurrent work without turning programs into
+chaos.
+
+## Who This Is For
+
+- learners who already understand application boundaries
+- Go developers who want stronger intuition for goroutines, context, scheduling, and bounded work
+
+## Mental Model
+
+Concurrency is about coordination, cancellation, and limits.
+The goal is not to add goroutines everywhere.
+The goal is to structure concurrent work so it can start, stop, and fail in controlled ways.
+
+## What You Should Learn Here
+
+- goroutine fundamentals
+- context and cancellation
+- timers, deadlines, and scheduling
+- worker-pool and fan-out/fan-in style patterns
+- bounded failure handling in concurrent systems
+
+## Current Source Content
+
+- [11-concurrency/context](../../11-concurrency/context/)
+- [11-concurrency/goroutines](../../11-concurrency/goroutines/)
+- [11-concurrency/time-and-scheduling](../../11-concurrency/time-and-scheduling/)
+- [12-concurrency-patterns](../../12-concurrency-patterns/)
+
+## Finish This Stage When
+
+- you can explain when concurrency helps and when it hurts
+- you can wire cancellation and timeouts into real flows
+- you can build bounded worker or pipeline patterns
+- you can spot common goroutine leaks and coordination mistakes
+
+## Next Stage
+
+Move to [6 Quality and Performance](./06-quality-and-performance.md).

--- a/docs/stages/06-quality-and-performance.md
+++ b/docs/stages/06-quality-and-performance.md
@@ -1,0 +1,41 @@
+# 6 Quality and Performance
+
+## Purpose
+
+`6 Quality and Performance` teaches how to trust and measure engineering work.
+
+## Who This Is For
+
+- learners who can already build meaningful systems
+- developers who want stronger testing and profiling instincts
+
+## Mental Model
+
+Correctness and speed are not guesses.
+They are proven through tests, benchmarks, profiling, and repeatable checks.
+
+## What You Should Learn Here
+
+- unit and integration testing
+- HTTP client testing
+- profiling and performance inspection
+- benchmark-driven improvement
+- environment-aware test workflows
+
+## Current Source Content
+
+- [13-quality-and-performance/testing](../../13-quality-and-performance/testing/)
+- [13-quality-and-performance/http-client-testing](../../13-quality-and-performance/http-client-testing/)
+- [13-quality-and-performance/profiling](../../13-quality-and-performance/profiling/)
+- [13-quality-and-performance/4-testcontainers](../../13-quality-and-performance/4-testcontainers/)
+
+## Finish This Stage When
+
+- you can design tests that prove behavior instead of only chasing coverage
+- you can benchmark and profile before making performance claims
+- you can improve code with measurement instead of guesswork
+- you understand when full-environment tests are worth the cost
+
+## Next Stage
+
+Move to [7 Architecture](./07-architecture.md).

--- a/docs/stages/07-architecture.md
+++ b/docs/stages/07-architecture.md
@@ -1,0 +1,40 @@
+# 7 Architecture
+
+## Purpose
+
+`7 Architecture` teaches how systems are shaped at the package and service boundary level.
+
+## Who This Is For
+
+- learners who already build, test, and profile non-trivial systems
+- developers who want stronger structure and boundary reasoning
+
+## Mental Model
+
+Architecture is not diagram theater.
+It is the discipline of choosing boundaries that keep code understandable, testable, and able to
+change safely.
+
+## What You Should Learn Here
+
+- package boundary design
+- service structure and interface seams
+- architectural trade-offs in real systems
+- boundary choices inside a capstone-sized codebase
+
+## Current Source Content
+
+- [14-application-architecture/package-design](../../14-application-architecture/package-design/)
+- [14-application-architecture/grpc](../../14-application-architecture/grpc/)
+- architectural slices of [14-application-architecture/enterprise-capstone](../../14-application-architecture/enterprise-capstone/)
+
+## Finish This Stage When
+
+- you can explain why a system is split the way it is
+- you can spot weak package boundaries and suggest better ones
+- you can discuss service seams and ownership with evidence
+- you can read a larger codebase without losing the architectural thread
+
+## Next Stage
+
+Move to [8 Production Engineering](./08-production-engineering.md).

--- a/docs/stages/08-production-engineering.md
+++ b/docs/stages/08-production-engineering.md
@@ -1,0 +1,48 @@
+# 8 Production Engineering
+
+## Purpose
+
+`8 Production Engineering` turns built systems into operated systems.
+
+## Who This Is For
+
+- learners who can already build and structure meaningful applications
+- developers who want stronger runtime and operations instincts
+
+## Mental Model
+
+Software is not finished when it runs once on your machine.
+This stage teaches what changes when software must be observed, configured, shut down safely, and
+deployed with less guesswork.
+
+## What You Should Learn Here
+
+- structured logging
+- graceful shutdown
+- deployment packaging
+- configuration boundaries
+- early observability and runtime support thinking
+
+## Current Source Content
+
+- [14-application-architecture/structured-logging](../../14-application-architecture/structured-logging/)
+- [14-application-architecture/graceful-shutdown](../../14-application-architecture/graceful-shutdown/)
+- [14-application-architecture/docker-and-deployment](../../14-application-architecture/docker-and-deployment/)
+
+Beta additions planned:
+
+- config surfaces
+- tracing and monitoring entry docs
+- operating checklists that connect to the flagship project
+
+## Finish This Stage When
+
+- you can explain what good logs are for
+- you know how to stop services safely
+- you can package and run a deployment-oriented application flow
+- you can reason about runtime behavior, not just implementation details
+
+## Next Stage
+
+Move to [9 Expert Layer](./09-expert-layer.md) or [10 Flagship Project](./10-flagship-project.md),
+depending on whether you want more pressure first or a longer integrated build path first.

--- a/docs/stages/09-expert-layer.md
+++ b/docs/stages/09-expert-layer.md
@@ -1,0 +1,45 @@
+# 9 Expert Layer
+
+## Purpose
+
+`9 Expert Layer` creates engineering pressure through review, diagnosis, and trade-off analysis.
+
+## Who This Is For
+
+- learners who can already build, test, structure, and operate meaningful systems
+- developers who want stronger review and judgment skills instead of more syntax
+
+## Mental Model
+
+This stage is about judgment under pressure.
+The work shifts from "can I implement this?" to "can I critique, diagnose, and improve this under
+constraints?"
+
+## What You Should Learn Here
+
+- code review and critique
+- anti-pattern detection
+- failure analysis
+- redesign under constraints
+- trade-off reasoning across correctness, simplicity, speed, and operability
+
+## Current Source Content
+
+This stage does not yet have a dedicated public source folder on `main`.
+
+Expected beta seeds:
+
+- review and diagnosis tasks derived from later-stage lessons
+- anti-pattern and debugging slices derived from real projects
+- rubric-heavy work connected to the flagship project
+
+## Finish This Stage When
+
+- you can explain why code is weak, not just say that it feels wrong
+- you can diagnose failures with evidence instead of guesswork
+- you can defend trade-offs and redesign choices clearly
+- you can review unfamiliar code and still identify the real risks
+
+## Next Stage
+
+Move to [10 Flagship Project](./10-flagship-project.md).

--- a/docs/stages/10-flagship-project.md
+++ b/docs/stages/10-flagship-project.md
@@ -1,0 +1,46 @@
+# 10 Flagship Project
+
+## Purpose
+
+`10 Flagship Project` is the long-running proof surface for the curriculum.
+
+## Who This Is For
+
+- learners who want one product spine that integrates many stages together
+- developers who want a stronger portfolio-quality proof path inside the repo
+
+## Mental Model
+
+A flagship project is not a random extra app.
+It is the place where backend, concurrency, quality, architecture, operations, and judgment start
+to interact inside one evolving system.
+
+## What You Should Learn Here
+
+- staged feature growth instead of one giant final dump
+- architectural and operational trade-offs inside a single system
+- checkpoint-driven improvement
+- cross-stage integration from backend through production
+
+## Current Source Content
+
+- [14-application-architecture/enterprise-capstone](../../14-application-architecture/enterprise-capstone/)
+- milestone project patterns already used across the alpha curriculum
+
+Beta additions planned:
+
+- clearer project spine milestones
+- tighter rubric integration
+- more explicit handoff from expert pressure into flagship checkpoints
+
+## Finish This Stage When
+
+- you can grow one system across multiple stages without losing structure
+- you can explain the design and operations decisions in the project
+- you can improve the system through iteration instead of only feature addition
+- you can use the project as real proof of engineering growth
+
+## Next Stage
+
+Move to [11 Code Generation](./11-code-generation.md) once you already understand the kinds of
+systems and code you want generation tools to accelerate.

--- a/docs/stages/11-code-generation.md
+++ b/docs/stages/11-code-generation.md
@@ -1,0 +1,39 @@
+# 11 Code Generation
+
+## Purpose
+
+`11 Code Generation` teaches leverage after understanding.
+
+## Who This Is For
+
+- learners who already understand the code and systems they are working with
+- developers who want to use generation responsibly instead of blindly
+
+## Mental Model
+
+Generation is multiplication, not understanding.
+It becomes useful only after you know what the generated code is doing and how it fits into the
+system.
+
+## What You Should Learn Here
+
+- where generation helps
+- where generation creates hidden cost
+- how generated code fits into normal review and maintenance workflows
+- how to keep generated workflows understandable
+
+## Current Source Content
+
+- [15-code-generation](../../15-code-generation/)
+
+## Finish This Stage When
+
+- you can explain why a generation workflow exists
+- you can read and review the code that generation produces
+- you know when not to use generation
+- you understand generation as leverage, not magic
+
+## Next Stage
+
+Use this stage as a late specialization layer after the flagship and expert-pressure work are
+already meaningful to you.

--- a/docs/stages/README.md
+++ b/docs/stages/README.md
@@ -1,0 +1,45 @@
+# Beta Stage Guide
+
+The beta curriculum is organized by engineering stage instead of the alpha-era section numbering.
+
+These stage pages are the public learner-facing entry surfaces for the beta model.
+The source content still lives in the current section folders while the regrouping work continues.
+
+## How To Use These Docs
+
+1. Pick the stage that matches your current goal.
+2. Read the stage page first so you know what the stage owns.
+3. Follow the linked source sections and tracks inside the repo.
+4. Use the `Next stage` note at the bottom of each page when you are ready to move forward.
+
+## Stage Doc Contract
+
+Every stage page uses the same shape:
+
+- `Purpose`: what this stage owns in the curriculum
+- `Who this is for`: the learner profile that should start here
+- `Mental model`: the framing idea learners should carry while studying the stage
+- `What you should learn here`: the main outcomes
+- `Current source content`: the alpha sections or tracks that currently feed the stage
+- `Finish this stage when`: the signs that the learner is ready to move on
+- `Next stage`: the most natural follow-up
+
+This keeps the public learner experience consistent even while the physical folder layout is still
+being regrouped.
+
+## Beta Stages
+
+| Stage | Entry doc |
+| --- | --- |
+| `0 Foundation` | [00-foundation.md](./00-foundation.md) |
+| `1 Language Fundamentals` | [01-language-fundamentals.md](./01-language-fundamentals.md) |
+| `2 Types and Design` | [02-types-and-design.md](./02-types-and-design.md) |
+| `3 Modules and IO` | [03-modules-and-io.md](./03-modules-and-io.md) |
+| `4 Backend Engineering` | [04-backend-engineering.md](./04-backend-engineering.md) |
+| `5 Concurrency System` | [05-concurrency-system.md](./05-concurrency-system.md) |
+| `6 Quality and Performance` | [06-quality-and-performance.md](./06-quality-and-performance.md) |
+| `7 Architecture` | [07-architecture.md](./07-architecture.md) |
+| `8 Production Engineering` | [08-production-engineering.md](./08-production-engineering.md) |
+| `9 Expert Layer` | [09-expert-layer.md](./09-expert-layer.md) |
+| `10 Flagship Project` | [10-flagship-project.md](./10-flagship-project.md) |
+| `11 Code Generation` | [11-code-generation.md](./11-code-generation.md) |


### PR DESCRIPTION
## Summary
- add the first public beta stage entry doc set for stages 0 through 11
- define a consistent stage README contract in docs/stages/README.md
- wire the new stage docs into the root README so beta routing has visible entry pages

## Issue
- closes #179

## Testing
- docs-only change
- git diff --check
