### PR TITLE
Regroup the Architecture beta stage

### DIFF
--- a/14-application-architecture/grpc/README.md
+++ b/14-application-architecture/grpc/README.md
@@ -1,80 +1,54 @@
-# Section 26: gRPC
+# Track D: gRPC Architecture Reference
 
-## Beginner → Expert Mapping
+## Mission
 
-| Topic | Level | Importance | Engineering Concept |
-|-------|-------|------------|---------------------|
-| Protocol Buffers | Beginner | **Critical** | Schema-first API definition |
-| Unary RPC | Beginner | **Critical** | Request/response like HTTP |
-| Server streaming | Intermediate | High | Real-time data push |
-| Client streaming | Advanced | High | Batch upload, chunked writes |
-| Bidirectional streaming | Advanced | High | Chat, live collaboration |
-| Interceptors | Advanced | **Critical** | Middleware for gRPC |
+This surface shows how schema-first service boundaries look in Go when transport contracts matter
+as much as handler code.
 
-## Engineering Depth
+It is intentionally treated as an architecture reference surface in beta, not as the main proof
+path for the stage.
 
-gRPC is Go's native RPC framework, built by Google. It uses Protocol Buffers (proto3) as its IDL — a schema language that generates type-safe client and server code in any language. A Go client can seamlessly call a Python server, a Rust server, or a Java server with zero manual serialization code.
+## Beta Stage Ownership
 
-**Why gRPC over REST:**
-- **2-10x faster**: Binary framing (HTTP/2) + protobuf encoding vs text JSON
-- **Streaming**: First-class bidirectional streaming over a single TCP connection
-- **Type safety**: The proto schema IS the contract — no drift between client and server
-- **Code generation**: Client stubs generated automatically, no manual HTTP client
+This track belongs to [7 Architecture](../../docs/stages/07-architecture.md).
 
-**Proto3 → Go generation workflow:**
-```bash
-# Install tools (one-time setup)
-go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-brew install protobuf  # or apt install protobuf-compiler
+Within the beta public shell, it is a reference surface for service contracts, generated boundary
+code, and RPC-style architecture after the package-design path is already clear.
 
-# Generate Go code from .proto
-protoc --go_out=. --go-grpc_out=. proto/service.proto
-```
+## Why This Surface Matters
 
-## Contents
+gRPC is useful here because it forces architecture decisions into explicit contracts:
 
-| Directory | Topic | Level |
-|-----------|-------|-------|
-| `proto/` | Service definition files | Beginner |
-| `gen/` | Generated Go code (committed so you can run without protoc) | — |
-| `1-unary/` | Simple request/response RPC | Beginner |
-| `2-streaming/` | Server-side streaming and interceptors | Intermediate |
+- messages and services are schema-first
+- client and server boundaries are typed
+- transport seams become visible and reviewable
+- code generation supports the contract instead of replacing design thinking
 
-## How to Run
+## Current Surface Shape
 
-```bash
-# Terminal 1: start the server
-go run ./14-application-architecture/grpc/1-unary/server
+| Area | Focus |
+| --- | --- |
+| `proto/` | service and message definitions |
+| `gen/` | generated Go code committed for runnable examples |
+| `1-unary/` | basic request/response RPC |
+| `2-streaming/` | streaming flows and interceptors |
 
-# Terminal 2: run the client
-go run ./14-application-architecture/grpc/1-unary/client
+## How To Use It In Beta
 
-# Terminal 1: start the streaming server
-go run ./14-application-architecture/grpc/2-streaming/server
-
-# Terminal 2: run the streaming client
-go run ./14-application-architecture/grpc/2-streaming/client
-```
-
-## Adding to go.mod
-
-```bash
-go get google.golang.org/grpc
-go get google.golang.org/protobuf
-```
+1. complete the live `package-design` path first
+2. read this surface when you want stronger intuition for service boundaries
+3. treat it as architectural reinforcement, not as a required milestone before continuing
 
 ## References
 
