### PR TITLE
Publish beta architecture transition explainer

### DIFF
--- a/LEARNING-PATH.md
+++ b/LEARNING-PATH.md
@@ -5,6 +5,9 @@ This guide explains how learners should move through the beta public curriculum.
 The repo is now organized around a beta stage model, even though most source content still lives in
 the current alpha-era section folders.
 
+For the public explanation of how that works, read
+[docs/beta-public-architecture.md](./docs/beta-public-architecture.md).
+
 Start with the stage pages:
 
 - [docs/stages/README.md](./docs/stages/README.md)
@@ -242,6 +245,7 @@ The beta stages regroup the current source sections like this:
 
 - [README.md](./README.md)
 - [docs/stages/README.md](./docs/stages/README.md)
+- [docs/beta-public-architecture.md](./docs/beta-public-architecture.md)
 - [docs/curriculum/README.md](./docs/curriculum/README.md)
 - [COMMON-MISTAKES.md](./COMMON-MISTAKES.md)
 - [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ from zero to production-minded engineering work.
 The beta public architecture is now the main learner-facing direction. The source content still
 lives in the current section folders while the beta shell is rolled out incrementally.
 
+If you want the public explanation of that transition model, read
+[docs/beta-public-architecture.md](./docs/beta-public-architecture.md).
+
 ## Start Here
 
 Pick the release channel that matches what you want:
@@ -98,6 +101,7 @@ These docs are still useful during the beta shell rollout:
 | --- | --- |
 | [LEARNING-PATH.md](./LEARNING-PATH.md) | current learning guide during the beta routing transition |
 | [docs/stages/README.md](./docs/stages/README.md) | beta stage entry index and stage-by-stage public routing |
+| [docs/beta-public-architecture.md](./docs/beta-public-architecture.md) | explanation of alpha source inventory versus beta public architecture |
 | [docs/curriculum/README.md](./docs/curriculum/README.md) | alpha source inventory and section-by-section curriculum map |
 | [COMMON-MISTAKES.md](./COMMON-MISTAKES.md) | common Go bugs and fixes |
 | [ROADMAP.md](./ROADMAP.md) | public roadmap and release direction |
@@ -120,6 +124,9 @@ During the beta rollout:
 
 That means the README now presents the curriculum by beta stage even though the physical folder
 layout is still mostly the alpha-era section structure.
+
+For the full explanation of that relationship, see
+[docs/beta-public-architecture.md](./docs/beta-public-architecture.md).
 
 ## Run Lessons And Exercises
 

--- a/docs/beta-public-architecture.md
+++ b/docs/beta-public-architecture.md
@@ -1,0 +1,158 @@
+# Alpha Source Inventory vs Beta Public Architecture
+
+The Go Engineer is in a transition period.
+
+That means two things are true at the same time:
+
+- the repo still contains the alpha-era section inventory as the main source content
+- the public learner-facing navigation is now moving to the beta stage model
+
+This document explains how those two layers fit together.
+
+## The Short Version
+
+Use this rule:
+
+- if you want to know **how to navigate the curriculum as a learner**, follow the beta stage docs
+- if you want to know **where the current source content physically lives**, follow the alpha source
+  inventory
+
+Beta is the navigation truth.
+Alpha is still the physical source inventory for much of the repo.
+
+## What Alpha Means Right Now
+
+In this repo, `alpha` refers to the current section-based content inventory:
+
+- `01-core-foundations`
+- `02-control-flow`
+- `03-data-structures`
+- ...
+- `15-code-generation`
+
+Alpha proved that the curriculum could be migrated, validated, and cleaned up section by section.
+
+Alpha is still valuable because it contains the lessons, exercises, milestone projects, and source
+files learners use today.
+
+## What Beta Means Right Now
+
+`Beta` means the learner-facing curriculum architecture is being reorganized around engineering
+stages instead of only section numbers.
+
+The beta stages are:
+
+1. `0 Foundation`
+2. `1 Language Fundamentals`
+3. `2 Types and Design`
+4. `3 Modules and IO`
+5. `4 Backend Engineering`
+6. `5 Concurrency System`
+7. `6 Quality and Performance`
+8. `7 Architecture`
+9. `8 Production Engineering`
+10. `9 Expert Layer`
+11. `10 Flagship Project`
+12. `11 Code Generation`
+
+These stages are the public learner-routing model.
+
+## Why The Repo Uses Both At Once
+
+We are not discarding alpha content and rewriting the entire repo from scratch in one destructive
+move.
+
+Instead, beta does three things:
+
+1. regroup existing alpha content into clearer learner-facing stages
+2. split some alpha sections where the learner-facing boundary is better than the current folder
+   boundary
+3. add a few new beta-only layers where alpha was too thin, especially:
+   - `0 Foundation`
+   - `8 Production Engineering`
+   - `9 Expert Layer`
+   - `10 Flagship Project`
+
+This lets the curriculum improve without pretending the current folder tree has already been
+perfectly rebuilt.
+
+## What A Split Looks Like
+
+Some alpha sections map cleanly to one beta stage.
+Some do not.
+
+Examples:
+
+- `10-web-and-database` mostly feeds `4 Backend Engineering`
+- `15-code-generation` maps directly to `11 Code Generation`
+- `01-core-foundations` splits across:
+  - `0 Foundation`
+  - `1 Language Fundamentals`
+- `14-application-architecture` splits across:
+  - `7 Architecture`
+  - `8 Production Engineering`
+  - `10 Flagship Project`
+
+So if a learner sees one alpha section feeding more than one beta stage, that is intentional.
+It is not duplication by accident.
+
+## What To Trust For What
+
+Use these docs based on the question you are asking:
+
+### If you are a learner
+
+Use:
+
+- [README.md](../README.md)
+- [LEARNING-PATH.md](../LEARNING-PATH.md)
+- [docs/stages/README.md](./stages/README.md)
+
+These docs tell you how to move through the curriculum now.
+
+### If you want the physical source layout
+
+Use:
+
+- [docs/curriculum/README.md](./curriculum/README.md)
+- the current top-level section folders
+
+These show where the source content currently lives.
+
+### If you are a maintainer or contributor
+
+Use:
+
+- the beta shell docs for public navigation truth
+- the source inventory docs for where files live today
+- `planning/v2` for frozen planning and regrouping direction
+
+## What This Does Not Mean
+
+This transition model does **not** mean:
+
+- the repo has two different public curricula
+- learners should ignore the stage model
+- the alpha folder structure is the final learner-facing architecture
+- every section must be physically moved before beta guidance can be honest
+
+It means the public navigation model is changing first, and the physical regrouping work continues
+incrementally.
+
+## Practical Learner Rule
+
+If you are unsure what to do next:
+
+1. start from the beta stage docs
+2. choose the stage that matches your current goal
+3. follow the linked source sections from there
+4. use the alpha inventory only when you need to understand where files live physically
+
+## Bottom Line
+
+The Go Engineer is not trying to keep alpha and beta as competing systems.
+
+The alpha section inventory is still the source content.
+The beta stage model is the public learner-facing architecture.
+
+That is the transition model.

--- a/docs/stages/README.md
+++ b/docs/stages/README.md
@@ -5,6 +5,9 @@ The beta curriculum is organized by engineering stage instead of the alpha-era s
 These stage pages are the public learner-facing entry surfaces for the beta model.
 The source content still lives in the current section folders while the regrouping work continues.
 
+If you want the public explanation of that relationship, read
+[../beta-public-architecture.md](../beta-public-architecture.md).
+
 ## How To Use These Docs
 
 1. Pick the stage that matches your current goal.


### PR DESCRIPTION
## Summary
- add one public explainer for alpha source inventory versus beta public architecture
- link that explainer from the README, stage guide, and learning-path guide
- keep the change limited to beta-facing shell docs

## Issue
- closes #181

## Testing
- docs-only change
- git diff --check
