### PR TITLE
Regroup the Production Engineering beta stage

### DIFF
--- a/14-application-architecture/docker-and-deployment/README.md
+++ b/14-application-architecture/docker-and-deployment/README.md
@@ -1,106 +1,53 @@
-# Docker & Deployment (§14 · Docker)
+# Track E: Docker and Deployment Reference
 
-## Overview
+## Mission
 
-This section teaches containerization with Docker through practical examples. You'll learn to write efficient Dockerfiles, leverage multi-stage builds for minimal images, and optimize layer caching for faster rebuilds.
+This surface shows how Go applications move from local execution into containerized deployment
+workflows.
 
-## Why Docker for Go?
+It is intentionally treated as a production-engineering reference surface in beta, not as the main
+proof path for the stage.
 
-Go has an **unfair advantage** in the container world:
+## Beta Stage Ownership
 
-- **Statically linked binaries**: No runtime dependencies
-- **Single binary output**: Unlike Python/Node which need large runtimes
-- **Fast startup**: Milliseconds instead of seconds
-- **Minimal Docker images**: 5-20MB instead of 500MB+
+This track belongs to [8 Production Engineering](../../docs/stages/08-production-engineering.md).
 
-## Learning Path
+Within the beta public shell, it is a reference surface for packaging, image design, and
+deployment-oriented workflow after the logging and shutdown tracks are already clear.
 
-### Lesson 1: Single-Stage Dockerfile (DO.1)
-**Concepts**: Basic dockerfile structure, FROM, WORKDIR, COPY, RUN, ENTRYPOINT
+## Why This Surface Matters
 
-Learn the fundamentals:
-```dockerfile
-FROM alpine:3.19
-WORKDIR /app
-COPY . .
-RUN go build -o main main.go
-ENTRYPOINT ["./main"]
-```
+Deployment changes the shape of a system:
 
-### Lesson 2: Multi-Stage Builds (DO.2)
-**Concepts**: Build stage, runtime stage, COPY --from, minimal final image
+- packaging decisions affect startup, security, and rebuild speed
+- container structure changes how applications are configured and run
+- rollout workflow exposes whether shutdown and observability decisions were actually sound
 
-The Go superpower - separate compile from runtime:
-```dockerfile
-# Build stage (heavy, compile only)
-FROM golang:1.26-alpine AS builder
-WORKDIR /build
-COPY . .
-RUN go build -o app main.go
+## Current Surface Shape
 
-# Runtime stage (minimal, run only)
-FROM alpine:3.19
-COPY --from=builder /build/app .
-ENTRYPOINT ["./app"]
-```
+| Area | Focus |
+| --- | --- |
+| `1-dockerfile/` | basic Dockerfile structure |
+| `2-multi-stage/` | builder/runtime separation for Go binaries |
+| `3-layer-caching/` | cache-aware image construction and rebuild speed |
 
-**Impact**: Reduces final image from 350MB → 15MB!
+## How To Use It In Beta
 
-### Lesson 3: Layer Caching & Optimization (DO.3)
-**Concepts**: Docker layer caching, go.mod caching, .dockerignore, build optimization
+1. complete the live structured-logging and graceful-shutdown paths first
+2. read this surface when you want stronger packaging and deployment intuition
+3. treat it as production reinforcement, not as a required public milestone before continuing
 
-Cache your dependencies separately:
-```dockerfile
-# Cache dependencies first (rarely change)
-COPY go.mod go.sum ./
-RUN go mod download
+## Best-Practice Themes
 
-# Then copy source (changes frequently)
-COPY . .
+- use multi-stage builds when shipping Go services
+- separate stable dependency layers from fast-changing source layers
+- keep images small, understandable, and intentional
+- connect container packaging decisions back to runtime operations
 
-# Build
-RUN go build -o app main.go
-```
+## Next Step
 
