### PR TITLE
Regroup the Code Generation beta stage

### DIFF
--- a/15-code-generation/README.md
+++ b/15-code-generation/README.md
@@ -11,6 +11,12 @@ The live v2 slice focuses on three habits:
 - generating mocks from interfaces when hand-written test doubles stop scaling
 - generating typed data-access code from SQL instead of relying on reflection-heavy ORMs
 
+## Beta Stage Ownership
+
+This section belongs to [11 Code Generation](../docs/stages/11-code-generation.md).
+
+Within the beta public shell, it is the complete live source section for that stage.
+
 ## Who Should Start Here
 
 ### Full Path
@@ -66,5 +72,9 @@ then the code-generation part of the curriculum is doing its job.
 ## Next Step
 
 After `CG.3`, you have reached the end of the current public curriculum line.
+
+In the beta shell, that means you have completed
+[11 Code Generation](../docs/stages/11-code-generation.md).
+
 The best next move is to revisit any weak milestone, rebuild a capstone from memory, or apply the
 patterns in your own production-style Go project.

--- a/docs/stages/11-code-generation.md
+++ b/docs/stages/11-code-generation.md
@@ -15,6 +15,14 @@ Generation is multiplication, not understanding.
 It becomes useful only after you know what the generated code is doing and how it fits into the
 system.
 
+## Why This Stage Exists
+
+This stage exists so learners use generation as leverage after understanding, not as a shortcut
+around understanding.
+
+The goal is to make generation workflows reviewable, intentional, and connected to real system
+needs.
+
 ## What You Should Learn Here
 
 - where generation helps
@@ -22,9 +30,68 @@ system.
 - how generated code fits into normal review and maintenance workflows
 - how to keep generated workflows understandable
 
+## Stage Shape
+
+This stage currently has one live public source section with one focused generation path:
+
+1. `15-code-generation`
+   - the live beta path for `go generate`, generated mocks, and schema-driven SQL generation
+
+That makes this stage intentionally narrow.
+It is about responsible leverage, not about turning the repo into a catalog of tooling for its own
+sake.
+
 ## Current Source Content
 
 - [15-code-generation](../../15-code-generation/)
+
+## Stage Support Docs
+
+Use these support docs when you want the beta-stage view of code generation:
+
+- [Code Generation support index](./code-generation/README.md)
+- [Stage map](./code-generation/stage-map.md)
+- [Milestone guidance](./code-generation/milestone-guidance.md)
+
+## Where This Stage Starts
+
+Start with [Section 15: Code Generation](../../15-code-generation/).
+
+That section is already the full public source surface for this stage.
+
+## Recommended Order
+
+Use this order for the current beta-facing path:
+
+1. `CG.1` for the `go generate` mental model
+2. `CG.2` for generated mocks and test workflow leverage
+3. `CG.3` for schema-driven SQL generation in production-style code
+
+## Path Guidance
+
+### Full Path
+
+Enter this stage after the flagship and expert-pressure work are already meaningful.
+That keeps generation connected to real engineering needs instead of abstract tool enthusiasm.
+
+### Bridge Path
+
+If you already use generation tools professionally, you can move faster, but do not skip `CG.1`.
+That lesson establishes the "build-time workflow, not runtime magic" contract for the whole stage.
+
+### Targeted Path
+
+If your immediate goal is tooling leverage:
+
+- start with `CG.1` if you need the basic generation model
+- start with `CG.2` if your gap is test double generation
+- start with `CG.3` if your gap is query/code generation around SQL
+
+## Stage Milestones
+
+The current live milestone backbone is:
+
+- `CG.3` sqlc workflow
 
 ## Finish This Stage When
 
@@ -32,6 +99,12 @@ system.
 - you can read and review the code that generation produces
 - you know when not to use generation
 - you understand generation as leverage, not magic
+
+More concretely:
+
+- you can explain why generated code still belongs inside normal review and maintenance flows
+- you can connect generation workflows back to testability, contracts, or data access needs
+- you can explain when generation reduces risk and when it increases hidden cost
 
 ## Next Stage
 

--- a/docs/stages/code-generation/README.md
+++ b/docs/stages/code-generation/README.md
@@ -1,0 +1,15 @@
+# Code Generation Support Docs
+
+Use these docs when you want the beta-stage view of code generation without reading the full source
+section first.
+
+## In This Folder
+
+- [Stage map](./stage-map.md)
+- [Milestone guidance](./milestone-guidance.md)
+
+## Current Stage Scope
+
+`11 Code Generation` currently draws from:
+
+- [15-code-generation](../../../15-code-generation/)

--- a/docs/stages/code-generation/milestone-guidance.md
+++ b/docs/stages/code-generation/milestone-guidance.md
@@ -1,0 +1,25 @@
+# Code Generation Milestone Guidance
+
+## What Counts As Stage Completion
+
+You should be able to explain why a generation workflow exists, how it fits into the build and
+review process, and when it should not be used.
+
+## Milestone
+
+### `CG.3` sqlc workflow
+
+This proves that generation can support production data-access code without turning the workflow
+into hidden runtime magic.
+
+## Bridge Path Check
+
+If you are moving quickly through this stage, make sure you can still explain:
+
+- why `go generate` is a build-time workflow
+- why generated mocks and query code still need review
+- why generation should reduce manual repetition without hiding the real system model
+
+## Ready To Use
+
+At this point, generation should feel like leverage you understand, not magic you tolerate.

--- a/docs/stages/code-generation/stage-map.md
+++ b/docs/stages/code-generation/stage-map.md
@@ -1,0 +1,24 @@
+# Code Generation Stage Map
+
+## Stage Goal
+
+This stage teaches learners how to use generation as understandable leverage after system context
+already exists.
+
+## Public Stage Shape
+
+| Surface | Role In Stage |
+| --- | --- |
+| [15-code-generation](../../../15-code-generation/) | live beta path for `go generate`, generated mocks, and schema-driven SQL generation |
+
+## Live Milestone Backbone
+
+| ID | Surface | Why It Matters |
+| --- | --- | --- |
+| `CG.3` | sqlc workflow | proves that generation can support type-safe data access without hiding the underlying model |
+
+## Recommended Order
+
+1. `CG.1`
+2. `CG.2`
+3. `CG.3`


### PR DESCRIPTION
## Summary
- strengthen the public Code Generation stage shell
- align Section 15 with beta stage ownership
- publish stage support docs for the code generation stage map and milestone guidance

## Validation
- docs-only change
- git diff --check

Closes #245
Closes #246
Closes #247
Closes #248