### PR TITLE
Align Sections 02 to 04 with beta stage ownership

### DIFF
--- a/02-control-flow/README.md
+++ b/02-control-flow/README.md
@@ -12,6 +12,17 @@ By the end of Section 02, you should be comfortable with:
 - `switch` for readable multi-branch logic
 - combining loops, branching, map lookups, and small helpers in one exercise
 
+## Beta Stage Ownership
+
+This section belongs to [1 Language Fundamentals](../docs/stages/01-language-fundamentals.md).
+
+Within the beta public shell, it is the second of four connected parts:
+
+1. Section 01 `language-basics`
+2. Section 02 `control-flow`
+3. Section 03 `data-structures`
+4. Section 04 `functions-and-errors`
+
 ## Who Should Start Here
 
 ### Full Path
@@ -65,3 +76,5 @@ then you are ready to move into data structures in Section 03.
 ## Next Step
 
 After `CF.4`, continue to Section 03: Data Structures.
+In the beta shell, that keeps you inside
+[1 Language Fundamentals](../docs/stages/01-language-fundamentals.md).

--- a/03-data-structures/README.md
+++ b/03-data-structures/README.md
@@ -13,6 +13,17 @@ By the end of Section 03, you should be comfortable with:
 - pointers for mutation and nil-aware references
 - combining those pieces in one small in-memory program
 
+## Beta Stage Ownership
+
+This section belongs to [1 Language Fundamentals](../docs/stages/01-language-fundamentals.md).
+
+Within the beta public shell, it is the third of four connected parts:
+
+1. Section 01 `language-basics`
+2. Section 02 `control-flow`
+3. Section 03 `data-structures`
+4. Section 04 `functions-and-errors`
+
 ## Who Should Start Here
 
 ### Full Path
@@ -70,3 +81,5 @@ then you are ready to move into functions and errors in Section 04.
 ## Next Step
 
 After `DS.6`, continue to Section 04: Functions and Errors.
+In the beta shell, that is still part of
+[1 Language Fundamentals](../docs/stages/01-language-fundamentals.md).

--- a/04-functions-and-errors/README.md
+++ b/04-functions-and-errors/README.md
@@ -14,6 +14,17 @@ By the end of Section 04, you should be comfortable reading and writing:
 - defer-based cleanup
 - panic and recover boundaries
 
+## Beta Stage Ownership
+
+This section belongs to [1 Language Fundamentals](../docs/stages/01-language-fundamentals.md).
+
+Within the beta public shell, it is the fourth and final part of that stage:
+
+1. Section 01 `language-basics`
+2. Section 02 `control-flow`
+3. Section 03 `data-structures`
+4. Section 04 `functions-and-errors`
+
 ## Who Should Start Here
 
 ### Full Path
@@ -103,5 +114,11 @@ reorders the live lesson paths.
 
 ## Next Step
 
-After `FE.9`, continue to [Section 05: Types and Interfaces](../05-types-and-interfaces).
+After `FE.9`, you have completed the core milestone path for
+[1 Language Fundamentals](../docs/stages/01-language-fundamentals.md).
+
+From there, move to [2 Types and Design](../docs/stages/02-types-and-design.md).
+The first source section in that next stage is
+[Section 05: Types and Interfaces](../05-types-and-interfaces).
+
 If you want one more pattern lesson before moving on, finish `FE.10` first.


### PR DESCRIPTION
## Summary
- align Sections 02 to 04 with the beta `1 Language Fundamentals` stage
- add explicit stage-ownership notes to the three section READMEs
- keep the slice narrow by touching only section-level routing surfaces

## Testing
- git diff --check

Closes #194