### PR TITLE
Regroup the Concurrency System beta stage

### DIFF
--- a/11-concurrency/README.md
+++ b/11-concurrency/README.md
@@ -16,6 +16,18 @@ By the end of the live v2 slice, you should be comfortable:
 Section 11 still contains additional concurrency material beyond this live slice. Those surfaces
 remain available as legacy reference lessons while the first milestone path is migrated.
 
+## Beta Stage Ownership
+
+This section belongs to [5 Concurrency System](../docs/stages/05-concurrency-system.md).
+
+Within the beta public shell, it is the first and foundation-heavy half of that stage:
+
+1. Section 11 `concurrency`
+2. Section 12 `concurrency-patterns`
+
+That means Section 11 is where learners build the core coordination vocabulary before the stage
+moves into higher-pressure patterns in Section 12.
+
 ## Who Should Start Here
 
 ### Full Path
@@ -111,3 +123,8 @@ That keeps Section 11 useful now without pretending the entire mega-section is f
 
 After you finish the track or milestone you care about here, continue to
 [Section 12: Concurrency Patterns](../12-concurrency-patterns).
+
+In the beta shell, that keeps you inside
+[5 Concurrency System](../docs/stages/05-concurrency-system.md)
+before you move on to
+[6 Quality and Performance](../docs/stages/06-quality-and-performance.md).

--- a/12-concurrency-patterns/README.md
+++ b/12-concurrency-patterns/README.md
@@ -13,6 +13,18 @@ By the end of the live v2 slice, you should be comfortable:
 - building bounded concurrent pipelines instead of launching unbounded background work
 - combining concurrency control and operational safety in small real exercises
 
+## Beta Stage Ownership
+
+This section belongs to [5 Concurrency System](../docs/stages/05-concurrency-system.md).
+
+Within the beta public shell, it is the second and pattern-heavy half of that stage:
+
+1. Section 11 `concurrency`
+2. Section 12 `concurrency-patterns`
+
+That means this section should be read as the place where concurrency primitives become
+production-shaped patterns instead of as a completely separate topic.
+
 ## Who Should Start Here
 
 ### Full Path
@@ -77,4 +89,9 @@ main errgroup and pool path into the public curriculum graph:
 
 ## Next Step
 
-After `CP.5`, continue to [Section 13: Quality and Performance](../13-quality-and-performance).
+After `CP.5`, you have completed the current live milestone path for
+[5 Concurrency System](../docs/stages/05-concurrency-system.md).
+
+From there, move to [6 Quality and Performance](../docs/stages/06-quality-and-performance.md).
+The first source section in that next stage is
+[Section 13: Quality and Performance](../13-quality-and-performance).

--- a/docs/stages/05-concurrency-system.md
+++ b/docs/stages/05-concurrency-system.md
@@ -16,6 +16,14 @@ Concurrency is about coordination, cancellation, and limits.
 The goal is not to add goroutines everywhere.
 The goal is to structure concurrent work so it can start, stop, and fail in controlled ways.
 
+## Why This Stage Exists
+
+This stage is where "I can launch goroutines" turns into "I can reason about concurrent systems."
+
+The goal is not to make learners memorize channel tricks.
+The goal is to build real judgment about coordination, cancellation, deadlines, bounded work, and
+failure propagation.
+
 ## What You Should Learn Here
 
 - goroutine fundamentals
@@ -24,6 +32,19 @@ The goal is to structure concurrent work so it can start, stop, and fail in cont
 - worker-pool and fan-out/fan-in style patterns
 - bounded failure handling in concurrent systems
 
+## Stage Shape
+
+This stage currently has one foundation-heavy section plus one higher-order pattern section:
+
+1. Section `11` `concurrency`
+   - the live public foundation layer for goroutines, context, and time-based coordination
+2. Section `12` `concurrency-patterns`
+   - the live public pattern layer for `errgroup`, bounded pipelines, and pressure-aware
+     coordination
+
+That means the stage is intentionally split into "learn the primitives" and "apply the
+production-shaped patterns" instead of pretending those are the same difficulty level.
+
 ## Current Source Content
 
 - [11-concurrency/context](../../11-concurrency/context/)