-**Key Insight**: Order matters! Put stable layers earlier to leverage build cache.
-
----
-
-## Directory Structure
-
-```
-docker-and-deployment/
-├── README.md                  (This file)
-├── 1-dockerfile/              (Basic Dockerfile example)
-├── 2-multi-stage/             (Optimized multi-stage build)
-└── 3-layer-caching/           (Caching best practices)
-```
-
----
-
-## Best Practices Summary
-
-✅ **Always use multi-stage builds for Go**
-✅ **Leverage layer caching** - dependencies before source
-✅ **Use Alpine Linux** - minimal, secure, fast
-✅ **Create .dockerignore** - exclude `.git`, test files, etc.
-✅ **COPY before RUN** - cache dependencies separately
-✅ **Tag images with versions** - avoid relying on `latest`
-✅ **Run as non-root user** - security best practice
-✅ **Keep base images updated** - security patches
-
----
-
-## Real-World Application
-
-This Docker setup is used in the **Enterprise Capstone Project** where:
-- Build stage compiles the Go binary
-- Runtime stage serves the REST API
-- Docker Compose orchestrates PostgreSQL + Go app
-- Migrations run automatically on startup
-
-See [Enterprise Capstone](../enterprise-capstone) for the full application.
-
-## Next Steps
-
-🚀 **After this section**: [Enterprise Capstone](../enterprise-capstone) — Build a complete REST API application with Docker Compose and PostgreSQL deployment
+After you use this surface, return to the
+[Production Engineering stage](../../docs/stages/08-production-engineering.md)
+or continue into
+[10 Flagship Project](../../docs/stages/10-flagship-project.md)
+if you want to apply deployment thinking inside a larger system.

--- a/14-application-architecture/graceful-shutdown/README.md
+++ b/14-application-architecture/graceful-shutdown/README.md
@@ -5,6 +5,13 @@
 This track teaches you how to keep services correct during deploys, restarts, and termination
 signals instead of treating shutdown as an afterthought.
 
+## Beta Stage Ownership
+
+This track belongs to [8 Production Engineering](../../docs/stages/08-production-engineering.md).
+
+Within the beta public shell, it is the second live learner path for that stage.
+It turns runtime thinking into explicit shutdown and drain behavior.
+
 ## Track Map
 
 | ID | Type | Surface | Why It Matters | Requires |
@@ -35,3 +42,11 @@ then the graceful-shutdown part of Section 14 is doing its job.
 
 After `GS.3`, continue back to the [Section 14 overview](../README.md) or move to
 [Section 15: Code Generation](../../15-code-generation).
+
+In the beta shell, you can also move from
+[8 Production Engineering](../../docs/stages/08-production-engineering.md)
+into either
+[9 Expert Layer](../../docs/stages/09-expert-layer.md)
+or
+[10 Flagship Project](../../docs/stages/10-flagship-project.md),
+depending on whether you want more pressure or a longer integrated build path next.

--- a/14-application-architecture/structured-logging/README.md
+++ b/14-application-architecture/structured-logging/README.md
@@ -5,6 +5,14 @@
 This track teaches you how to turn logs into queryable operational data instead of leaving them as
 strings that only make sense after a production incident has already happened.
 
+## Beta Stage Ownership
+
+This track belongs to [8 Production Engineering](../../docs/stages/08-production-engineering.md).
+
+Within the beta public shell, it is the first live learner path for that stage.
+It is where learners build runtime visibility habits before moving into shutdown and deployment
+behavior.
+
 ## Track Map
 
 | ID | Type | Surface | Why It Matters | Requires |
@@ -36,3 +44,6 @@ then the structured-logging part of Section 14 is doing its job.
 
 After `SL.5`, continue to the [Graceful Shutdown track](../graceful-shutdown) or back to the
 [Section 14 overview](../README.md).
+
+In the beta shell, this keeps you inside
+[8 Production Engineering](../../docs/stages/08-production-engineering.md).

