### PR TITLE
Publish Types and Design stage map and milestone guidance

### DIFF
--- a/docs/stages/02-types-and-design.md
+++ b/docs/stages/02-types-and-design.md
@@ -51,6 +51,15 @@ transform real data with those types?"
 - [06-composition](../../06-composition/)
 - [07-strings-and-text](../../07-strings-and-text/)
 
+## Stage Support Docs
+
+Use these support docs when you want the beta-stage view without digging through three section
+READMEs:
+
+- [Types and Design support index](./types-and-design/README.md)
+- [Stage map](./types-and-design/stage-map.md)
+- [Milestone guidance](./types-and-design/milestone-guidance.md)
+
 ## Where This Stage Starts
 
 This stage starts at [05-types-and-interfaces](../../05-types-and-interfaces/).

--- a/docs/stages/types-and-design/README.md
+++ b/docs/stages/types-and-design/README.md
@@ -1,0 +1,27 @@
+# 2 Types and Design Support Docs
+
+This folder supports the beta `2 Types and Design` stage.
+
+Use these docs when you want a stage-level view of how the current Section `05` through Section
+`07` source content fits together.
+
+## Use These In This Order
+
+1. [stage-map.md](./stage-map.md)
+2. [milestone-guidance.md](./milestone-guidance.md)
+
+Then work through the source sections in order:
+
+1. [05-types-and-interfaces](../../../05-types-and-interfaces/)
+2. [06-composition](../../../06-composition/)
+3. [07-strings-and-text](../../../07-strings-and-text/)
+
+## What These Docs Are For
+
+- `stage-map.md`: a clear map of what each section owns inside the stage
+- `milestone-guidance.md`: a practical guide to the three milestone proof surfaces
+
+## What These Docs Are Not
+
+They do not replace the source lessons.
+They exist to make the stage-level path and milestone expectations easier to follow.

--- a/docs/stages/types-and-design/milestone-guidance.md
+++ b/docs/stages/types-and-design/milestone-guidance.md
@@ -1,0 +1,54 @@
+# Types and Design Milestone Guidance
+
+The `2 Types and Design` stage has three proof surfaces.
+
+These milestones show whether a learner can model and shape data intentionally instead of only
+copying patterns.
+
+## Milestone Backbone
+
+| ID | Surface | What It Proves |
+| --- | --- | --- |
+| `TI.6` | payroll processor project | you can model domain data with structs, methods, interfaces, and a small generic helper |
+| `CO.3` | bank account project | you can use composition and embedding deliberately without confusing them for inheritance |
+| `ST.6` | config parser project | you can parse, transform, and render text-driven workflows cleanly |
+
+## How To Use These Milestones
+
+### Full Path
+
+Complete all three in order.
+They are the strongest proof that the stage really stuck.
+
+### Bridge Path
+
+If you move faster through the lessons, use these milestones as the non-skippable proof surfaces.
+Do not claim the stage is done if you only skimmed the lessons and skipped the milestone work.
+
+### Targeted Path
+
+If you enter the stage late, choose the milestone that best matches your real gap first, then
+check backward honestly:
+
+- weak on structs, methods, interfaces, or generics: start with `TI.6`
+- weak on reuse and embedding: start with `CO.3`
+- weak on parsing, formatting, or rendering text: start with `ST.6`
+
+## Honest Readiness Signals
+
+You are likely ready to leave this stage when:
+
+- you can complete the milestone without copying the solution line by line
+- you can explain why the design is shaped that way
+- you can change a type, boundary, or output shape without the whole program collapsing
+- you can name the trade-off you made instead of only saying that the code works
+
+## If A Milestone Feels Too Hard
+
+That is usually a routing signal, not a failure signal.
+
+Go back one layer:
+
+- `TI.6` too hard: revisit structs, methods, interfaces, and generic helpers
+- `CO.3` too hard: revisit named-field composition and embedding basics
+- `ST.6` too hard: revisit strings, formatting, regex, and templates

--- a/docs/stages/types-and-design/stage-map.md
+++ b/docs/stages/types-and-design/stage-map.md
@@ -1,0 +1,59 @@
+# Types and Design Stage Map
+
+This stage turns basic Go fluency into more intentional modeling and design choices.
+
+It takes learners from structs and interfaces through composition and embedding, then into text
+transformation and rendering workflows that depend on those design choices.
+
+## Stage Flow
+
+1. `types-and-interfaces`
+   - source: [05-types-and-interfaces](../../../05-types-and-interfaces/)
+   - core job: teach structs, methods, interfaces, and small generic helpers
+   - milestone: `TI.6` payroll processor project
+2. `composition`
+   - source: [06-composition](../../../06-composition/)
+   - core job: teach explicit reuse, embedding, promoted behavior, and shadowing
+   - milestone: `CO.3` bank account project
+3. `strings-and-text`
+   - source: [07-strings-and-text](../../../07-strings-and-text/)
+   - core job: teach parsing, formatting, rendering, and text-driven workflow design
+   - milestone: `ST.6` config parser project
+
+## What Each Part Adds
+
+### `types-and-interfaces`
+
+This is where the learner starts modeling data and behavior with clear type boundaries instead of
+only writing procedural code.
+
+### `composition`
+
+This is where the learner starts reusing behavior explicitly without sliding into inheritance
+thinking.
+
+### `strings-and-text`
+
+This is where the learner starts shaping real inputs and outputs through parsing and rendering
+instead of ad hoc text handling.
+
+## Recommended Full-Path Order
+
+1. Finish the Section `05` milestone path first.
+2. Move through Section `06` and complete `CO.3`.
+3. Move through Section `07` and complete `ST.6`.
+
+## Bridge-Path Reminder
+
+If structs, methods, and interfaces already feel familiar, you can move faster through the early
+repetition.
+What you should not skip is proof:
+
+- `TI.6`
+- `CO.3`
+- `ST.6`
+
+## Exit Condition
+
+You are ready for `3 Modules and IO` when you can finish the three stage milestones honestly and
+explain how type design, reuse, and text-driven workflows connect together.


### PR DESCRIPTION
## Summary
- add Types and Design support docs for stage map and milestone guidance
- link the main stage entry doc to those new support surfaces
- keep the change inside the beta shell without rewriting the alpha lesson inventory

## Testing
- git diff --check

Closes #202