### PR TITLE
Update learning-path routing for beta stages

### DIFF
--- a/LEARNING-PATH.md
+++ b/LEARNING-PATH.md
@@ -1,835 +1,256 @@
 # The Go Engineer Learning Path Guide
 
-This document describes the complete learning path through The Go Engineer curriculum and provides guidance for both learners and curriculum designers.
+This guide explains how learners should move through the beta public curriculum.
 
-## 🎯 Core Learning Philosophy
+The repo is now organized around a beta stage model, even though most source content still lives in
+the current alpha-era section folders.
 
-The curriculum follows a **Spiral Learning Model**:
+Start with the stage pages:
 
-1. **Phase 1: Foundations** (Chapters 01-04): Core syntax, control flow, data structures, and errors.
-2. **Phase 2: Intermediate** (Chapters 05-08): Abstraction, composition, strings/text, and modules.
-3. **Phase 3: IO & CLI** (Chapter 09): Filesystem, encoding, and building CLI tools.
-4. **Phase 4: Systems** (Chapters 10-12): Web development, databases, and concurrency.
-5. **Phase 5: Architecture** (Chapters 13-14): Quality, performance, logging, gRPC, and production design.
-6. **Phase 6: Professional** (Chapter 15): Code generation and automation.
+- [docs/stages/README.md](./docs/stages/README.md)
+- [docs/stages/00-foundation.md](./docs/stages/00-foundation.md)
+- [docs/stages/01-language-fundamentals.md](./docs/stages/01-language-fundamentals.md)
+- [docs/stages/02-types-and-design.md](./docs/stages/02-types-and-design.md)
+- [docs/stages/03-modules-and-io.md](./docs/stages/03-modules-and-io.md)
+- [docs/stages/04-backend-engineering.md](./docs/stages/04-backend-engineering.md)
+- [docs/stages/05-concurrency-system.md](./docs/stages/05-concurrency-system.md)
+- [docs/stages/06-quality-and-performance.md](./docs/stages/06-quality-and-performance.md)
+- [docs/stages/07-architecture.md](./docs/stages/07-architecture.md)
+- [docs/stages/08-production-engineering.md](./docs/stages/08-production-engineering.md)
+- [docs/stages/09-expert-layer.md](./docs/stages/09-expert-layer.md)
+- [docs/stages/10-flagship-project.md](./docs/stages/10-flagship-project.md)
+- [docs/stages/11-code-generation.md](./docs/stages/11-code-generation.md)
 
-## 📚 Learning Tracks
+## Current Repo Reality
 
-Depending on your background, follow different entry points:
+During beta:
 
-### Track A: Complete Beginner
-→ Start at **§01.1 (GS.1)** and follow sequentially through all sections.
+- the stage model is the public navigation truth
+- the current section folders remain the source inventory
+- some stages regroup multiple alpha sections
+- some alpha sections split across more than one beta stage
 
-**Time**: 6-12 months full-time, 1-2 years part-time
+Use this rule while navigating:
 
-**Pathway**:
-```
-GS.1 → GS.2 → GS.3 → GS.4 → LB.1 → LB.2 → LB.3 → LB.4 
-→ CF.1 → CF.2 → CF.3 → CF.4 → DS.1 → DS.2 → DS.3 → DS.4 → DS.5 → DS.6
-... (continue sequentially)
-```
+1. choose a path
+2. open the stage page for that path
+3. follow the linked source tracks and sections from there
 
-### Track B: Experienced Programmer
-→ **Skim** §01-03 (1-2 hours), **deep dive** §04-07 (Go idioms), **explore** §09+ (real applications).
+If you want the raw source inventory, use [docs/curriculum/README.md](./docs/curriculum/README.md).
 
-**Recommended starting points**:
-- Know Python/JavaScript? Start at **FE.1 (Functions)** after skimming basics
-- Know C/Java? Start at **TI.1 (Structs)** after skimming sections 01-04
-- Know systems programming? Jump to **§09 (IO)** after verifying Go syntax
+## The Three Canonical Paths
 
-**Time**: 2-4 months
+The beta learning system uses one curriculum with three routes:
 
-### Track C: Experienced Go Developer
-→ Jump directly to advanced topics you want to master.
-
-**Recommended paths**:
-- **Concurrency**: Start at **GC.1 (Goroutines)** if unsure about patterns
-- **Web Development**: Start at **WM.1 (Routing)** for modern HTTP patterns
-- **Production**: Start at **TE.1 (Testing)** for best practices
-- **Architecture**: Start at **PD.1 (Package Design)** for scalable structure
+1. `Full Path`
+2. `Bridge Path`
+3. `Targeted Path`
 
-**Time**: 1-2 weeks per section
+The routes do not create separate curricula.
+They change pacing and entry strategy while keeping one shared system.
 
----
+## Full Path
 
-## 🔗 Knowledge Progression by Section
+### Best For
 