--- a/docs/stages/08-production-engineering.md
+++ b/docs/stages/08-production-engineering.md
@@ -15,6 +15,14 @@ Software is not finished when it runs once on your machine.
 This stage teaches what changes when software must be observed, configured, shut down safely, and
 deployed with less guesswork.
 
+## Why This Stage Exists
+
+This stage exists because "it works on my machine" is not the same thing as "this system can be
+operated safely."
+
+The goal is to help learners think about logs, shutdown behavior, packaging, and deployment as part
+of correctness instead of late operational cleanup.
+
 ## What You Should Learn Here
 
 - structured logging
@@ -23,17 +31,90 @@ deployed with less guesswork.
 - configuration boundaries
 - early observability and runtime support thinking
 
+## Stage Shape
+
+This stage currently has two live public paths plus one deployment-oriented reference surface:
+
+1. `structured-logging`
+   - the live beta path for log shape, request context, handlers, and redaction
+2. `graceful-shutdown`
+   - the live beta path for service lifecycle handling and drain order
+3. `docker-and-deployment`
+   - a production reference surface for packaging and deployment workflow
+
+That means the stage is honest about where proof work happens now while still exposing deployment
+material that matters for later flagship and production growth.
+
 ## Current Source Content
 
 - [14-application-architecture/structured-logging](../../14-application-architecture/structured-logging/)
 - [14-application-architecture/graceful-shutdown](../../14-application-architecture/graceful-shutdown/)
 - [14-application-architecture/docker-and-deployment](../../14-application-architecture/docker-and-deployment/)
 
-Beta additions planned:
+## Stage Support Docs
 
-- config surfaces
-- tracing and monitoring entry docs
-- operating checklists that connect to the flagship project
+Use these support docs when you want the beta-stage view without digging through all of Section
+`14`:
+
+- [Production Engineering support index](./production-engineering/README.md)
+- [Stage map](./production-engineering/stage-map.md)
+- [Milestone guidance](./production-engineering/milestone-guidance.md)
+
+## Where This Stage Starts
+
+Start with [14-application-architecture/structured-logging](../../14-application-architecture/structured-logging/).
+
+That is the most accessible public entry because it teaches learners how to think about runtime
+signals from a running system before they move into shutdown and deployment flow.
+
+## Recommended Order
+
+Use this order for the current beta-facing path:
+
+1. complete the structured-logging track from `SL.1` through `SL.5`
+2. complete the graceful-shutdown track from `GS.1` through `GS.3`
+3. use `docker-and-deployment` as the next production reference surface for packaging and runtime
+   rollout thinking
+
+## Path Guidance
+
+### Full Path
+
+Complete structured logging first, then graceful shutdown, then deployment reading.
+This keeps the stage ordered around runtime visibility, safe stop behavior, and finally deployment
+packaging.
+
+### Bridge Path
+
+You can move faster if observability and service lifecycle concepts already feel familiar, but do
+not skip:
+
+- `SL.1`
+- `SL.2`
+- `SL.5`
+- `GS.1`
+- `GS.3`
+
+Those are the main proof surfaces that show you can reason about operated systems instead of only
+running programs locally.
+
+### Targeted Path
+
+If you enter this stage with a narrow goal:
+
+- start with `structured-logging` if your gap is runtime visibility
+- start with `graceful-shutdown` if your gap is lifecycle safety during deploys
+- use `docker-and-deployment` when your gap is packaging and container workflow
+
+## Stage Milestones
+
+The current live milestone backbone is:
+
+- `SL.5` PII redactor exercise
+- `GS.3` shutdown capstone
+
+`docker-and-deployment` is an important production surface, but it is currently a reference layer
+instead of the main public beta proof path.
 
 ## Finish This Stage When
 
@@ -41,6 +122,13 @@ Beta additions planned:
 - you know how to stop services safely
 - you can package and run a deployment-oriented application flow
 - you can reason about runtime behavior, not just implementation details
