### PR TITLE
Regroup the Flagship Project beta stage

### DIFF
--- a/14-application-architecture/enterprise-capstone/README.md
+++ b/14-application-architecture/enterprise-capstone/README.md
@@ -1,52 +1,63 @@
-# Section 22: Enterprise Capstone Project
+# Flagship Seed: Enterprise Capstone
 
-Welcome to the absolute pinnacle of **The Go Engineer**.
+## Mission
 
-If you've made it this far, you are ready to construct a production-grade Backend service. We have stripped away the magic, and now we are putting the pieces together properly.
+This surface is the current flagship project seed for the beta curriculum.
 
-This is a multi-package, Dockerized REST API connected to a PostgreSQL database with automated startup schema migrations.
+It is a multi-package Go service that brings together backend flow, persistence, architecture,
+runtime behavior, and deployment-oriented thinking inside one longer-running system.
 
-## System Architecture
+## Beta Stage Ownership
 
-We are strictly following the Standard Go Package Layout:
+This project belongs to [10 Flagship Project](../../docs/stages/10-flagship-project.md).
 
-- **`cmd/api/main.go`**: The entry point. Handles DB connections, migrations, and shutting down securely.
-- **`internal/models/`**: Domain structs (e.g., `User`, `Post`).
-- **`internal/repository/`**: Abstractions over SQL queries.
-- **`internal/middleware/`**: HTTP request wrappers (Logging, Secure Headers, Panic Recovery).
-- **`internal/handlers/`**: The HTTP logic itself.
+Within the beta public shell, it is the main source surface for the flagship stage.
 
-## How to run the entire backend stack
+## Why This Project Matters
 
-Ensure you have Docker Desktop installed.
+This project exists so the curriculum has one integrated system where earlier stage skills meet:
 
-1. Open your terminal in this directory (`22-enterprise-capstone`)
-2. Run the command:
+- backend request and data flow
+- repository-style persistence boundaries
+- package and handler structure
+- runtime and deployment-oriented behavior
+- longer feedback loops than a single exercise can provide
 
-   ```bash
-   docker-compose up -d --build
-   ```
+## Current Project Shape
 
-3. Watch as a PostgreSQL database spins up instantly, the Go application compiles via a Multi-Stage Dockerfile, runs its embedded `.sql` migrations automatically, and attaches to port `:8080`.
+| Area | Role |
+| --- | --- |
+| `Dockerfile` | packages the application for containerized execution |
+| `docker-compose.yml` | runs the application with supporting services |
+| `internal/` | holds the service internals and application boundaries |
 
-## Testing the API
+## How To Use It In Beta
+
+1. run the project and explain what each major part is responsible for
+2. treat it as a staged flagship path, not as one giant final assignment
+3. use checkpoint thinking before making large changes
+
+## Run The Project
+
+Make sure Docker is available, then run from this directory:
 
 ```bash
-# Register a user
+docker-compose up -d --build
+```
+
+That starts the current flagship seed and its supporting services.
+
+## Example API Flow
+
+```bash
 curl -X POST -H "Content-Type: application/json" -d '{"email":"test@go.dev", "password":"password123"}' http://localhost:8080/register
-
-# Login
 curl -X POST -H "Content-Type: application/json" -d '{"email":"test@go.dev", "password":"password123"}' http://localhost:8080/login
-
-# Create a Post
 curl -X POST -H "Authorization: Bearer <ID_FROM_LOGIN>" -H "Content-Type: application/json" -d '{"title":"Capstone", "content":"Docker is amazing"}' http://localhost:8080/posts
-
-# View Posts
 curl http://localhost:8080/posts
 ```
 
+## Next Step
 
-## Learning Path
-
-| ID | Lesson | Concept | Requires |
-| --- | --- | --- | --- |
+After you understand this seed, return to the
+[Flagship Project stage](../../docs/stages/10-flagship-project.md)
+and use the checkpoint guidance there to decide what kind of work should come next.

--- a/docs/stages/10-flagship-project.md
+++ b/docs/stages/10-flagship-project.md
@@ -15,6 +15,14 @@ A flagship project is not a random extra app.
 It is the place where backend, concurrency, quality, architecture, operations, and judgment start
 to interact inside one evolving system.
 
+## Why This Stage Exists
+
+This stage exists so the curriculum has one long-running proof surface instead of only isolated
+milestones.
+
+The goal is to give learners a system they can extend, review, debug, and improve across multiple
+engineering dimensions without losing the thread.
+
 ## What You Should Learn Here
 
 - staged feature growth instead of one giant final dump
@@ -22,16 +30,78 @@ to interact inside one evolving system.
 - checkpoint-driven improvement
 - cross-stage integration from backend through production
 
+## Stage Shape
+
+This stage currently has one primary flagship seed plus one supporting pattern source:
+
+1. `enterprise-capstone`
+   - the main flagship project seed on `main`
+2. milestone project patterns already used across the alpha curriculum
+   - supporting examples for how checkpoints, scoped increments, and proof surfaces can work
+
+That means the stage is anchored in one real project spine while still learning from the smaller
+project patterns already present elsewhere in the repo.
+
 ## Current Source Content
 
 - [14-application-architecture/enterprise-capstone](../../14-application-architecture/enterprise-capstone/)
 - milestone project patterns already used across the alpha curriculum
 
-Beta additions planned:
+## Stage Support Docs
 
