### PR TITLE
Regroup the Expert Layer beta stage

### DIFF
--- a/docs/stages/09-expert-layer.md
+++ b/docs/stages/09-expert-layer.md
@@ -15,6 +15,14 @@ This stage is about judgment under pressure.
 The work shifts from "can I implement this?" to "can I critique, diagnose, and improve this under
 constraints?"
 
+## Why This Stage Exists
+
+This stage exists because strong engineers are not defined only by the code they can write from a
+blank file.
+
+They are also defined by the quality of their judgment when reviewing, debugging, redesigning, and
+making trade-offs under pressure.
+
 ## What You Should Learn Here
 
 - code review and critique
@@ -23,15 +31,81 @@ constraints?"
 - redesign under constraints
 - trade-off reasoning across correctness, simplicity, speed, and operability
 
+## Stage Shape
+
+This stage is intentionally built from beta shells and source seeds rather than from one dedicated
+alpha section.
+
+The current public shape is:
+
+1. review and diagnosis tasks derived from later-stage milestone surfaces
+2. anti-pattern and redesign tasks derived from backend, concurrency, and production work
+3. rubric-heavy pressure work that prepares learners for the flagship project
+
+That means this stage is about engineering pressure and judgment, not about introducing another
+large topic inventory.
+
 ## Current Source Content
 
 This stage does not yet have a dedicated public source folder on `main`.
 
-Expected beta seeds:
+## Stage Support Docs
 
-- review and diagnosis tasks derived from later-stage lessons
-- anti-pattern and debugging slices derived from real projects
-- rubric-heavy work connected to the flagship project
+Use these support docs when you want the beta-stage view of Expert Layer:
+
+- [Expert Layer support index](./expert-layer/README.md)
+- [Source seeds and ownership](./expert-layer/source-seeds.md)
+- [Stage map](./expert-layer/stage-map.md)
+- [Pressure guidance](./expert-layer/pressure-guidance.md)
+
+## Where This Stage Starts
+
+This stage starts after the learner can already build, test, structure, and operate meaningful Go
+systems.
+
+In practice, the first entry surfaces should be diagnosis and review tasks derived from the later
+beta milestones, not new syntax lessons.
+
+## Recommended Order
+
+Use this order for the current beta-facing shell:
+
+1. start with review and diagnosis tasks derived from completed milestone work
+2. move into redesign and anti-pattern tasks that force trade-off explanation
+3. use rubric-heavy pressure work as the handoff into the flagship project
+
+## Path Guidance
+
+### Full Path
+
+Enter this stage only after the earlier build/test/operate stages feel solid.
+The goal here is not new breadth.
+It is stronger judgment.
+
+### Bridge Path
+
+If you already work professionally, you may move into this stage earlier, but only if you can
+already explain:
+
+- why a design is weak, not just that it feels odd
+- how to diagnose a failure with evidence
+- how to defend a trade-off between correctness, simplicity, performance, and operability
+
+### Targeted Path
+
+If you enter this stage with a narrow goal:
+
+- choose review tasks if your gap is critique quality
+- choose diagnosis tasks if your gap is debugging and failure analysis
+- choose redesign tasks if your gap is trade-off reasoning
+
+## Current Public Output Shape
+
+This stage currently publishes guidance and source seeds instead of one fixed milestone backbone.
+
+That is intentional.
+The public beta goal is to define the pressure model clearly before it gets expanded into a larger
+task bank.
 
 ## Finish This Stage When
 
@@ -39,6 +113,13 @@ Expected beta seeds:
 - you can diagnose failures with evidence instead of guesswork
 - you can defend trade-offs and redesign choices clearly
 - you can review unfamiliar code and still identify the real risks
+
+More concretely:
+
+- you can review a real code surface and identify the most meaningful risks first
+- you can explain how you would redesign a weak surface under explicit constraints
+- you can connect review comments back to correctness, operability, and maintainability
+- you are ready to carry that judgment into a longer flagship build path
 
 ## Next Stage
 

