### PR TITLE
Seed the first Expert Layer pressure tasks

### DIFF
--- a/docs/stages/expert-layer/README.md
+++ b/docs/stages/expert-layer/README.md
@@ -5,6 +5,7 @@ repo for judgment-heavy source seeds.
 
 ## In This Folder
 
+- [Task index](./tasks/README.md)
 - [Source seeds and ownership](./source-seeds.md)
 - [Stage map](./stage-map.md)
 - [Pressure guidance](./pressure-guidance.md)

--- a/docs/stages/expert-layer/stage-map.md
+++ b/docs/stages/expert-layer/stage-map.md
@@ -14,6 +14,11 @@ constraints.
 | Redesign tasks | practice trade-off reasoning under constraints |
 | Flagship-linked pressure tasks | prepare learners for the longer integrated project path |
 
+## First Public Task Seeds
+
+- [DB.6 repository boundary review](./tasks/review-db6-repository-boundary.md)
+- [CP.5 health checker diagnosis](./tasks/diagnose-cp5-health-checker-failure.md)
+
 ## Entry Requirement
 
 This stage is for learners who already have meaningful milestone experience from the earlier beta

--- a/docs/stages/expert-layer/tasks/README.md
+++ b/docs/stages/expert-layer/tasks/README.md
@@ -1,0 +1,10 @@
+# Expert Layer Task Index
+
+These are the first public pressure tasks for `9 Expert Layer`.
+
+They are intentionally seeded from real milestone surfaces that already exist in the curriculum.
+
+## Current Tasks
+
+- [DB.6 repository boundary review](./review-db6-repository-boundary.md)
+- [CP.5 health checker diagnosis](./diagnose-cp5-health-checker-failure.md)

--- a/docs/stages/expert-layer/tasks/diagnose-cp5-health-checker-failure.md
+++ b/docs/stages/expert-layer/tasks/diagnose-cp5-health-checker-failure.md
@@ -1,0 +1,71 @@
+# CP.5 Health Checker Diagnosis
+
+## Mission
+
+Diagnose a failure or weakness in the `CP.5` health-checker milestone by working from evidence
+instead of guesswork.
+
+## Type
+
+- diagnosis task
+
+## Level
+
+- stretch
+
+## Prerequisites
+
+- [5 Concurrency System](../../05-concurrency-system.md)
+- `CP.5`
+- [rubric and checkpoint template](../../../templates/rubric-checkpoint-template.md)
+
+## Task
+
+1. Inspect the `CP.5` health-checker surface and identify one likely concurrency or coordination
+   failure mode.
+2. Explain what evidence you would inspect first to confirm it.
+3. Propose one bounded fix and explain why it is safer than the most obvious shallow alternative.
+
+## Evidence
+
+- describe the suspected failure in concrete terms
+- explain what signal, behavior, or code surface would support the diagnosis
+- justify the proposed fix in terms of bounded concurrency, cancellation, or ownership
+
+## Rubric
+
+### 1. Correctness
+
+The diagnosis should match a plausible concurrency failure mode.
+
+### 2. Completeness
+
+The learner should cover the failure, the evidence trail, and the proposed fix.
+
+### 3. Boundary Handling
+
+The learner should discuss cancellation, sibling work, ownership, or bounded concurrency directly.
+
+### 4. Code Quality
+
+The proposed fix should reduce ambiguity or coordination risk without overengineering the surface.
+
+### 5. Verification Discipline
+
+The diagnosis should rely on observable evidence instead of intuition alone.
+
+### 6. Explanation Quality
+
+The learner should explain why the chosen fix is better than a shallow alternative.
+
+## Common Weak Answers
+
+- guessing at a race or leak without naming the evidence trail
+- proposing "just add more locks" without explaining the coordination problem
+- describing a failure mode without suggesting a bounded fix
+
+## Next Step
+
+Use this task as a bridge into
+[10 Flagship Project](../../10-flagship-project.md)
+when you want the same judgment pressure applied to a larger system.

--- a/docs/stages/expert-layer/tasks/review-db6-repository-boundary.md
+++ b/docs/stages/expert-layer/tasks/review-db6-repository-boundary.md
@@ -1,0 +1,74 @@
+# DB.6 Repository Boundary Review
+
+## Mission
+
+Review the `DB.6` repository-pattern milestone and explain whether its boundaries are clear enough
+for a small backend service.
+
+## Type
+
+- review task
+
+## Level
+
+- core
+
+## Prerequisites
+
+- [4 Backend Engineering](../../04-backend-engineering.md)
+- `DB.6`
+- [rubric and checkpoint template](../../../templates/rubric-checkpoint-template.md)
+
+## Task
+
+1. Review the `DB.6` repository pattern surface and identify the three most important engineering
+   risks or weaknesses.
+2. Explain which one matters most and why.
+3. Propose one boundary improvement that would make the surface easier to test, reason about, or
+   evolve.
+
+## Evidence
+
+- point to the specific boundary or code shape you are criticizing
+- explain why it is a real engineering problem instead of a style preference
+- justify the priority order of your top three findings
+
+## Rubric
+
+### 1. Correctness
+
+The review should describe real issues, not imagined ones.
+
+### 2. Completeness
+
+The learner should cover three findings and rank them clearly.
+
+### 3. Boundary Handling
+
+The review should discuss repository seams, SQL ownership, or service-boundary clarity directly.
+
+### 4. Code Quality
+
+The proposed improvement should make the surface clearer, safer, or easier to change.
+
+### 5. Verification Discipline
+
+The review should point to specific evidence from the milestone surface.
+
+### 6. Explanation Quality
+
+The learner should justify why the top issue matters most instead of only listing problems.
+
+## Common Weak Answers
+
+- naming three style nits instead of meaningful engineering risks
+- proposing a large refactor without explaining the problem it solves
+- criticizing boundaries without pointing to concrete evidence
+
+## Next Step
+
+Move to the diagnosis task at
+[CP.5 health checker diagnosis](./diagnose-cp5-health-checker-failure.md)
+or continue to the
+[Flagship Project stage](../../10-flagship-project.md)
+if you want longer-form pressure next.


### PR DESCRIPTION
## Summary
- add the first public Expert Layer task index
- seed one review task from DB.6 and one diagnosis task from CP.5
- link the new tasks into the Expert Layer stage map

## Validation
- docs-only change
- git diff --check

Closes #257