-- clearer project spine milestones
-- tighter rubric integration
-- more explicit handoff from expert pressure into flagship checkpoints
+Use these support docs when you want the beta-stage view of the flagship path:
+
+- [Flagship Project support index](./flagship-project/README.md)
+- [Stage map](./flagship-project/stage-map.md)
+- [Checkpoint guidance](./flagship-project/checkpoint-guidance.md)
+
+## Where This Stage Starts
+
+Start with [14-application-architecture/enterprise-capstone](../../14-application-architecture/enterprise-capstone/).
+
+That is the current flagship seed on `main`.
+The other milestone project patterns support the stage, but the capstone project is the primary
+spine.
+
+## Recommended Order
+
+Use this order for the current beta-facing shell:
+
+1. read and run the enterprise capstone so the system shape is concrete
+2. identify the first checkpoint boundary before making large changes
+3. extend the project in staged increments instead of treating it as one giant final dump
+4. use smaller milestone project patterns as reference when you need scope discipline
+
+## Path Guidance
+
+### Full Path
+
+Enter this stage after the earlier build/test/structure/operate stages are already meaningful.
+The flagship should integrate those habits, not replace them.
+
+### Bridge Path
+
+If you already build real services, you can move into this stage earlier, but only if you can
+already explain:
+
+- backend boundaries
+- cancellation and concurrency safety
+- testing and profiling habits
+- operational concerns like logs and shutdown
+
+### Targeted Path
+
+If your immediate goal is portfolio-quality proof work, use this stage as the place where the
+earlier stage habits are recombined into one system.
+
+## Checkpoint Backbone
+
+The current public checkpoint model is:
+
+- foundation checkpoint: run the system, understand the moving parts, and explain the project shape
+- architecture checkpoint: explain the major package and service boundaries
+- operations checkpoint: explain runtime, deployment, and lifecycle behavior
+- iteration checkpoint: extend the system deliberately without collapsing the design
 
 ## Finish This Stage When
 
@@ -39,6 +109,13 @@ Beta additions planned:
 - you can explain the design and operations decisions in the project
 - you can improve the system through iteration instead of only feature addition
 - you can use the project as real proof of engineering growth
+
+More concretely:
+
+- you can explain why the project is split the way it is
+- you can choose the next checkpoint based on real risk and learning value
+- you can connect implementation choices back to testing, operations, and maintainability
+- you can use the flagship as proof of engineering growth instead of as a random finished demo
 
 ## Next Stage
 

--- a/docs/stages/flagship-project/README.md
+++ b/docs/stages/flagship-project/README.md
@@ -1,0 +1,16 @@
+# Flagship Project Support Docs
+
+Use these docs when you want the beta-stage view of the flagship path without reverse-engineering
+it from the source tree alone.
+
+## In This Folder
+
+- [Stage map](./stage-map.md)
+- [Checkpoint guidance](./checkpoint-guidance.md)
+
+## Current Stage Scope
+
+`10 Flagship Project` currently draws from:
+
+- [14-application-architecture/enterprise-capstone](../../../14-application-architecture/enterprise-capstone/)
+- milestone project patterns already used across the alpha curriculum

--- a/docs/stages/flagship-project/checkpoint-guidance.md
+++ b/docs/stages/flagship-project/checkpoint-guidance.md
@@ -1,0 +1,31 @@
+# Flagship Project Checkpoint Guidance
+
+## Why Checkpoints Matter
+
+The flagship project should grow through checkpoints, not through one giant unstructured feature
+dump.
+
+Checkpoints keep the work reviewable, explainable, and tied to learning value.
+
+## Current Checkpoints
+
+### Foundation checkpoint
+
+Run the system, explain the moving parts, and identify the main boundaries before changing code.
+
+### Architecture checkpoint
+
+Explain why the major packages, handlers, and repository surfaces exist and where the seams are.
+
+### Operations checkpoint
+
+Explain how the system is started, observed, and stopped, including any deployment-facing behavior.
+
+### Iteration checkpoint
+
+Choose one meaningful improvement and explain why it matters more than the next obvious feature.
+
+## Ready To Move On
+
+Move to [11 Code Generation](../11-code-generation.md) when the flagship system gives you enough
+context to evaluate generation as leverage instead of magic.

--- a/docs/stages/flagship-project/stage-map.md
+++ b/docs/stages/flagship-project/stage-map.md
@@ -1,0 +1,28 @@
+# Flagship Project Stage Map
+
+## Stage Goal
+
+This stage gives the curriculum one long-running system where earlier-stage habits are forced to
+work together.
+
+## Public Stage Shape
+
+| Surface | Role In Stage |
+| --- | --- |
+| [enterprise-capstone](../../../14-application-architecture/enterprise-capstone/) | current flagship seed and main integrated project spine |
+| milestone project patterns from earlier stages | supporting examples for scoped increments and checkpoint discipline |
+
+## Current Checkpoint Model
+
+| Checkpoint | Purpose |
+| --- | --- |
+| Foundation | understand and run the system end to end |
+| Architecture | explain the main boundaries and why they exist |
+| Operations | explain runtime, deployment, and lifecycle behavior |
+| Iteration | add or improve behavior without collapsing the design |
+
+## Handoff
+
+After the flagship path is meaningful, [11 Code Generation](../11-code-generation.md) becomes much
+more useful because there is now a real system context for deciding what should and should not be
+generated.


### PR DESCRIPTION
## Summary
- strengthen the public Flagship Project stage shell
- align the enterprise capstone with beta flagship stage ownership
- publish stage support docs for the flagship stage map and checkpoint guidance

## Validation
- docs-only change
- git diff --check

Closes #241
Closes #242
Closes #243
Closes #244