@@ -31,12 +52,94 @@ The goal is to structure concurrent work so it can start, stop, and fail in cont
 - [11-concurrency/time-and-scheduling](../../11-concurrency/time-and-scheduling/)
 - [12-concurrency-patterns](../../12-concurrency-patterns/)
 
+## Stage Support Docs
+
+Use these support docs when you want the beta-stage view without digging through the full Section
+`11` and Section `12` inventories:
+
+- [Concurrency System support index](./concurrency-system/README.md)
+- [Stage map](./concurrency-system/stage-map.md)
+- [Milestone guidance](./concurrency-system/milestone-guidance.md)
+
+## Where This Stage Starts
+
+Start with [Section 11: Concurrency](../../11-concurrency/).
+
+That is the public entry to this stage because it teaches the coordination vocabulary that Section
+`12` depends on.
+Section `12` stays inside the same stage, but it should come after the foundation tracks.
+
+## Recommended Order
+
+Use this order for the current beta-facing path:
+
+1. complete the Goroutines track from `GC.1` through `GC.7`
+2. complete the Context track from `CT.1` through `CT.5`
+3. complete the Time and Scheduling track from `TM.1` through `TM.7`
+4. move to Section `12` and complete the `CP.1` through `CP.5` path
+5. use the remaining concurrency reference surfaces after the live milestones if you want deeper
+   coverage
+
+## Path Guidance
+
+### Full Path
+
+Work through Section `11` first, then move into Section `12`.
+This stage is designed to build intuition before adding higher-pressure concurrency patterns.
+
+### Bridge Path
+
+You can move faster if goroutines, channels, timeouts, and HTTP cancellation already feel familiar,
+but do not skip:
+
+- `GC.1`
+- `GC.4`
+- `CT.1`
+- `CT.3`
+- `TM.1`
+- `TM.3`
+- `CP.1`
+- `CP.4`
+
+Those are the main proof surfaces that keep the stage grounded in coordination discipline instead
+of concurrency folklore.
+
+### Targeted Path
+
+If you enter this stage with a narrow goal:
+
+- start with the Goroutines track if your gap is basic coordination
+- start with the Context track if your gap is cancellation and timeout control
+- start with the Time track if your gap is timers, deadlines, and scheduling
+- move to Section `12` once you can explain bounded work and cancellation boundaries without hand
+  waving
+
+## Stage Milestones
+
+The current live milestone backbone is:
+
+- `GC.7` concurrent downloader
+- `CT.5` timeout-aware API client
+- `TM.7` console reminder
+- `CP.5` URL health checker
+
+`CP.4` remains an important promoted exercise inside this stage because it is the first place where
+bounded-concurrency pressure becomes explicit.
+
 ## Finish This Stage When
 
 - you can explain when concurrency helps and when it hurts
 - you can wire cancellation and timeouts into real flows
 - you can build bounded worker or pipeline patterns
 - you can spot common goroutine leaks and coordination mistakes
+
+More concretely:
+
+- you can explain why goroutines need ownership and shutdown boundaries
+- you can propagate context cancellation through I/O and sibling work
+- you can use timers and tickers without leaking background behavior
+- you can explain why bounded concurrency is a systems decision, not just a syntax pattern
+- you can complete `CP.5` without treating `errgroup` as magic
 
 ## Next Stage
 

--- a/docs/stages/concurrency-system/README.md
+++ b/docs/stages/concurrency-system/README.md
@@ -1,0 +1,18 @@
+# Concurrency System Support Docs
+
+Use these docs when you want the beta-stage view of concurrency without switching back and forth
+between the Section `11` and Section `12` source inventories.
+
+## In This Folder
+
+- [Stage map](./stage-map.md)
+- [Milestone guidance](./milestone-guidance.md)
+
+## Current Stage Scope
+
+`5 Concurrency System` currently spans:
+
+- [Section 11: Concurrency](../../../11-concurrency/)
+- [Section 12: Concurrency Patterns](../../../12-concurrency-patterns/)
+
+The public beta route starts with Section `11` and then moves into Section `12`.

