### PR TITLE
Publish Backend Engineering stage map and milestone guidance

### DIFF
--- a/docs/stages/04-backend-engineering.md
+++ b/docs/stages/04-backend-engineering.md
@@ -51,6 +51,15 @@ broader Section `10` inventory.
 - [10-web-and-database/databases](../../10-web-and-database/databases/)
 - [10-web-and-database/database-migrations](../../10-web-and-database/database-migrations/)
 
+## Stage Support Docs
+
+Use these support docs when you want the beta-stage view without digging through the full Section
+`10` inventory:
+
+- [Backend Engineering support index](./backend-engineering/README.md)
+- [Stage map](./backend-engineering/stage-map.md)
+- [Milestone guidance](./backend-engineering/milestone-guidance.md)
+
 ## Where This Stage Starts
 
 Start with the databases track at

--- a/docs/stages/backend-engineering/README.md
+++ b/docs/stages/backend-engineering/README.md
@@ -1,0 +1,29 @@
+# 4 Backend Engineering Support Docs
+
+This folder supports the beta `4 Backend Engineering` stage.
+
+Use these docs when you want a stage-level view of how the current Section `10` source content fits
+together.
+
+## Use These In This Order
+
+1. [stage-map.md](./stage-map.md)
+2. [milestone-guidance.md](./milestone-guidance.md)
+
+Then work through the source surfaces in order:
+
+1. [10-web-and-database/databases](../../../10-web-and-database/databases/)
+2. optional reference surfaces:
+   - [10-web-and-database/http-client](../../../10-web-and-database/http-client/)
+   - [10-web-and-database/database-migrations](../../../10-web-and-database/database-migrations/)
+   - [10-web-and-database/web-masterclass](../../../10-web-and-database/web-masterclass/)
+
+## What These Docs Are For
+
+- `stage-map.md`: a clear map of what the live beta path and the reference surfaces each do
+- `milestone-guidance.md`: a practical guide to the current live proof surface
+
+## What These Docs Are Not
+
+They do not replace the source lessons.
+They exist to make the stage-level path and milestone expectations easier to follow.

--- a/docs/stages/backend-engineering/milestone-guidance.md
+++ b/docs/stages/backend-engineering/milestone-guidance.md
@@ -1,0 +1,49 @@
+# Backend Engineering Milestone Guidance
+
+The `4 Backend Engineering` stage currently has one promoted live proof surface.
+
+That narrower scope is intentional for now.
+The beta route is promoting the databases path first instead of pretending the entire Section `10`
+inventory is already equally mature.
+
+## Live Milestone Backbone
+
+| ID | Surface | What It Proves |
+| --- | --- | --- |
+| `DB.6` | repository pattern project | you can connect persistence, transactions, and repository boundaries inside a service-shaped backend flow |
+
+## How To Use This Milestone
+
+### Full Path
+
+Complete the databases track in order and use `DB.6` as the main proof surface for the stage.
+
+### Bridge Path
+
+If you move faster through the lessons, use `DB.6` as the non-skippable proof surface.
+Do not claim the stage is done if you only skimmed the data-access lessons and skipped the project.
+
+### Targeted Path
+
+If you enter this stage late because your main gap is backend persistence and service boundaries,
+start with the databases path first.
+Use the other Section `10` directories as reference reading rather than as a substitute for the
+live milestone path.
+
+## Honest Readiness Signals
+
+You are likely ready to leave this stage when:
+
+- you can complete `DB.6` without copying the solution line by line
+- you can explain why the repository exists instead of only saying that it works
+- you can reason about transaction boundaries and context-aware execution clearly
+- you can describe which Section `10` surfaces are live beta path versus reference-only
+
+## If The Milestone Feels Too Hard
+
+That is usually a routing signal, not a failure signal.
+
+Go back one layer:
+
+- `DB.6` too hard: revisit connecting to the database, query execution, scanning rows, prepared
+  statements, and transaction flow

--- a/docs/stages/backend-engineering/stage-map.md
+++ b/docs/stages/backend-engineering/stage-map.md
@@ -1,0 +1,56 @@
+# Backend Engineering Stage Map
+
+This stage turns language, type, and I/O fluency into service-shaped application work.
+
+It starts with the live databases path, while keeping the rest of the current Section `10` source
+tree available as reference material.
+
+## Stage Flow
+
+1. `databases`
+   - source: [10-web-and-database/databases](../../../10-web-and-database/databases/)
+   - core job: teach `database/sql`, transactions, repository boundaries, and context-aware
+     persistence
+   - milestone: `DB.6` repository pattern project
+2. `http-client`, `database-migrations`, and `web-masterclass`
+   - source surfaces:
+     - [10-web-and-database/http-client](../../../10-web-and-database/http-client/)
+     - [10-web-and-database/database-migrations](../../../10-web-and-database/database-migrations/)
+     - [10-web-and-database/web-masterclass](../../../10-web-and-database/web-masterclass/)
+   - core job: provide broader backend reference material while the live beta route is still
+     focused on the databases path first
+
+## What Each Part Adds
+
+### `databases`
+
+This is where the learner stops treating persistence as hidden plumbing and starts reasoning about
+queries, repositories, transactions, and data safety directly.
+
+### `reference surfaces`
+
+These directories widen the backend picture around HTTP and migrations without pretending they are
+already the main public beta learner route.
+
+## Recommended Full-Path Order
+
+1. Finish the databases track from `DB.1` through `DB.6`.
+2. Use the other Section `10` surfaces as reinforcement after the databases milestone path is
+   stable.
+
+## Bridge-Path Reminder
+
+If SQL basics or service-style code already feel somewhat familiar, you can move faster through the
+early repetition.
+What you should not skip is proof:
+
+- `DB.1`
+- `DB.3`
+- `DB.5`
+- `DB.6`
+
+## Exit Condition
+
+You are ready for `5 Concurrency System` when you can finish the live databases milestone path
+honestly and explain how request flow, persistence boundaries, and transaction safety connect in a
+real service-style program.


### PR DESCRIPTION
## Summary
- add Backend Engineering support docs for stage map and milestone guidance
- link the main stage entry doc to those new support surfaces
- keep the change inside the beta shell without rewriting the alpha lesson inventory

## Testing
- git diff --check

Closes #216