--- a/docs/stages/expert-layer/README.md
+++ b/docs/stages/expert-layer/README.md
@@ -1,0 +1,15 @@
+# Expert Layer Support Docs
+
+Use these docs when you want the beta-stage view of Expert Layer without searching across the whole
+repo for judgment-heavy source seeds.
+
+## In This Folder
+
+- [Source seeds and ownership](./source-seeds.md)
+- [Stage map](./stage-map.md)
+- [Pressure guidance](./pressure-guidance.md)
+
+## Current Stage Scope
+
+`9 Expert Layer` currently draws from cross-stage source seeds rather than one dedicated section on
+`main`.

--- a/docs/stages/expert-layer/pressure-guidance.md
+++ b/docs/stages/expert-layer/pressure-guidance.md
@@ -1,0 +1,23 @@
+# Expert Layer Pressure Guidance
+
+## What Pressure Means Here
+
+Pressure in this stage does not mean artificial difficulty for its own sake.
+It means tasks that force the learner to justify judgment:
+
+- what is the most important risk?
+- what evidence supports that claim?
+- what trade-off are you choosing?
+- what would you change first, and why?
+
+## Good Task Shapes
+
+- review a real surface and rank the top risks
+- diagnose a failure and explain the evidence trail
+- redesign a weak boundary under explicit constraints
+- justify why one improvement should happen before another
+
+## Ready To Move On
+
+Move to [10 Flagship Project](../10-flagship-project.md) when review, diagnosis, and redesign work
+feel grounded in evidence instead of instinct alone.

--- a/docs/stages/expert-layer/source-seeds.md
+++ b/docs/stages/expert-layer/source-seeds.md
@@ -1,0 +1,36 @@
+# Expert Layer Source Seeds and Ownership
+
+## Stage Ownership
+
+Expert Layer is a beta shell that reuses source seeds from later-stage work.
+It does not claim ownership of an entire alpha section.
+
+## Current Seed Categories
+
+### Review and critique seeds
+
+- late milestone surfaces from backend, concurrency, quality, and production stages
+- README and API surfaces that can be reviewed for clarity and engineering honesty
+
+### Diagnosis and debugging seeds
+
+- concurrency failure scenarios
+- performance and profiling investigation tasks
+- production-behavior analysis tasks
+
+### Redesign and trade-off seeds
+
+- package-boundary redesign work
+- service-boundary redesign work
+- trade-off analysis across simplicity, correctness, performance, and operability
+
+### Flagship handoff seeds
+
+- flagship checkpoint reviews
+- rubric-heavy implementation critique
+- staged redesign tasks connected to the long-running project spine
+
+## What This Means In Beta
+
+This stage is intentionally assembled from existing stage outputs and later-stage project work
+instead of from a standalone topic inventory.

--- a/docs/stages/expert-layer/stage-map.md
+++ b/docs/stages/expert-layer/stage-map.md
@@ -1,0 +1,25 @@
+# Expert Layer Stage Map
+
+## Stage Goal
+
+This stage teaches learners how to critique, diagnose, and redesign engineering work under real
+constraints.
+
+## Public Stage Shape
+
+| Surface Type | Role In Stage |
+| --- | --- |
+| Review tasks | practice identifying the most important engineering risks first |
+| Diagnosis tasks | practice failure analysis with evidence |
+| Redesign tasks | practice trade-off reasoning under constraints |
+| Flagship-linked pressure tasks | prepare learners for the longer integrated project path |
+
+## Entry Requirement
+
+This stage is for learners who already have meaningful milestone experience from the earlier beta
+stages.
+
+## Handoff
+
+The natural handoff from this stage is [10 Flagship Project](../10-flagship-project.md), where the
+same judgment skills need to hold up over a larger system.


### PR DESCRIPTION
## Summary
- strengthen the public Expert Layer stage shell
- define source seeds and ownership for expert-layer pressure work
- publish stage support docs for the expert layer map and pressure guidance

## Validation
- docs-only change
- git diff --check

Closes #237
Closes #238
Closes #239
Closes #240