### PR TITLE
Align Sections 05 to 07 with beta stage ownership

### DIFF
--- a/05-types-and-interfaces/README.md
+++ b/05-types-and-interfaces/README.md
@@ -13,6 +13,16 @@ By the end of Section 05, you should be comfortable reading and writing:
 - small generic helpers built on interface-aware constraints
 - polymorphic code that works across multiple concrete types
 
+## Beta Stage Ownership
+
+This section belongs to [2 Types and Design](../docs/stages/02-types-and-design.md).
+
+Within the beta public shell, it is the first of three connected parts:
+
+1. Section 05 `types-and-interfaces`
+2. Section 06 `composition`
+3. Section 07 `strings-and-text`
+
 ## Who Should Start Here
 
 ### Full Path
@@ -96,4 +106,7 @@ This pilot intentionally avoids breaking the current Section 05 filesystem layou
 ## Next Step
 
 After `TI.6`, continue to [Section 06: Composition](../06-composition).
+In the beta shell, that keeps you inside
+[2 Types and Design](../docs/stages/02-types-and-design.md).
+
 If you want one more stretch lesson before moving on, finish `TI.7` first.

--- a/06-composition/README.md
+++ b/06-composition/README.md
@@ -12,6 +12,16 @@ By the end of Section 06, you should be comfortable reading and writing:
 - shadowed methods that change behavior at the outer type boundary
 - small domain models that reuse behavior without class hierarchies
 
+## Beta Stage Ownership
+
+This section belongs to [2 Types and Design](../docs/stages/02-types-and-design.md).
+
+Within the beta public shell, it is the second of three connected parts:
+
+1. Section 05 `types-and-interfaces`
+2. Section 06 `composition`
+3. Section 07 `strings-and-text`
+
 ## Who Should Start Here
 
 ### Full Path
@@ -86,3 +96,5 @@ This pilot intentionally avoids breaking the current Section 06 filesystem layou
 ## Next Step
 
 After `CO.3`, continue to [Section 07: Strings and Text](../07-strings-and-text).
+In the beta shell, that is still part of
+[2 Types and Design](../docs/stages/02-types-and-design.md).

--- a/07-strings-and-text/README.md
+++ b/07-strings-and-text/README.md
@@ -14,6 +14,16 @@ By the end of Section 07, you should be comfortable reading and writing:
 - template-driven text rendering
 - small text-processing tools with runnable behavior and tests
 
+## Beta Stage Ownership
+
+This section belongs to [2 Types and Design](../docs/stages/02-types-and-design.md).
+
+Within the beta public shell, it is the third and final part of that stage:
+
+1. Section 05 `types-and-interfaces`
+2. Section 06 `composition`
+3. Section 07 `strings-and-text`
+
 ## Who Should Start Here
 
 ### Full Path
@@ -92,4 +102,9 @@ This pilot intentionally avoids breaking the current Section 07 filesystem layou
 
 ## Next Step
 
-After `ST.6`, continue to [Section 08: Modules and Packages](../08-modules-and-packages).
+After `ST.6`, you have completed the core milestone path for
+[2 Types and Design](../docs/stages/02-types-and-design.md).
+
+From there, move to [3 Modules and IO](../docs/stages/03-modules-and-io.md).
+The first source section in that next stage is
+[Section 08: Modules and Packages](../08-modules-and-packages).


### PR DESCRIPTION
## Summary
- align Sections 05 to 07 with the beta `2 Types and Design` stage
- add explicit stage-ownership notes to the three section READMEs
- keep the slice narrow by touching only section-level routing surfaces

## Testing
- git diff --check

Closes #201