-### Section 01: Core Foundations (Entry Point)
+- complete beginners
+- learners new to programming
+- learners new to Go who want the most support
 
-**Difficulty**: ⭐️ (Beginner)
+### Route Rule
 
-**Prerequisites**: None
+Follow the stages in order:
 
-**Learning Objectives**:
-- Understand Go's development environment
-- Write and run basic Go programs
-- Use variables, constants, and basic types
-- Apply conditional logic and loops
+`0 -> 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7 -> 8 -> 9 -> 10 -> 11`
 
-**Key Concepts Flow**:
-```
-Installation 
-  ↓
-Hello World (package main, fmt.Println)
-  ↓
-How Go Works (compilation, packages, exports)
-  ↓
-Dev Environment (go fmt, go vet, go build, go test)
-  ↓
-Variables (var, :=, zero values, types)
-  ↓
-Constants (const, compile-time optimization)
-  ↓
-Enums (iota, named types)
-  ↓
-Application Logger Exercise (synthesis of all concepts)
-```
-
-**Transition to §02**: "Now that you understand syntax and can run code, let's control program flow with loops and conditionals."
-
----
-
-### Section 02: Control Flow (Linear)
-
-**Difficulty**: ⭐️ (Beginner)
-
-**Prerequisites**: §01 (variables, constants, basic types)
-
-**Learning Objectives**:
-- Master all loop forms (C-style, while-style, infinite, range)
-- Implement conditional logic (if/else, guard clauses)
-- Use switch statements effectively
-- Combine loops, conditionals, and switches
+### What To Do
 
-**Key Concepts Flow**:
-```
-For Loop (C-style, while-style, infinite, range)
-  ↓
-If/Else (guard clauses, comma-ok idiom)
-  ↓
-Switch (no fall-through, type assertions)
-  ↓
-Pricing Calculator Exercise (combining all three)
-```
-
-**Transition to §03**: "With control flow mastered, let's learn how Go organizes data: arrays, slices, maps, and pointers."
-
----
-
-### Section 03: Data Structures (Building)
-
-**Difficulty**: ⭐️⭐️ (Beginner-Intermediate)
-
-**Prerequisites**: §01, §02 (syntax, control flow)
-
-**Learning Objectives**:
-- Understand fixed-size arrays and their memory model
-- Master slices (dynamic arrays with shared backing)
-- Use maps for fast lookups
-- Understand pointers and reference vs value semantics
-- Navigate complex slicing scenarios
-
-**Key Concepts Flow**:
-```
-Arrays 
-  ↓
-Slices (make, append, capacity)
-  ↓
-Maps (hash tables, O(1) lookup)
-  ↓
-Pointers (& and * operators, nil)
-     ↑ (depends on)
-Slices-2 Advanced (sub-slicing, backing array traps)
-  ↓
-Contact Manager Exercise (combining all structures)
-```
-
-**⚠️ Critical Transition Point**:  
-Pointers are often the hardest concept for newcomers. The curriculum teaches arrays first (fixed memory), then slices (dynamic memory), then pointers (references). This progression builds intuition.
-
-**If struggling**: Review §03.1-3 before attempting §03.4.
-
-**Transition to §04**: "Data is organized. Now let's organize behavior: functions, closures, and error handling."
-
----
-
-### Section 04: Functions & Errors (Pivotal)
-
-**Difficulty**: ⭐️⭐️ (Intermediate)
-
-**Prerequisites**: §01, §02, §03 (all basics)
-
-**Learning Objectives**:
-- Write functions with multiple returns
-- Master Go's error handling convention
-- Use defer for cleanup
-- Handle panics safely
-- Design custom error types
-
-**Key Concepts Flow**:
-```
-Functions (parameters, return types, pass-by-value)
-  ↓
-Closures & Recursion (captured variables, scope)
-  ↓
-Variadic Functions (...T syntax)
-  ↓
-Multiple Returns (error convention)
-     ↑ (foundation for)
-Custom Errors (error interface, sentinel errors)
-  ↓
-Error Wrapping (%w, errors.Is, errors.As)
-  ↓
-Defer (LIFO execution, cleanup)
-  ↓
-Panic & Recover (only inside defer)
-  ↓
-Error Handling Exercise (synthesis of error patterns)
-```
-
-**⚠️ Critical Transition Point**:  
-Error handling is Go's most distinctive feature. The curriculum teaches this **before** objects/interfaces because errors are used everywhere. Master this section.
-
-**Transition to §05**: "Functions organize behavior. Now let's make reusable, composable behavior with types and methods."
+- study the stage entry page before entering each stage
+- follow the linked source sections in order
+- do the required milestone exercises, checkpoints, and mini-projects
+- do not skip repetition by default
 
