### PR TITLE
Publish Modules and IO stage map and milestone guidance

### DIFF
--- a/docs/stages/03-modules-and-io.md
+++ b/docs/stages/03-modules-and-io.md
@@ -50,6 +50,15 @@ The stage is intentionally ordered from "how is this code organized and versione
 - [09-io-and-cli/encoding](../../09-io-and-cli/encoding/)
 - [09-io-and-cli/filesystem](../../09-io-and-cli/filesystem/)
 
+## Stage Support Docs
+
+Use these support docs when you want the beta-stage view without digging through Section `08` plus
+the Section `09` track docs:
+
+- [Modules and IO support index](./modules-and-io/README.md)
+- [Stage map](./modules-and-io/stage-map.md)
+- [Milestone guidance](./modules-and-io/milestone-guidance.md)
+
 ## Where This Stage Starts
 
 This stage starts at [08-modules-and-packages](../../08-modules-and-packages/).

--- a/docs/stages/modules-and-io/README.md
+++ b/docs/stages/modules-and-io/README.md
@@ -1,0 +1,28 @@
+# 3 Modules and IO Support Docs
+
+This folder supports the beta `3 Modules and IO` stage.
+
+Use these docs when you want a stage-level view of how the current Section `08` plus the Section
+`09` tracks fit together.
+
+## Use These In This Order
+
+1. [stage-map.md](./stage-map.md)
+2. [milestone-guidance.md](./milestone-guidance.md)
+
+Then work through the source surfaces in order:
+
+1. [08-modules-and-packages](../../../08-modules-and-packages/)
+2. [09-io-and-cli/cli-tools](../../../09-io-and-cli/cli-tools/)
+3. [09-io-and-cli/encoding](../../../09-io-and-cli/encoding/)
+4. [09-io-and-cli/filesystem](../../../09-io-and-cli/filesystem/)
+
+## What These Docs Are For
+
+- `stage-map.md`: a clear map of what the section and tracks own inside the stage
+- `milestone-guidance.md`: a practical guide to the four milestone proof surfaces
+
+## What These Docs Are Not
+
+They do not replace the source lessons.
+They exist to make the stage-level path and milestone expectations easier to follow.

--- a/docs/stages/modules-and-io/milestone-guidance.md
+++ b/docs/stages/modules-and-io/milestone-guidance.md
@@ -1,0 +1,57 @@
+# Modules and IO Milestone Guidance
+
+The `3 Modules and IO` stage has four proof surfaces.
+
+These milestones show whether a learner can work across module, process, encoding, and filesystem
+boundaries instead of staying inside toy in-memory examples.
+
+## Milestone Backbone
+
+| ID | Surface | What It Proves |
+| --- | --- | --- |
+| `MP.3` | versioning workshop | you understand module versioning, `/v2` import paths, and local `replace` reasoning |
+| `CL.4` | file organizer | you can build a safe CLI workflow with arguments, flags, and clear output |
+| `EN.6` | config parser | you can handle encoded configuration data through real JSON/config workflows |
+| `FS.7` | log search tool | you can traverse files and directories without tangling search, reading, and matching logic |
+
+## How To Use These Milestones
+
+### Full Path
+
+Complete all four in order.
+They are the strongest proof that the stage really stuck.
+
+### Bridge Path
+
+If you move faster through the lessons, use these milestones as the non-skippable proof surfaces.
+Do not claim the stage is done if you only skimmed the lessons and skipped the milestone work.
+
+### Targeted Path
+
+If you enter the stage late, choose the milestone that best matches your real boundary gap first,
+then check backward honestly:
+
+- weak on modules and dependency behavior: start with `MP.3`
+- weak on CLI tooling: start with `CL.4`
+- weak on encoding and config flows: start with `EN.6`
+- weak on files and directory traversal: start with `FS.7`
+
+## Honest Readiness Signals
+
+You are likely ready to leave this stage when:
+
+- you can complete the milestone without copying the solution line by line
+- you can explain why the tool or workflow is shaped that way
+- you can change an input, path, or output shape without the whole program collapsing
+- you can describe which boundary the code is protecting and why
+
+## If A Milestone Feels Too Hard
+
+That is usually a routing signal, not a failure signal.
+
+Go back one layer:
+
+- `MP.3` too hard: revisit `go.mod`, dependency commands, and module versioning rules
+- `CL.4` too hard: revisit args, flags, and small command dispatch
+- `EN.6` too hard: revisit marshalling, unmarshalling, and config-loading patterns
+- `FS.7` too hard: revisit file basics, directory traversal, and I/O composition

--- a/docs/stages/modules-and-io/stage-map.md
+++ b/docs/stages/modules-and-io/stage-map.md
@@ -1,0 +1,56 @@
+# Modules and IO Stage Map
+
+This stage teaches how Go programs cross package, tool, encoding, and filesystem boundaries.
+
+It takes learners from module reasoning into command-line tools, encoded data flows, and real file
+operations that interact with the outside world.
+
+## Stage Flow
+
+1. `modules-and-packages`
+   - source: [08-modules-and-packages](../../../08-modules-and-packages/)
+   - core job: teach module boundaries, dependency management, versioning, and build-surface reasoning
+   - milestone: `MP.3` versioning workshop
+2. `io-and-cli`
+   - source surfaces:
+     - [09-io-and-cli/cli-tools](../../../09-io-and-cli/cli-tools/)
+     - [09-io-and-cli/encoding](../../../09-io-and-cli/encoding/)
+     - [09-io-and-cli/filesystem](../../../09-io-and-cli/filesystem/)
+   - core job: teach CLI flows, encoding workflows, and filesystem tooling patterns
+   - milestone backbone: `CL.4`, `EN.6`, `FS.7`
+
+## What Each Part Adds
+
+### `modules-and-packages`
+
+This is where the learner stops treating the Go toolchain as magic and starts understanding
+package layout, dependency state, and version boundaries.
+
+### `io-and-cli`
+
+This is where the learner starts writing tools that interact with real inputs and outputs instead
+of only in-memory examples.
+
+## Recommended Full-Path Order
+
+1. Finish the Section `08` milestone path first.
+2. Complete the `cli-tools` track milestone.
+3. Complete the `encoding` track milestone.
+4. Complete the `filesystem` track milestone.
+
+## Bridge-Path Reminder
+
+If modules, packages, and standard-library tooling already feel familiar, you can move faster
+through the early repetition.
+What you should not skip is proof:
+
+- `MP.3`
+- `CL.4`
+- `EN.6`
+- `FS.7`
+
+## Exit Condition
+
+You are ready for `4 Backend Engineering` when you can finish the four stage milestones honestly
+and explain how module boundaries, CLI interfaces, encoded data, and filesystem logic connect in a
+real tool.


### PR DESCRIPTION
## Summary
- add Modules and IO support docs for stage map and milestone guidance
- link the main stage entry doc to those new support surfaces
- keep the change inside the beta shell without rewriting the alpha lesson inventory

## Testing
- git diff --check

Closes #209