### PR TITLE
Publish Language Fundamentals stage map and milestone guidance

### DIFF
--- a/docs/stages/01-language-fundamentals.md
+++ b/docs/stages/01-language-fundamentals.md
@@ -53,6 +53,15 @@ The stage is intentionally ordered from "what is a value?" to "what is a functio
 - [03-data-structures](../../03-data-structures/)
 - [04-functions-and-errors](../../04-functions-and-errors/)
 
+## Stage Support Docs
+
+Use these support docs when you want the beta-stage view without digging through four section
+READMEs:
+
+- [Language Fundamentals support index](./language-fundamentals/README.md)
+- [Stage map](./language-fundamentals/stage-map.md)
+- [Milestone guidance](./language-fundamentals/milestone-guidance.md)
+
 ## Where This Stage Starts
 
 This stage starts at [01-core-foundations/language-basics](../../01-core-foundations/language-basics/).

--- a/docs/stages/language-fundamentals/README.md
+++ b/docs/stages/language-fundamentals/README.md
@@ -1,0 +1,28 @@
+# 1 Language Fundamentals Support Docs
+
+This folder supports the beta `1 Language Fundamentals` stage.
+
+Use these docs when you want a stage-level view of how the current Section `01` through Section
+`04` source content fits together.
+
+## Use These In This Order
+
+1. [stage-map.md](./stage-map.md)
+2. [milestone-guidance.md](./milestone-guidance.md)
+
+Then work through the source sections in order:
+
+1. [01-core-foundations/language-basics](../../../01-core-foundations/language-basics/)
+2. [02-control-flow](../../../02-control-flow/)
+3. [03-data-structures](../../../03-data-structures/)
+4. [04-functions-and-errors](../../../04-functions-and-errors/)
+
+## What These Docs Are For
+
+- `stage-map.md`: a clear map of what each section owns inside the stage
+- `milestone-guidance.md`: a practical guide to the four milestone proof surfaces
+
+## What These Docs Are Not
+
+They do not replace the source lessons.
+They exist to make the stage-level path and milestone expectations easier to follow.

--- a/docs/stages/language-fundamentals/milestone-guidance.md
+++ b/docs/stages/language-fundamentals/milestone-guidance.md
@@ -1,0 +1,57 @@
+# Language Fundamentals Milestone Guidance
+
+The `1 Language Fundamentals` stage has four proof surfaces.
+
+These are not just exercises to check off.
+Together, they show whether a learner can actually use the stage instead of only reading it.
+
+## Milestone Backbone
+
+| ID | Surface | What It Proves |
+| --- | --- | --- |
+| `LB.4` | application logger | you can write a small Go program with named values, simple structure, and readable output |
+| `CF.4` | pricing calculator | you can combine loops, conditionals, maps, and small helpers in one runnable flow |
+| `DS.6` | contact manager | you can use slices, maps, and pointers together without losing track of mutation |
+| `FE.9` | error handling project | you can model failures explicitly and use functions and cleanup in a disciplined way |
+
+## How To Use These Milestones
+
+### Full Path
+
+Complete all four in order.
+They are the strongest proof that the stage really stuck.
+
+### Bridge Path
+
+If you move faster through the lessons, use these milestones as the non-skippable proof surfaces.
+Do not claim the stage is done if you only skimmed the lessons and skipped the milestone work.
+
+### Targeted Path
+
+If you enter the stage late, choose the milestone that best matches your real gap first, then
+check backward honestly:
+
+- weak on basic Go program shape: start with `LB.4`
+- weak on decision logic and loops: start with `CF.4`
+- weak on collections and mutation: start with `DS.6`
+- weak on function contracts and failures: start with `FE.9`
+
+## Honest Readiness Signals
+
+You are likely ready to leave this stage when:
+
+- you can complete the milestone without copying the solution line by line
+- you can explain why the solution is shaped that way
+- you can make a small variation without the whole program falling apart
+- you can describe your own mistakes clearly instead of guessing
+
+## If A Milestone Feels Too Hard
+
+That is usually a routing signal, not a failure signal.
+
+Go back one layer:
+
+- `LB.4` too hard: revisit `language-basics`
+- `CF.4` too hard: revisit `for`, `if`, and `switch`
+- `DS.6` too hard: revisit slices, maps, and pointers
+- `FE.9` too hard: revisit multiple returns, custom errors, wrapping, and `defer`

--- a/docs/stages/language-fundamentals/stage-map.md
+++ b/docs/stages/language-fundamentals/stage-map.md
@@ -1,0 +1,66 @@
+# Language Fundamentals Stage Map
+
+This stage is the early programming backbone of the beta curriculum.
+
+It takes learners from first real Go syntax through collections, mutation, functions, and explicit
+error handling.
+
+## Stage Flow
+
+1. `language-basics`
+   - source: [01-core-foundations/language-basics](../../../01-core-foundations/language-basics/)
+   - core job: teach values, variables, constants, and simple program structure
+   - milestone: `LB.4` application logger
+2. `control-flow`
+   - source: [02-control-flow](../../../02-control-flow/)
+   - core job: teach loops, branching, and readable decision logic
+   - milestone: `CF.4` pricing calculator
+3. `data-structures`
+   - source: [03-data-structures](../../../03-data-structures/)
+   - core job: teach slices, maps, pointers, and mutation-aware thinking
+   - milestone: `DS.6` contact manager
+4. `functions-and-errors`
+   - source: [04-functions-and-errors](../../../04-functions-and-errors/)
+   - core job: teach function boundaries, explicit failures, wrapping, and cleanup
+   - milestone: `FE.9` error handling project
+
+## What Each Part Adds
+
+### `language-basics`
+
+This is where the learner stops merely reading syntax and starts writing small Go programs.
+
+### `control-flow`
+
+This is where the learner starts making programs do real work through branching and repetition.
+
+### `data-structures`
+
+This is where the learner starts managing state, collections, and mutation honestly instead of
+line-by-line imitation.
+
+### `functions-and-errors`
+
+This is where the learner starts treating function signatures and errors as explicit contracts.
+
+## Recommended Full-Path Order
+
+1. Finish the `language-basics` track first.
+2. Move through Section `02` and complete `CF.4`.
+3. Move through Section `03` and complete `DS.6`.
+4. Move through Section `04` and complete `FE.9`.
+
+## Bridge-Path Reminder
+
+If Go syntax is already familiar, you can move faster through the early repetition.
+What you should not skip is proof:
+
+- `LB.4`
+- `CF.4`
+- `DS.6`
+- `FE.9`
+
+## Exit Condition
+
+You are ready for `2 Types and Design` when you can finish the four stage milestones honestly and
+explain how values, control flow, collections, mutation, functions, and errors connect together.


### PR DESCRIPTION
## Summary
- add Language Fundamentals support docs for stage map and milestone guidance
- link the main stage entry doc to those new support surfaces
- keep the change inside the beta shell without rewriting the alpha lesson inventory

## Testing
- git diff --check

Closes #195