-- [gRPC Go Quick Start](https://grpc.io/docs/languages/go/quickstart/)
-- [Protocol Buffers Language Guide](https://protobuf.dev/programming-guides/proto3/)
-- [google.golang.org/grpc](https://pkg.go.dev/google.golang.org/grpc)
+1. [gRPC Go Quick Start](https://grpc.io/docs/languages/go/quickstart/)
+2. [Protocol Buffers Language Guide](https://protobuf.dev/programming-guides/proto3/)
+3. [google.golang.org/grpc](https://pkg.go.dev/google.golang.org/grpc)
 
+## Next Step
 
-## Learning Path
-
-| ID | Lesson | Concept | Requires |
-| --- | --- | --- | --- |
-| GR.1 | [proto definition + gen](./proto) | proto3 service/message · protoc · generated Go stubs | 🟢 entry |
-| GR.2 | [unary server](./server) | Implement generated interface · status codes · interceptors · metadata | GR.1 |
-| GR.3 | [unary client](./client) | grpc.NewClient · typed stub · context deadline · status.FromError | GR.1, GR.2 |
+After you use this surface, return to the
+[Architecture stage](../../docs/stages/07-architecture.md)
+or continue into
+[8 Production Engineering](../../docs/stages/08-production-engineering.md)
+if your current gap is operating systems safely.

--- a/14-application-architecture/package-design/README.md
+++ b/14-application-architecture/package-design/README.md
@@ -5,6 +5,14 @@
 This track teaches you how to organize a Go codebase so package boundaries reinforce the design
 instead of hiding problems behind generic folders and global helpers.
 
+## Beta Stage Ownership
+
+This track belongs to [7 Architecture](../../docs/stages/07-architecture.md).
+
+Within the beta public shell, it is the current live learner path for that stage.
+The other architecture-owned Section `14` surfaces remain valuable, but this track is where the
+beta proof path starts.
+
 ## Track Map
 
 | ID | Type | Surface | Why It Matters | Requires |
@@ -35,3 +43,6 @@ then the package-design part of Section 14 is doing its job.
 
 After `PD.3`, continue to the [Structured Logging track](../structured-logging) or back to the
 [Section 14 overview](../README.md).
+
+In the beta shell, the next public stage after Architecture is
+[8 Production Engineering](../../docs/stages/08-production-engineering.md).

--- a/docs/stages/07-architecture.md
+++ b/docs/stages/07-architecture.md
@@ -15,6 +15,14 @@ Architecture is not diagram theater.
 It is the discipline of choosing boundaries that keep code understandable, testable, and able to
 change safely.
 
+## Why This Stage Exists
+
+This stage exists to move learners from "I can build features" to "I can shape systems
+deliberately."
+
+The goal is to teach boundary judgment: package seams, service contracts, and structure inside a
+larger codebase.
+
 ## What You Should Learn Here
 
 - package boundary design
@@ -22,11 +30,91 @@ change safely.
 - architectural trade-offs in real systems
 - boundary choices inside a capstone-sized codebase
 
+## Stage Shape
+
+This stage currently has one live public path plus two important architecture-owned reference
+surfaces:
+
+1. `package-design`
+   - the current live beta path for package naming, visibility, and project layout
+2. `grpc`
+   - an architecture reference surface for schema-first service boundaries and RPC-style contracts
+3. architectural slices of `enterprise-capstone`
+   - a larger-system seed that shows how package and service boundaries hold together under more
+     pressure
+
+That means the stage is honest about where learners should complete proof work now while still
+surfacing the broader architecture material already in the repo.
+
 ## Current Source Content
 
 - [14-application-architecture/package-design](../../14-application-architecture/package-design/)
 - [14-application-architecture/grpc](../../14-application-architecture/grpc/)
 - architectural slices of [14-application-architecture/enterprise-capstone](../../14-application-architecture/enterprise-capstone/)
+
+## Stage Support Docs
+
+Use these support docs when you want the beta-stage view without digging through all of Section
+`14`:
+
+- [Architecture support index](./architecture/README.md)
+- [Stage map](./architecture/stage-map.md)
+- [Milestone guidance](./architecture/milestone-guidance.md)
+
+## Where This Stage Starts
+
+Start with [14-application-architecture/package-design](../../14-application-architecture/package-design/).
+
+That is the current live beta entry because package boundaries are the foundation for everything
+else in this stage.
+The `grpc` and capstone architecture surfaces become more useful once that boundary vocabulary is
+already clear.
+
+## Recommended Order
+
+Use this order for the current beta-facing path:
+
+1. complete the package-design track from `PD.1` through `PD.3`
+2. use `grpc` as the next architecture reference surface for service contracts and RPC boundaries
+3. use the architectural slices of `enterprise-capstone` once you want a larger system to read and
+   reason about
+
+## Path Guidance
+
+### Full Path
+
+Complete the package-design track first, then move into the reference surfaces.
+This keeps the stage grounded in boundary discipline instead of jumping straight into framework or
+capstone complexity.
+
+### Bridge Path
+
+You can move faster if package design, interfaces, and service boundaries already feel somewhat
+familiar, but do not skip:
+
+- `PD.1`
+- `PD.2`
+- `PD.3`
+
+Those are the main proof surfaces that show you can reason about architectural boundaries, not just
+consume architecture vocabulary.
+
+### Targeted Path
+
+If you enter this stage with a narrow goal:
+
+- start with `package-design` if your gap is package boundaries and structure
+- use `grpc` if your gap is service contracts and RPC architecture
+- use `enterprise-capstone` architecture slices if your gap is reading larger systems
+
+## Stage Milestones
+
+The current live milestone backbone is:
+
+- `PD.3` project layout
+
+The `grpc` and `enterprise-capstone` surfaces are important architecture seeds, but they are not
+yet promoted as the main public beta proof path.
 
 ## Finish This Stage When
 
@@ -34,6 +122,15 @@ change safely.
 - you can spot weak package boundaries and suggest better ones
 - you can discuss service seams and ownership with evidence
 - you can read a larger codebase without losing the architectural thread
+
+More concretely:
+
+- you can explain why package boundaries should reflect domain responsibilities instead of folder
+  fashion
+- you can discuss service contracts and interface seams without hand waving
+- you understand which Section `14` surfaces belong to Architecture versus Production Engineering
+  versus Flagship Project
+- you can complete `PD.3` and use the reference surfaces to extend your architectural judgment
 
 ## Next Stage
 

--- a/docs/stages/architecture/README.md
+++ b/docs/stages/architecture/README.md
@@ -1,0 +1,17 @@
+# Architecture Support Docs
+
+Use these docs when you want the beta-stage view of the architecture regroup without reading every
+Section `14` surface directly.
+
+## In This Folder
+
+- [Stage map](./stage-map.md)
+- [Milestone guidance](./milestone-guidance.md)
+
+## Current Stage Scope
+
+`7 Architecture` currently draws from:
+
+- [14-application-architecture/package-design](../../../14-application-architecture/package-design/)
+- [14-application-architecture/grpc](../../../14-application-architecture/grpc/)
+- architectural slices of [14-application-architecture/enterprise-capstone](../../../14-application-architecture/enterprise-capstone/)

--- a/docs/stages/architecture/milestone-guidance.md
+++ b/docs/stages/architecture/milestone-guidance.md
@@ -1,0 +1,27 @@
+# Architecture Milestone Guidance
+
+## What Counts As Stage Completion
+
+You should be able to explain why a system is split the way it is, not just say that the folders
+look organized.
+
+## Milestone
+
+### `PD.3` project layout
+
+This proves that you can move from naming and visibility rules into a layout that matches the real
+shape of a growing Go system.
+
+## Bridge Path Check
+
+If you are moving quickly through this stage, make sure you can still explain:
+
+- why package names should represent a domain or responsibility
+- why `internal/` is a real boundary and not a decorative folder
+- why a project layout should grow with the system instead of being over-designed on day one
+- why service contracts and code generation still need architectural judgment
+
+## Ready To Move On
+
+Move to [8 Production Engineering](../08-production-engineering.md) when package boundaries and
+service seams feel understandable instead of magical.

--- a/docs/stages/architecture/stage-map.md
+++ b/docs/stages/architecture/stage-map.md
@@ -1,0 +1,32 @@
+# Architecture Stage Map
+
+## Stage Goal
+
+This stage teaches learners how to choose and defend boundaries inside real Go systems.
+
+## Public Stage Shape
+
+| Surface | Role In Stage |
+| --- | --- |
+| [package-design](../../../14-application-architecture/package-design/) | live beta path for package naming, visibility, and project layout |
+| [grpc](../../../14-application-architecture/grpc/) | architecture reference surface for schema-first service boundaries |
+| [enterprise-capstone](../../../14-application-architecture/enterprise-capstone/) | larger-system architecture seed for reading package and service seams |
+
+## Live Milestone Backbone
+
+| ID | Surface | Why It Matters |
+| --- | --- | --- |
+| `PD.3` | project layout | proves learners can choose a package layout that reflects system shape |
+
+## Recommended Order
+
+1. `PD.1` through `PD.3`
+2. `grpc`
+3. architecture-oriented capstone reading
+
+## Reference Surfaces That Still Matter
+
+These are important architecture surfaces, but they are not the current public beta proof path:
+
+- `grpc`
+- architectural slices of `enterprise-capstone`


### PR DESCRIPTION
## Summary
- strengthen the public Architecture stage shell
- align architecture-owned Section 14 track docs with beta stage ownership
- publish stage support docs for the architecture stage map and milestone guidance

## Validation
- docs-only change
- git diff --check

Closes #229
Closes #230
Closes #231
Closes #232