### PR TITLE
Align Sections 08 to 09 with beta stage ownership

### DIFF
--- a/08-modules-and-packages/README.md
+++ b/08-modules-and-packages/README.md
@@ -13,6 +13,15 @@ By the end of Section 08, you should be comfortable reading and writing:
 - local override workflows with `replace`
 - optional platform and test surfaces through build tags
 
+## Beta Stage Ownership
+
+This section belongs to [3 Modules and IO](../docs/stages/03-modules-and-io.md).
+
+Within the beta public shell, it is the first of two connected parts:
+
+1. Section 08 `modules-and-packages`
+2. Section 09 `io-and-cli`
+
 ## Who Should Start Here
 
 ### Full Path
@@ -94,4 +103,7 @@ This pilot intentionally avoids breaking the current Section 08 filesystem layou
 ## Next Step
 
 After `MP.3`, continue to [Section 09: I/O and CLI Tools](../09-io-and-cli).
+In the beta shell, that keeps you inside
+[3 Modules and IO](../docs/stages/03-modules-and-io.md).
+
 If you want one more stretch lesson before moving on, finish `MP.4` first.

--- a/09-io-and-cli/README.md
+++ b/09-io-and-cli/README.md
@@ -12,6 +12,15 @@ By the end of Section 09, you should be comfortable reading and writing:
 - filesystem tools that traverse directories, stream content, and keep I/O testable
 - runnable utilities that interact with the outside world without turning into fragile scripts
 
+## Beta Stage Ownership
+
+This section belongs to [3 Modules and IO](../docs/stages/03-modules-and-io.md).
+
+Within the beta public shell, it is the second and final part of that stage:
+
+1. Section 08 `modules-and-packages`
+2. Section 09 `io-and-cli`
+
 ## Who Should Start Here
 
 ### Full Path
@@ -92,5 +101,9 @@ That keeps the section useful for current learners while the broader v2 migratio
 
 ## Next Step
 
-After you finish the track or milestone you care about here, continue to
+After you finish the track or milestone you care about here, you have completed the core milestone
+path for [3 Modules and IO](../docs/stages/03-modules-and-io.md).
+
+From there, move to [4 Backend Engineering](../docs/stages/04-backend-engineering.md).
+The first source section in that next stage is
 [Section 10: Web and Database](../10-web-and-database).


### PR DESCRIPTION
## Summary
- align Sections 08 to 09 with the beta `3 Modules and IO` stage
- add explicit stage-ownership notes to the two section READMEs
- keep the slice narrow by touching only section-level routing surfaces

## Testing
- git diff --check

Closes #208