+
+More concretely:
+
+- you can explain why structured logs are operational data instead of prettier strings
+- you can coordinate readiness, request drain, worker drain, and shutdown order
+- you understand why deployment packaging changes the operational shape of a program
+- you know which production surfaces are the current beta path and which remain reference material
 
 ## Next Stage
 

--- a/docs/stages/production-engineering/README.md
+++ b/docs/stages/production-engineering/README.md
@@ -1,0 +1,17 @@
+# Production Engineering Support Docs
+
+Use these docs when you want the beta-stage view of the production regroup without reading every
+Section `14` surface directly.
+
+## In This Folder
+
+- [Stage map](./stage-map.md)
+- [Milestone guidance](./milestone-guidance.md)
+
+## Current Stage Scope
+
+`8 Production Engineering` currently draws from:
+
+- [14-application-architecture/structured-logging](../../../14-application-architecture/structured-logging/)
+- [14-application-architecture/graceful-shutdown](../../../14-application-architecture/graceful-shutdown/)
+- [14-application-architecture/docker-and-deployment](../../../14-application-architecture/docker-and-deployment/)

--- a/docs/stages/production-engineering/milestone-guidance.md
+++ b/docs/stages/production-engineering/milestone-guidance.md
@@ -1,0 +1,31 @@
+# Production Engineering Milestone Guidance
+
+## What Counts As Stage Completion
+
+You should be able to explain how a service is observed, how it stops safely, and how packaging
+choices affect runtime behavior.
+
+## Milestones
+
+### `SL.5` PII redactor exercise
+
+This proves that learners understand logging as policy-enforced operational data, not as a stream
+of ad hoc debug strings.
+
+### `GS.3` shutdown capstone
+
+This proves that lifecycle behavior can be designed deliberately instead of being left to process
+termination luck.
+
+## Bridge Path Check
+
+If you are moving quickly through this stage, make sure you can still explain:
+
+- why handler-based logging and context propagation matter operationally
+- why shutdown order affects correctness during deploys
+- why deployment packaging changes operational behavior instead of merely changing delivery format
+
+## Ready To Move On
+
+Move to [9 Expert Layer](../09-expert-layer.md) or [10 Flagship Project](../10-flagship-project.md)
+once the current stage path feels operationally understandable instead of mysterious.

--- a/docs/stages/production-engineering/stage-map.md
+++ b/docs/stages/production-engineering/stage-map.md
@@ -1,0 +1,33 @@
+# Production Engineering Stage Map
+
+## Stage Goal
+
+This stage teaches learners how to think about runtime visibility, shutdown safety, and deployment
+workflow as part of engineering correctness.
+
+## Public Stage Shape
+
+| Surface | Role In Stage |
+| --- | --- |
+| [structured-logging](../../../14-application-architecture/structured-logging/) | live beta path for operational log shape and redaction |
+| [graceful-shutdown](../../../14-application-architecture/graceful-shutdown/) | live beta path for drain order and lifecycle safety |
+| [docker-and-deployment](../../../14-application-architecture/docker-and-deployment/) | reference surface for packaging and deployment workflow |
+
+## Live Milestone Backbone
+
+| ID | Surface | Why It Matters |
+| --- | --- | --- |
+| `SL.5` | PII redactor exercise | proves that log pipelines can enforce operational policy |
+| `GS.3` | shutdown capstone | proves that service stop behavior can be coordinated deliberately |
+
+## Recommended Order
+
+1. `SL.1` through `SL.5`
+2. `GS.1` through `GS.3`
+3. `docker-and-deployment`
+
+## Reference Surfaces That Still Matter
+
+These are important production surfaces, but they are not the current public beta proof path:
+
+- `docker-and-deployment`


### PR DESCRIPTION
## Summary
- strengthen the public Production Engineering stage shell
- align production-owned Section 14 track docs with beta stage ownership
- publish stage support docs for the production engineering stage map and milestone guidance

## Validation
- docs-only change
- git diff --check

Closes #233
Closes #234
Closes #235
Closes #236