--- a/docs/stages/concurrency-system/milestone-guidance.md
+++ b/docs/stages/concurrency-system/milestone-guidance.md
@@ -1,0 +1,42 @@
+# Concurrency System Milestone Guidance
+
+## What Counts As Stage Completion
+
+You should be able to finish the current live milestone path and explain the reasoning behind it,
+not just run the final programs.
+
+## Milestones
+
+### `GC.7` concurrent downloader
+
+This is the first proof that you can coordinate multiple goroutines without losing ownership of
+results, synchronization, or shutdown.
+
+### `CT.5` timeout-aware API client
+
+This proves that cancellation is not just a local variable.
+It has to reach real I/O boundaries cleanly.
+
+### `TM.7` console reminder
+
+This proves that timers and tickers are lifecycle tools, not background magic.
+
+### `CP.5` URL health checker
+
+This is the strongest current stage proof.
+It asks you to combine cancellation, bounded concurrency, and failure-aware coordination in one
+small system.
+
+## Bridge Path Check
+
+If you are moving quickly through this stage, make sure you can still explain:
+
+- why `WaitGroup` and channels solve different problems
+- why context cancellation should reach HTTP and database calls
+- why timers need explicit stop/drain behavior in long-running systems
+- why bounded concurrency is safer than unbounded fan-out
+
+## Ready To Move On
+
+Move to [6 Quality and Performance](../06-quality-and-performance.md) when you can complete the
+current path and explain the coordination choices in plain language.

--- a/docs/stages/concurrency-system/stage-map.md
+++ b/docs/stages/concurrency-system/stage-map.md
@@ -1,0 +1,41 @@
+# Concurrency System Stage Map
+
+## Stage Goal
+
+This stage teaches learners how to structure concurrent work so it can start, coordinate, cancel,
+and stop without turning the program into hidden chaos.
+
+## Public Stage Shape
+
+| Part | Source Surface | Role In Stage |
+| --- | --- | --- |
+| Foundations | [Section 11: Concurrency](../../../11-concurrency/) | teaches goroutines, context, timers, and the vocabulary of controlled concurrent work |
+| Patterns | [Section 12: Concurrency Patterns](../../../12-concurrency-patterns/) | teaches `errgroup`, bounded pipelines, and pressure-aware concurrency patterns |
+
+## Live Milestone Backbone
+
+| ID | Surface | Why It Matters |
+| --- | --- | --- |
+| `GC.7` | concurrent downloader | proves goroutine coordination and bounded fan-out |
+| `CT.5` | timeout-aware API client | proves cancellation and deadline propagation through I/O |
+| `TM.7` | console reminder | proves timer/ticker lifecycle management |
+| `CP.5` | URL health checker | proves `errgroup`, sibling cancellation, and bounded concurrent work |
+
+## Recommended Order
+
+1. `GC.1` through `GC.7`
+2. `CT.1` through `CT.5`
+3. `TM.1` through `TM.7`
+4. `CP.1` through `CP.5`
+
+## Reference Surfaces That Still Matter
+
+These are still useful, but they are not the current public beta backbone:
+
+- `GC.8`
+- `GC.9`
+- `GC.10`
+- `TM.4`
+- `TM.5`
+- `TM.6`
+- `6-worker-pool`


### PR DESCRIPTION
## Summary
- strengthen the public Concurrency System stage shell
- align Sections 11 and 12 with shared beta stage ownership
- publish stage support docs for the concurrency stage map and milestone guidance

## Validation
- docs-only change
- git diff --check

Closes #220
Closes #221
Closes #222
Closes #223