----
-
-### Section 05: Types & Interfaces (Abstraction)
-
-**Difficulty**: ⭐️⭐️⭐️ (Intermediate-Advanced)
-
-**Prerequisites**: §01-04 (all previous concepts)
-
-**Learning Objectives**:
-- Define structs and attach methods
-- Implement interfaces implicitly
-- Understand polymorphism via interfaces
-- Use generics with constraints
-- Design type hierarchies
-
-**Key Concepts Flow**:
-```
-Structs (fields, constructors, value vs pointer receivers)
-  ↓
-Methods (receiver syntax, method sets)
-  ↓
-Interfaces (implicit satisfaction, type assertions)
-  ↓
-Stringer (first interface to implement)
-  ↓
-Generics ([T constraint], comparable, union types)
-  ↓
-Payroll Processor Exercise (synthesis of all)
-```
+### Why This Path Exists
 
-**⚠️ New Difficulty Level**:  
-This is where the curriculum transitions from "syntax" to "design patterns". Expect increased conceptual complexity.
+This is the honest zero-to-engineer route.
+It optimizes for confidence, reinforcement, and fewer hidden gaps.
 
-**If struggling**: Review interfaces (§05.3) multiple times. They're fundamental to Go.
-
-**Transition to §06**: "We've built isolated types. Now let's combine them into larger systems."
-
----
-
-### Section 06: Composition (Design)
-
-**Difficulty**: ⭐️⭐️ (Intermediate)
-
-**Prerequisites**: §05 (structs, methods)
-
-**Learning Objectives**:
-- Implement composition (has-a) vs inheritance (is-a)
-- Use embedding for type promotion
-- Understand field shadowing
-
-**Key Concepts Flow**:
-```
-Composition (named fields, reuse)
-  ↓
-Embedding (anonymous fields, method promotion, shadowing)
-```
-
-**Note**: This is a short but important section. Go **doesn't have inheritance**; it uses composition and embedding instead.
-
-**Transition to §07**: "Now we've designed data structures. Let's work with complex data: text, formatting, and transformations."
-
----
-
-### Section 07: Strings & Text (Text Processing)
-
-**Difficulty**: ⭐️⭐️ (Intermediate)
-
-**Prerequisites**: §01-06 (type system, interfaces)
-
-**Learning Objectives**:
-- Understand Go's string model (immutable byte slices)
-- Master formatting with `fmt` verbs
-- Handle UTF-8 and runes correctly
-- Use regex for pattern matching
-- Generate text with templates
-
-**Key Concepts Flow**:
-```
-Strings (immutable, byte slices, strings.Builder)
-  ↓
-Formatting (fmt verbs, width/precision)
-  ↓
-Unicode & Runes (UTF-8 multi-byte, rune iteration)
-  ↓
-Regex (MustCompile, FindAll, capture groups)
-  ↓
-Text Templates (html/template, conditionals, loops)
-```
-
-**Transition to §08**: "Now that we understand Go's syntax and types, let's learn how to organize code: modules and packages."
-
----
-
-### Section 08: Modules & Packages (Organization)
-
-**Difficulty**: ⭐️⭐️ (Intermediate)
-
-**Prerequisites**: §01-07 (Go basics)
-
-**Learning Objectives**:
-- Understand Go modules and versioning
-- Manage dependencies effectively
-- Use semantic versioning
-- Resolve common dependency issues
-
-**Key Concepts Flow**:
-```
-Module Basics (go.mod, go.sum, module paths)
-  ↓
-Managing Dependencies (go get, go mod tidy, go list)
-  ↓
-Versioning (semver, v2 import path rule, replace, exclude)
-```
-
-**Transition to §09**: "With packages organized, let's read and write data: files, networking, encoding."
-
----
-
-### Section 09: IO & CLI (Real-World)
-
-**Difficulty**: ⭐️⭐️ (Intermediate)
-
-**Prerequisites**: §01-08 (fundamentals required for I/O)
-
-**Three parallel tracks** (choose based on project needs):
-
-#### Track 1: Filesystem
-```
-Files (ReadFile, WriteFile, OpenFile)
-  ↓
-Paths (Join, Base, Dir, Glob)
-  ↓
-Directories (MkdirAll, WalkDir, ReadDir)
-  ↓
-Temp Files (CreateTemp, unique names)
-  ↓
-Embed (//go:embed, single-binary deployment)
-  ↓
-IO Patterns (Reader/Writer, Copy, TeeReader)
-  ↓
-FS Testing (DirFS, MapFS for zero-disk tests)
-```
-
-#### Track 2: Encoding
-```
-JSON Marshal (encode structs to JSON)
-  ↓
-JSON Unmarshal (decode JSON to structs)
-  ↓
-JSON Encoder (streaming large data)
-  ↓
-JSON Decoder (streaming NDJSON)
-  ↓
-Base64 (transport-safe binary encoding)
-```
-
-#### Track 3: CLI Tools
-```
-OS Args (retrieve command-line arguments)
-  ↓
-Flags (flag package, typed arguments)
-  ↓
-Subcommands (routing, nested commands)
-```
-
-**Note**: These three tracks are **independent**. Take them in any order based on your project needs, but master one before combining with others.
-
-**Transition to §10**: "Great! Now you can read/write data. Let's build a complete web application with a database."
-
----
-
-### Section 10: Web & Database (Full-Stack) ⭐️🏆
-
-**Difficulty**: ⭐️⭐️⭐️ (Advanced)
-
-**Prerequisites**: ALL previous sections (this synthesizes everything)
-
-**Learning Objectives**:
-- Design and query databases with SQL
-- Build HTTP servers with routing
-- Implement web forms and validation
-- Manage user sessions and authentication
-- Access databases within web handlers
-- Build complete CRUD applications
-
-**⚠️ MOST COMPLEX SECTION**:  
-This section combines all previous knowledge. It's normal to feel overwhelmed. Work through slowly.
-
-### Database Track
-
-```
-Connecting (sql.Open, Ping, connection pools)
-  ↓
-Query INSERT (db.Exec, parameterization, bcrypt)
-  ↓
-Query SELECT (QueryRow, rows.Scan, iterator)
-  ↓
-Prepared Statements (explicit preparation optimization)
-  ↓
-Transactions (ACID, rollback, commit)
-```
-
-### Web Track
-
-```
-Routing (http.ServeMux, method patterns, {param})
-  ↓
-Dependency Injection (application struct, handler methods)
-  ↓
-Templates (html/template, layout + partials)
-  ↓
-Middleware (func(http.Handler) http.Handler, panic recovery)
-  ↓
-Sessions (cookie-based, flash messages)
-  ↓
-Authentication (bcrypt, middleware, context.WithValue)
-  ↓
-Forms (validation, field errors, re-populate)
-  ↓
-CRUD Operations (Create, Read, Update, Delete)
-  ↓
-Pagination (LIMIT/OFFSET, metadata)
-  ↓
-Comments (adjacency list, tree building)
-```
-
-### Web + Database: Full App
-
-```
-Posts CRUD (repository pattern, query pagination)
-  ↓
-Complete Application (all pieces together)
-```
-
-**Integration Pattern**:
-```
-                 ┌──────────────┐
-                 │   HTTP.Mux   │ (Routing)
-                 └──────────────┘
-                        ↓
-         ┌──────────────────────────────┐
-         ↓                              ↓
-    ┌─────────┐                   ┌──────────┐
-    │ Template │ (Display)         │ Database │ (Persistence)
-    └─────────┘                   └──────────┘
-         ↑                              ↑
-         └──────────────────────────────┘
-              DI (through struct)
-```
-
-**Critical Insight**:  
-The web server **handles requests** (routing → middleware → handlers) and the **database layer** handles persistence (connect → query → scan). Your job as a developer is wiring them together cleanly.
-
-**Transition to §11**: "You've built a web application. Now let's make it fast and responsive with concurrency."
-
----
-
-### Section 11: Concurrency (Parallelism) 🚀
-
-**Difficulty**: ⭐️⭐️⭐️⭐️ (Expert)
-
-**Prerequisites**: §01-10 (especially functions, interfaces, context from web)
-
-**Learning Objectives**:
-- Launch goroutines and synchronize with WaitGroups
-- Communicate between goroutines with channels
-- Use context for cancellation and timeouts
-- Design concurrent patterns (pipelines, fan-out/in)
-- Find and fix race conditions
-- Understand Go's scheduler and memory model
-
-### Goroutines & Channels Track
-
-```
-Goroutines (go keyword, scheduler, closure-capture bug)
-  ↓
-WaitGroups (Add, Done, Wait, pointer rule)
-  ↓
-Channels Unbuffered (send, receive, block-until-ready)
-  ↓
-Buffered Channels (decoupling producer/consumer)
-  ↓
-Closing Channels (broadcast, range over channel)
-  ↓
-Pipelines (fan-out, fan-in, stage composition)
-  ↓
-Race Conditions (Mutex, RWMutex, atomics, -race flag)
-  ↓
-Select Deep Dive (multiplexing, timeout pattern)
-  ↓
-Sync Primitives (Once, Map, when to use each)
-```
-
-### Context Track
-
-```
-Background & TODO (root contexts, interface)
-  ↓
-WithCancel (manual cancellation, tree propagation)
-  ↓
-WithTimeout (automatic deadline)
-  ↓
-WithValue (request-scoped metadata)
-```
-
-### Time & Scheduling Track
-
-```
-Time Basics (Duration, Add, Sub, wall vs monotonic)
-  ↓
-Formatting (reference time, Parse, RFC3339)
-  ↓
-Timers & Tickers (NewTimer, NewTicker, Stop)
-  ↓
-Random Numbers (PCG, IntN, Shuffle)
-  ↓
-Scheduler (actor model, scheduling tasks)
-  ↓
-Timezones (IANA database, always store UTC)
-```
-
-**⚠️ MOST DIFFICULT SECTION**:  
-Concurrency is notoriously hard to reason about. The curriculum teaches it **after** web development so you have context (background servers, workers, timeouts are all real use cases).
-
-**If struggling**: 
-- Review goroutines (§11.1) and channels (§11.3) multiple times
-- Study race conditions (§11.8) in depth
-- Run code with `-race` flag religiously
-- Use context for ALL long-running operations
-
-**Transition to §12**: "You understand concurrency. Now learn idiomatic patterns."
-
----
-
-### Section 12: Concurrency Patterns (Idioms)
-
-**Difficulty**: ⭐️⭐️⭐️⭐️ (Expert)
-
-**Prerequisites**: §11 (goroutines, channels, context)
-
-**Learning Objectives**:
-- Use errgroup for parallel work with error propagation
-- Implement sync.Pool for zero-allocation object reuse
-- Design bounded concurrency patterns
-
-**Key Concepts Flow**:
-```
-errgroup Basics (Group, Go, Wait, first-error semantics)
-  ↓
-errgroup + Context (auto-cancel on error, fan-out pipelines)
-  ↓
-sync.Pool (Get/Put, GC eviction, zero-alloc buffers)
-```
-
-**Transition to §13**: "Your program runs wrong or slowly. Let's test it thoroughly and optimize."
-
----
-
-### Section 13: Quality & Performance (Testing) ✅
-
-**Difficulty**: ⭐️⭐️ (Intermediate)
-
-**Prerequisites**: All previous (you test the code you write)
-
-**Three parallel tracks**:
-
-#### Testing Track
-```
-Unit Tests (testing.T, assert library)
-  ↓
-Table-Driven Tests (t.Run, data-matrix)
-  ↓
-HTTP Handler Tests (httptest, no real server)
-  ↓
-Benchmarking (testing.B, -benchmem, performance)
-```
-
-#### Mocking Track
-```
-Manual Mocks (MockHTTPClient struct, injection)
-  ↓
-Function-Injection Mocks (GetFunc field, spying)
-  ↓
-Table-Driven Mocks (sub-tests, per-case behavior)
-  ↓
-testify/mock (Mock struct, On/Return, assertions)
-```
-
-#### Profiling Track
-```
-CPU Profiling (pprof.StartCPUProfile, go tool pprof)
-  ↓
-Live pprof Endpoint (net/http/pprof, two-port pattern)
-```
-
-**Integration with Development**:  
-Write tests **as you code**, not after. Use table-driven tests for systematic coverage.
-
-**Transition to §14**: "Now you've written correct, fast code. Let's design it for production."
-
----
-
-### Section 14: Architecture (Production Design) 🏗️
-
-**Difficulty**: ⭐️⭐️⭐️ (Advanced)
-
-**Prerequisites**: Sections 01-13 (all fundamentals)
-
-**Six main tracks**:
-
-#### Package Design
-```
-Naming (short, lowercase, domain-based)
-  ↓
-Visibility (exported/unexported, internal/ compiler enforcement)
-  ↓
-Project Layout (cmd/, internal/, pkg/, start flat)
-```
-
-#### Docker
-```
-Single-Stage Dockerfile (basics, alpine)
-  ↓
-Multi-Stage Builds (builder stage, runtime stage, 15MB final images)
-  ↓
-Layer Caching (go.mod caching, .dockerignore, build optimization)
-```
-
-#### Logging
-```
-slog Basics (TextHandler, JSONHandler, structured logging)
-  ↓
-Context-Keyed Logger (private key, request_id, middleware)
-  ↓
-Custom slog.Handler (PrettyHandler, MultiHandler)
-  ↓
-zerolog Comparison (when to choose zerol vs slog)
-```
-
-#### gRPC
-```
-Proto Definition (proto3, code generation)
-  ↓
-Unary Server (implement generated interface)
-  ↓
-Unary Client (dial, stub, deadline)
-  ↓
-Server-side Streaming (WatchOrderStatus, pushing data)
-  ↓
-Bidirectional Streaming (ProcessOrderStream, concurrent streams)
-```
-
-#### Graceful Shutdown
-```
-Signal.NotifyContext (SIGTERM, SIGINT, ctx cancellation)
-  ↓
-HTTP Graceful Drain (Server.Shutdown, 30s deadline, readiness)
-```
-
-#### Enterprise Capstone
-```
-Full REST API + PostgreSQL + Docker Compose
-```
-
-**Integration Application**:  
-The **Enterprise Capstone** integrates ALL previous knowledge:
-- Package design (structure)
-- Docker (deployment)
-- Logging (observability)
-- Concurrency patterns (background workers)
-- Graceful shutdown (production reliability)
-- Web + database (functionality)
-
-This is your **capstone project**: a complete, production-ready REST API.
-
-**Transition to §15**: "Your application is production-ready. Let's automate parts of the build."
-
----
-
-### Section 15: Code Generation (Automation)
-
-**Difficulty**: ⭐️ (Beginner-Intermediate)
-
-**Prerequisites**: All previous (you understand what code generation solves)
-
-**Learning Objectives**:
-- Use //go:generate directive
-- Understand when code generation is appropriate
-- Implement mockery, stringer, sqlc patterns
-
-**Key Concepts Flow**:
-```
-go:generate Directive (tool invocation, build-time generation)
-  ├── mockery (interface mocking - expert depth)
-  ├── sqlc (type-safe SQL - expert depth)
-  └── stringer (enum string conversion)
-```
-
----
-
-## 🔄 Circular Dependencies & Reinforcement
-
-Certain concepts appear multiple times at different depths:
-
-| Concept | Introduced | Deepened | Mastered |
-|---------|-----------|----------|----------|
-| **Errors** | §04 | §08, §14 | Practice |
-| **Interfaces** | §05 | §09, §10, §13 | §14 |
-| **Concurrency** | §11 | §12 | §14 (servers with workers) |
-| **Testing** | §13 | Throughout | §13+ |
-| **HTTP** | §10 | §13, §14 | §14 |
-
-This **repetition at increasing depth** is intentional. Each section assumes you've seen the concept before.
-
----
-
-## ⚠️ Common Struggles & How to Overcome Them
-
-### Struggle 1: Pointers (§03)
-**Problem**: Confusing pass-by-value (copy) vs pass-by-reference (pointer)
-**Solution**: Revisit §01 (variable assignment), then §03.4 slowly
-**Practice**: Write a function that modifies a struct; understand why you need `*`
-
-### Struggle 2: Interfaces (§05)
-**Problem**: Don't understand implicit satisfaction or type assertions
-**Solution**: Review §05.3 deeply; implement Stringer yourself multiple times
-**Practice**: Convert a function that takes `interface{}` to accept a specific interface
-
-### Struggle 3: Concurrency (§11)
-**Problem**: Deadlocks, race conditions, unclear goroutine lifecycle
-**Solution**: Run ALL code with `-race` flag; use channels to synchronize
-**Practice**: Build a simple worker pool with buffered channels and WaitGroups
-
-### Struggle 4: Web + Database (§10)
-**Problem**: Unclear how HTTP handlers interact with database queries
-**Solution**: Draw boxes (handler, middleware, repository, db connection)
-**Practice**: Implement a single GET endpoint end-to-end
-
-### Struggle 5: Error Handling (§04)
-**Problem**: When to use custom errors vs sentinel errors vs wrapping
-**Solution**: §04.5-6 teaches patterns; follow them religiously
-**Practice**: Convert an error-returning function to use fmt.Errorf with %w
-
----
-
-## 📖 How to Use This Learning Path Document
-
-### For Learners
-1. Find your **track** (Beginner, Experienced Programmer, Experienced Go Dev)
-2. Follow the **prerequisite chain** for your chosen path
-3. If stuck, review the **Common Struggles** section
-4. Use **Key Concepts Flow** diagrams to understand section structure
-5. Follow the **Transitions** to understand how sections connect
-
-### For Contributors
-1. Look at your section's **Learning Objectives** and **Key Concepts Flow**
-2. Ensure lessons follow the **prerequisites** accurately
-3. Add exercises that **reinforce** the concepts (not just one example)
-4. Use **Progressive Difficulty**: basic example → edge cases → combinations
-5. If a lesson depends on 5+ prerequisites, break it into sub-lessons
-
-### For Curriculum Reviewers
-1. Check that **prerequisites** match actual curriculum.json
-2. Verify **difficulty progression** within and between sections
-3. Look for **missing transitions**: abrupt jumps in difficulty
-4. Identify **knowledge gaps**: concepts used but not taught
-5. Flag **inconsistent depth**: some topics shallow, others deep
-
----
-
-## 📊 Sample Learning Timeline
-
-### Complete Beginner (30 weeks)
-- **Weeks 1-2**: §01 Foundations
-- **Weeks 3-4**: §02-03 Data Structures
-- **Weeks 5-7**: §04-06 Functions, Types, Composition
-- **Weeks 8-9**: §07-09 Text and IO
-- **Weeks 10-15**: §10 Web + Database (longest)
-- **Weeks 16-20**: §11-13 Concurrency and Testing
-- **Weeks 21-25**: §14 Architecture
-- **Weeks 26-30**: Build projects using all knowledge
-
-### Experienced Programmer (8 weeks)
-- **Week 1**: Skim §01-04, focus on §05 (interfaces)
-- **Week 2**: §06-09 (Go idioms and IO)
-- **Week 3**: §10 Web Development
-- **Week 4-5**: §11-12 Concurrency
-- **Week 6**: §13 Testing  
-- **Week 7-8**: §14 Architecture
-- **Ongoing**: §15 Code Generation as needed
-
-### Experienced Go Developer (2-3 weeks)
-- **Pick from**: §11 (concurrency patterns), §13 (testing strategies), §14 (architecture best practices)
-- **Build**: Personal project using learned patterns
-- **Refer to**: Specific lessons as needed
-
----
-
-## 🚀 After Completing The Go Engineer
-
-Congratulations! You've mastered Go fundamentals. Next steps:
-
-1. **Build projects**: Apply what you've learned
-   - REST API with authentication
-   - CLI tool with subcommands
-   - Background worker system with concurrency
-
-2. **Explore advanced topics** (beyond curriculum):
-   - Systems programming (syscalls, cgo)
-   - Protocol Buffers and gRPC optimization
-   - Advanced concurrency (NUMA, lock-free structures)
-   - Kubernetes and cloud deployment
-   - Contributing to open-source Go projects
-
-3. **Master a domain**:
-   - Web: Echo, Gin, Chi frameworks
-   - CLI: cobra, urfave/cli
-   - Data: encoding/csv, gocv, Gonum
-   - DevOps: Terraform, Kubernetes operators
-
-4. **Stay updated**:
-   - Follow [golang-announce](https://groups.google.com/forum/#!forum/golang-announce)
-   - Read blogs: Dave Cheney, Bill Kennedy, Ben Johnson
-   - Contribute to Go and the community
-
----
-
-## Feedback & Improvements
-
-If you find this learning path document unclear, inaccurate, or incomplete:
-1. **Open an issue** (use [lesson_request.md](../.github/ISSUE_TEMPLATE/lesson_request.md))
-2. **Submit a PR** with improvements (see [CONTRIBUTING.md](../CONTRIBUTING.md))
-3. **Discuss** on discussions (coming soon)
-
-This curriculum is a living document; your feedback helps it improve.
-
----
-
-**Last Updated**: April 2026  
-**Version**: 1.0  
-**Total Learning Path**: 80+ lessons, 15 sections, 250+ concepts
+### Stage Flow
+
+- [0 Foundation](./docs/stages/00-foundation.md)
+- [1 Language Fundamentals](./docs/stages/01-language-fundamentals.md)
+- [2 Types and Design](./docs/stages/02-types-and-design.md)
+- [3 Modules and IO](./docs/stages/03-modules-and-io.md)
+- [4 Backend Engineering](./docs/stages/04-backend-engineering.md)
+- [5 Concurrency System](./docs/stages/05-concurrency-system.md)
+- [6 Quality and Performance](./docs/stages/06-quality-and-performance.md)
+- [7 Architecture](./docs/stages/07-architecture.md)
+- [8 Production Engineering](./docs/stages/08-production-engineering.md)
+- [9 Expert Layer](./docs/stages/09-expert-layer.md)
+- [10 Flagship Project](./docs/stages/10-flagship-project.md)
+- [11 Code Generation](./docs/stages/11-code-generation.md)
+
+## Bridge Path
+
+### Best For
+
+- experienced programmers who are new to Go
+- learners who know programming already but need Go-specific instincts
+
+### Route Rule
+
+Keep the same stage order, but skip repetition rather than proof.
+
+Recommended route:
+
+`0 (skim) -> 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7 -> 8 -> 10 -> 11`
+
+The `9 Expert Layer` remains valuable, but it is not the first stop for most bridge learners.
+
+### What To Skim
+
+Bridge learners may skim:
+
+- some beginner setup detail in `0 Foundation`
+- repetition-heavy early examples once the toolchain and basic execution model are clear
+- selected drills that only repeat concepts they already command
+
+### What Not To Skip
+
+Bridge learners should not skip:
+
+- Go-specific function and error handling patterns
+- structs, interfaces, and composition decisions
+- package and module boundaries
+- concurrency checkpoints if they plan to enter the concurrency stages
+- milestone exercises that prove real Go understanding
+
+### Best Starting Point
+
+Start here:
+
+- [0 Foundation](./docs/stages/00-foundation.md) for a fast setup and tooling sanity pass
+- then move quickly into [1 Language Fundamentals](./docs/stages/01-language-fundamentals.md)
+
+### Why This Path Exists
+
+This route is for transfer, not for ego.
+If you already know programming, you should move faster, but you still need proof that your prior
+mental models fit Go's style.
+
+## Targeted Path
+
+### Best For
+
+- working Go developers
+- learners fixing a specific weakness
+- learners returning to strengthen one area without replaying the whole curriculum
+
+### Route Rule
+
+Choose a stage intentionally, review the prerequisites honestly, then complete the stage's required
+practice and proof surfaces.
+
+### Entry Rule
+
+Before entering a later stage, ask:
+
+1. Do I really understand the earlier concepts this stage depends on?
+2. Can I complete the relevant checkpoint or milestone work, not just read the lessons?
+3. Am I skipping repetition, or am I skipping proof?
+
+### Recommended Entry Points
+
+| Goal | Start Here | Before You Start |
+| --- | --- | --- |
+| tighten Go fundamentals | [1 Language Fundamentals](./docs/stages/01-language-fundamentals.md) | skim [0 Foundation](./docs/stages/00-foundation.md) if tooling or execution still feels shaky |
+| improve data modeling and design | [2 Types and Design](./docs/stages/02-types-and-design.md) | be solid on functions, errors, and collections |
+| strengthen modules, files, encoding, or CLI work | [3 Modules and IO](./docs/stages/03-modules-and-io.md) | be comfortable with structs, errors, and basic package flow |
+| build backend applications | [4 Backend Engineering](./docs/stages/04-backend-engineering.md) | be solid on modules, IO, structs, interfaces, and error handling |
+| improve concurrency | [5 Concurrency System](./docs/stages/05-concurrency-system.md) | be solid on backend flow, errors, and context-aware thinking |
+| improve testing or profiling | [6 Quality and Performance](./docs/stages/06-quality-and-performance.md) | be able to build meaningful programs first |
+| improve architecture | [7 Architecture](./docs/stages/07-architecture.md) | be solid on packages, backend boundaries, and testing |
+| improve operations and runtime practices | [8 Production Engineering](./docs/stages/08-production-engineering.md) | be comfortable with backend and architecture concerns |
+| focus on review and diagnosis | [9 Expert Layer](./docs/stages/09-expert-layer.md) | come in with real implementation experience |
+| build a portfolio-level integrated system | [10 Flagship Project](./docs/stages/10-flagship-project.md) | have backend, concurrency, testing, and architecture depth |
+| use generation responsibly | [11 Code Generation](./docs/stages/11-code-generation.md) | understand the systems and code shapes being generated |
+
+### Why This Path Exists
+
+Not every serious learner should restart from zero.
+But targeted entry only works when prerequisites are checked honestly.
+
+## Validation Floors
+
+Fast paths are allowed.
+Proof is not optional.
+
+Use these validation floors:
+
+- `Full Path`: complete every required checkpoint and milestone mini-project
+- `Bridge Path`: complete every checkpoint plus the important stage milestones
+- `Targeted Path`: complete the chosen stage's checkpoint or equivalent proof artifact before
+  claiming mastery
+
+## Mental-Model Rule
+
+Every beta stage includes a mental-model surface.
+Use the stage pages for that.
+
+That means:
+
+- beginners should not skip the stage README and mental-model framing
+- experienced learners may move faster, but should still read the stage framing before jumping into
+  source files
+- advanced learners should use the stage page to verify they are entering the right layer of the
+  curriculum
+
+## Suggested Starting Points By Learner Type
+
+### Complete Beginner
+
+Start with [0 Foundation](./docs/stages/00-foundation.md), then follow the Full Path in order.
+
+### Experienced Programmer New To Go
+
+Start with [0 Foundation](./docs/stages/00-foundation.md) for a quick environment and execution
+pass, then move into [1 Language Fundamentals](./docs/stages/01-language-fundamentals.md) on the
+Bridge Path.
+
+### Working Go Developer
+
+Choose your target stage from the table above and use the Targeted Path honestly.
+
+## How This Relates To The Existing Sections
+
+The beta stages regroup the current source sections like this:
+
+- `0 Foundation`: `01-core-foundations/getting-started`
+- `1 Language Fundamentals`: `01-core-foundations/language-basics`, `02`, `03`, `04`
+- `2 Types and Design`: `05`, `06`, `07`
+- `3 Modules and IO`: `08`, `09`
+- `4 Backend Engineering`: `10`
+- `5 Concurrency System`: `11`, `12`
+- `6 Quality and Performance`: `13`
+- `7 Architecture`: architecture-focused tracks from `14`
+- `8 Production Engineering`: operations-focused tracks from `14`
+- `9 Expert Layer`: beta additions
+- `10 Flagship Project`: `enterprise-capstone` plus later flagship regrouping
+- `11 Code Generation`: `15`
+
+## Recommended Companion Docs
+
+- [README.md](./README.md)
+- [docs/stages/README.md](./docs/stages/README.md)
+- [docs/curriculum/README.md](./docs/curriculum/README.md)
+- [COMMON-MISTAKES.md](./COMMON-MISTAKES.md)
+- [CONTRIBUTING.md](./CONTRIBUTING.md)
+
+## Bottom Line
+
+The beta learning-path rule is simple:
+
+- choose the path that matches your background honestly
+- navigate by stage first
+- follow the linked source content from the stage page
+- move fast if you want, but do not skip proof


### PR DESCRIPTION
## Summary
- rewrite LEARNING-PATH.md around the beta stage model and the three canonical routes
- define stage-aware Full Path, Bridge Path, and Targeted Path guidance
- keep the change limited to the beta-facing learning-path surface without editing alpha inventory docs

## Issue
- closes #180

## Testing
- docs-only change
- git diff --check
