### PR TITLE
Enforce pressure system surfaces

### DIFF
--- a/docs/stages/expert-layer/pressure-guidance.md
+++ b/docs/stages/expert-layer/pressure-guidance.md
@@ -23,6 +23,12 @@ Use the shared
 [rubric and checkpoint template](../../templates/rubric-checkpoint-template.md)
 when you define new expert-layer review or diagnosis tasks.
 
+## Current Task Index
+
+Use the public
+[task index](./tasks/README.md)
+when you want the current beta-ready task set instead of the generic pattern only.
+
 ## Ready To Move On
 
 Move to [10 Flagship Project](../10-flagship-project.md) when review, diagnosis, and redesign work

--- a/docs/stages/expert-layer/stage-map.md
+++ b/docs/stages/expert-layer/stage-map.md
@@ -14,10 +14,16 @@ constraints.
 | Redesign tasks | practice trade-off reasoning under constraints |
 | Flagship-linked pressure tasks | prepare learners for the longer integrated project path |
 
+Use the public task index here:
+
+- [Task index](./tasks/README.md)
+
 ## First Public Task Seeds
 
 - [DB.6 repository boundary review](./tasks/review-db6-repository-boundary.md)
 - [CP.5 health checker diagnosis](./tasks/diagnose-cp5-health-checker-failure.md)
+- [SL.5 redaction boundary review](./tasks/review-sl5-redaction-boundary.md)
+- [GS.3 shutdown-order redesign](./tasks/redesign-gs3-shutdown-order.md)
 
 ## Entry Requirement
 

--- a/docs/stages/expert-layer/tasks/README.md
+++ b/docs/stages/expert-layer/tasks/README.md
@@ -8,3 +8,5 @@ They are intentionally seeded from real milestone surfaces that already exist in
 
 - [DB.6 repository boundary review](./review-db6-repository-boundary.md)
 - [CP.5 health checker diagnosis](./diagnose-cp5-health-checker-failure.md)
+- [SL.5 redaction boundary review](./review-sl5-redaction-boundary.md)
+- [GS.3 shutdown-order redesign](./redesign-gs3-shutdown-order.md)

--- a/docs/stages/expert-layer/tasks/redesign-gs3-shutdown-order.md
+++ b/docs/stages/expert-layer/tasks/redesign-gs3-shutdown-order.md
@@ -1,0 +1,75 @@
+# GS.3 Shutdown-Order Redesign
+
+## Mission
+
+Redesign part of the `GS.3` shutdown capstone so service shutdown order becomes clearer and safer
+under operational pressure.
+
+## Type
+
+- redesign task
+
+## Level
+
+- production
+
+## Prerequisites
+
+- [8 Production Engineering](../../08-production-engineering.md)
+- `GS.3`
+- [rubric and checkpoint template](../../../templates/rubric-checkpoint-template.md)
+
+## Task
+
+1. Inspect the `GS.3` shutdown capstone and identify one shutdown-order or lifecycle boundary that
+   could become risky as the system grows.
+2. Propose a bounded redesign that improves the shutdown model without rebuilding the whole
+   application.
+3. Explain why your redesign is better than a simpler but riskier alternative.
+
+## Evidence
+
+- point to the lifecycle seam you want to redesign
+- explain the operational risk in concrete terms
+- justify why the redesign is bounded, realistic, and worth doing now
+
+## Rubric
+
+### 1. Correctness
+
+The redesign should target a plausible shutdown or lifecycle risk.
+
+### 2. Completeness
+
+The learner should describe the current risk, the redesign, and the trade-off versus an
+alternative.
+
+### 3. Boundary Handling
+
+The redesign should discuss shutdown order, readiness, worker drain, or resource ownership
+explicitly.
+
+### 4. Code Quality
+
+The proposed redesign should clarify the system instead of adding accidental complexity.
+
+### 5. Verification Discipline
+
+The redesign should be defended with concrete lifecycle reasoning, not generic “best practice”
+language.
+
+### 6. Explanation Quality
+
+The learner should explain why the chosen redesign is better than a shallow alternative.
+
+## Common Weak Answers
+
+- suggesting “just shut everything down faster” without discussing order
+- proposing a broad refactor with no bounded seam
+- naming lifecycle risks without tying them to actual service behavior
+
+## Next Step
+
+Use this task as a bridge into the
+[Flagship Project stage](../../10-flagship-project.md)
+when you want the same redesign pressure applied to a larger system.

--- a/docs/stages/expert-layer/tasks/review-sl5-redaction-boundary.md
+++ b/docs/stages/expert-layer/tasks/review-sl5-redaction-boundary.md
@@ -1,0 +1,74 @@
+# SL.5 Redaction Boundary Review
+
+## Mission
+
+Review the `SL.5` redaction milestone and explain whether sensitive-data handling is enforced in
+the right place.
+
+## Type
+
+- review task
+
+## Level
+
+- stretch
+
+## Prerequisites
+
+- [8 Production Engineering](../../08-production-engineering.md)
+- `SL.5`
+- [rubric and checkpoint template](../../../templates/rubric-checkpoint-template.md)
+
+## Task
+
+1. Review the `SL.5` redaction surface and identify the two most important risks around log
+   redaction boundaries.
+2. Explain which risk matters most in a real production setting and why.
+3. Propose one bounded improvement that would make the logging surface safer without turning it
+   into overbuilt infrastructure.
+
+## Evidence
+
+- point to the specific logging boundary you are evaluating
+- explain why the risk is real in terms of sensitive data, handler placement, or operational usage
+- justify why the proposed improvement is the right next move
+
+## Rubric
+
+### 1. Correctness
+
+The review should identify plausible operational risks in the logging/redaction flow.
+
+### 2. Completeness
+
+The learner should cover two risks, prioritize them, and propose one bounded improvement.
+
+### 3. Boundary Handling
+
+The review should discuss where redaction belongs and why that boundary matters.
+
+### 4. Code Quality
+
+The proposed change should improve safety or clarity without uncontrolled complexity.
+
+### 5. Verification Discipline
+
+The critique should rely on evidence from the current milestone surface.
+
+### 6. Explanation Quality
+
+The learner should explain why the top risk matters most under production pressure.
+
+## Common Weak Answers
+
+- treating redaction like a formatting preference instead of a boundary decision
+- proposing a total rewrite without explaining the current risk clearly
+- naming sensitive-data concerns without pointing to the actual surface
+
+## Next Step
+
+Continue to the redesign task at
+[GS.3 shutdown-order redesign](./redesign-gs3-shutdown-order.md)
+or move into the
+[Flagship Project stage](../../10-flagship-project.md)
+if you want system-scale pressure next.

--- a/docs/stages/flagship-project/README.md
+++ b/docs/stages/flagship-project/README.md
@@ -8,6 +8,7 @@ it from the source tree alone.
 - [Stage map](./stage-map.md)
 - [Checkpoint guidance](./checkpoint-guidance.md)
 - [Checkpoint set](./checkpoints/README.md)
+- [Implementation slices](./slices/README.md)
 
 ## Current Stage Scope
 

--- a/docs/stages/flagship-project/checkpoint-guidance.md
+++ b/docs/stages/flagship-project/checkpoint-guidance.md
@@ -18,6 +18,7 @@ when you define new flagship checkpoints.
 The current public checkpoint set lives here:
 
 - [Checkpoint set index](./checkpoints/README.md)
+- [Implementation slices](./slices/README.md)
 
 ### Foundation checkpoint
 

--- a/docs/stages/flagship-project/checkpoints/architecture-checkpoint.md
+++ b/docs/stages/flagship-project/checkpoints/architecture-checkpoint.md
@@ -59,7 +59,15 @@ The explanation should point to evidence in the current flagship seed.
 The learner should justify why the selected improvement matters more than a larger speculative
 redesign.
 
+## Common Weak Answers
+
+- calling a boundary “good” or “bad” without evidence from the current project structure
+- proposing a large rewrite instead of a bounded improvement
+- confusing operational concerns with architectural seams
+
 ## Next Step
 
-Move to the
+Use the
+[Architecture implementation slice](../slices/architecture-slice.md),
+then move to the
 [Operations checkpoint](./operations-checkpoint.md).

--- a/docs/stages/flagship-project/checkpoints/foundation-checkpoint.md
+++ b/docs/stages/flagship-project/checkpoints/foundation-checkpoint.md
@@ -56,7 +56,15 @@ The run path and explanation should be grounded in the actual project surface.
 
 The learner should show judgment about what is still unclear and why that matters.
 
+## Common Weak Answers
+
+- reporting that the project runs without describing the main runtime pieces
+- naming directories without explaining what role they play in the system
+- proposing a change before showing enough understanding of the current system
+
 ## Next Step
 
-Move to the
+Start with the
+[Foundation implementation slice](../slices/foundation-slice.md),
+then move to the
 [Architecture checkpoint](./architecture-checkpoint.md).

--- a/docs/stages/flagship-project/checkpoints/iteration-checkpoint.md
+++ b/docs/stages/flagship-project/checkpoints/iteration-checkpoint.md
@@ -57,8 +57,16 @@ The learner should define what evidence would prove the iteration was worthwhile
 
 The learner should justify why this improvement wins over plausible alternatives.
 
+## Common Weak Answers
+
+- choosing the most interesting change instead of the highest-leverage next step
+- describing a goal without defining how to prove the iteration helped
+- proposing an iteration that expands scope without a clear system reason
+
 ## Next Step
 
-After this checkpoint, either implement the chosen iteration or return to
+After this checkpoint, use the
+[First iteration slice](../slices/first-iteration-slice.md),
+then either implement the chosen iteration or return to
 [11 Code Generation](../../11-code-generation.md)
 once you have enough flagship context to use generation tools deliberately.

--- a/docs/stages/flagship-project/checkpoints/operations-checkpoint.md
+++ b/docs/stages/flagship-project/checkpoints/operations-checkpoint.md
@@ -57,7 +57,15 @@ The explanation should rely on visible system evidence instead of guesses about 
 
 The learner should explain why the chosen operational risk matters before more feature work.
 
+## Common Weak Answers
+
+- talking about production in abstract terms without tying it to the current project surfaces
+- naming logs or shutdown as concerns without identifying the specific operational seam
+- proposing broad platform work before justifying a bounded safety improvement
+
 ## Next Step
 
-Move to the
+Use the
+[Operations implementation slice](../slices/operations-slice.md),
+then move to the
 [Iteration checkpoint](./iteration-checkpoint.md).

--- a/docs/stages/flagship-project/slices/README.md
+++ b/docs/stages/flagship-project/slices/README.md
@@ -1,0 +1,10 @@
+# Flagship Implementation Slices
+
+These slices connect the public checkpoint model to actual implementation or iteration work.
+
+## Current Slices
+
+- [Foundation slice](./foundation-slice.md)
+- [Architecture slice](./architecture-slice.md)
+- [Operations slice](./operations-slice.md)
+- [First iteration slice](./first-iteration-slice.md)

--- a/docs/stages/flagship-project/slices/architecture-slice.md
+++ b/docs/stages/flagship-project/slices/architecture-slice.md
@@ -1,0 +1,16 @@
+# Architecture Slice
+
+## Goal
+
+Turn the architecture checkpoint into one bounded implementation or analysis slice.
+
+## Focus
+
+- inspect package and service seams
+- identify one boundary worth strengthening
+- keep the improvement bounded and explainable
+
+## Exit Signal
+
+You can explain the chosen boundary improvement and why it matters more than broader redesign work
+right now.

--- a/docs/stages/flagship-project/slices/first-iteration-slice.md
+++ b/docs/stages/flagship-project/slices/first-iteration-slice.md
@@ -1,0 +1,15 @@
+# First Iteration Slice
+
+## Goal
+
+Choose one meaningful next improvement for the enterprise capstone and connect it to a proof plan.
+
+## Focus
+
+- select one next improvement deliberately
+- justify why it wins over nearby alternatives
+- define the evidence that would prove the iteration was worth doing
+
+## Exit Signal
+
+You can explain both the chosen iteration and the proof surface that should validate it.

--- a/docs/stages/flagship-project/slices/foundation-slice.md
+++ b/docs/stages/flagship-project/slices/foundation-slice.md
@@ -1,0 +1,16 @@
+# Foundation Slice
+
+## Goal
+
+Get the enterprise capstone running and document the minimum runtime understanding needed before any
+larger change.
+
+## Focus
+
+- run the supported local workflow
+- name the key runtime pieces
+- record the first system questions instead of changing code too early
+
+## Exit Signal
+
+You can explain what starts the system, what supports it, and what still feels unclear.

--- a/docs/stages/flagship-project/slices/operations-slice.md
+++ b/docs/stages/flagship-project/slices/operations-slice.md
@@ -1,0 +1,15 @@
+# Operations Slice
+
+## Goal
+
+Turn the operations checkpoint into one bounded runtime-hardening slice.
+
+## Focus
+
+- inspect runtime, deployment, and lifecycle behavior
+- identify one operational weakness that matters now
+- propose or implement one bounded improvement
+
+## Exit Signal
+
+You can explain the operational risk clearly and defend the selected improvement.

--- a/docs/stages/flagship-project/stage-map.md
+++ b/docs/stages/flagship-project/stage-map.md
@@ -24,6 +24,7 @@ work together.
 Use the published checkpoint set here:
 
 - [Checkpoint set](./checkpoints/README.md)
+- [Implementation slices](./slices/README.md)
 
 ## Handoff
 

--- a/scripts/internal/curriculumvalidator/validator.go
+++ b/scripts/internal/curriculumvalidator/validator.go
@@ -670,11 +670,11 @@ func validatePressureDocs(root string, report func(string)) int {
 	}
 
 	requiredLinks := map[string][]string{
-		"docs/stages/expert-layer/README.md":                 {"./tasks/README.md"},
-		"docs/stages/expert-layer/stage-map.md":              {"./tasks/README.md"},
-		"docs/stages/expert-layer/pressure-guidance.md":      {"./tasks/README.md"},
-		"docs/stages/flagship-project/README.md":             {"./checkpoints/README.md", "./slices/README.md"},
-		"docs/stages/flagship-project/stage-map.md":          {"./checkpoints/README.md", "./slices/README.md"},
+		"docs/stages/expert-layer/README.md":                  {"./tasks/README.md"},
+		"docs/stages/expert-layer/stage-map.md":               {"./tasks/README.md"},
+		"docs/stages/expert-layer/pressure-guidance.md":       {"./tasks/README.md"},
+		"docs/stages/flagship-project/README.md":              {"./checkpoints/README.md", "./slices/README.md"},
+		"docs/stages/flagship-project/stage-map.md":           {"./checkpoints/README.md", "./slices/README.md"},
 		"docs/stages/flagship-project/checkpoint-guidance.md": {"./checkpoints/README.md", "./slices/README.md"},
 	}
 

--- a/scripts/internal/curriculumvalidator/validator.go
+++ b/scripts/internal/curriculumvalidator/validator.go
@@ -72,6 +72,7 @@ type Result struct {
 
 var runPathPattern = regexp.MustCompile(`\./[A-Za-z0-9._/\-]+`)
 var nextUpIDPattern = regexp.MustCompile(`NEXT UP:\s*([A-Z]{2,3}\.\d+)`)
+var markdownLinkPattern = regexp.MustCompile(`\[[^\]]+\]\(([^)]+)\)`)
 
 var (
 	allowedItemTypes = map[string]bool{
@@ -122,13 +123,15 @@ func Validate(root string, report func(string)) (Result, error) {
 		return Result{}, err
 	}
 
+	pressureErrors := validatePressureDocs(root, report)
+
 	return Result{
 		LessonCount:    lessonCount,
 		FilesScanned:   filesScanned,
 		V2SectionCount: v2SectionCount,
 		V2ItemCount:    v2ItemCount,
 		HasV2:          hasV2,
-		ErrorCount:     pathErrors + runErrors + v2Errors,
+		ErrorCount:     pathErrors + runErrors + v2Errors + pressureErrors,
 	}, nil
 }
 
@@ -637,6 +640,151 @@ func validateV2LessonNavigation(root string, items []V2Item, report func(string)
 		actualNextID := string(match[1])
 		if actualNextID != expectedNextID {
 			report(fmt.Sprintf("Invalid v2 lesson navigation footer: %s -> %s (expected %s)", item.ID, actualNextID, expectedNextID))
+			errorsFound++
+		}
+	}
+
+	return errorsFound
+}
+
+var rubricSurfaceHeadings = []string{
+	"## Mission",
+	"## Type",
+	"## Level",
+	"## Prerequisites",
+	"## Task",
+	"## Evidence",
+	"## Rubric",
+	"## Common Weak Answers",
+	"## Next Step",
+}
+
+func validatePressureDocs(root string, report func(string)) int {
+	errorsFound := 0
+
+	templatePath := "docs/templates/rubric-checkpoint-template.md"
+	if !pathExists(root, templatePath) {
+		report("Missing rubric template: docs/templates/rubric-checkpoint-template.md")
+		errorsFound++
+		return errorsFound
+	}
+
+	requiredLinks := map[string][]string{
+		"docs/stages/expert-layer/README.md":                 {"./tasks/README.md"},
+		"docs/stages/expert-layer/stage-map.md":              {"./tasks/README.md"},
+		"docs/stages/expert-layer/pressure-guidance.md":      {"./tasks/README.md"},
+		"docs/stages/flagship-project/README.md":             {"./checkpoints/README.md", "./slices/README.md"},
+		"docs/stages/flagship-project/stage-map.md":          {"./checkpoints/README.md", "./slices/README.md"},
+		"docs/stages/flagship-project/checkpoint-guidance.md": {"./checkpoints/README.md", "./slices/README.md"},
+	}
+
+	for relPath, links := range requiredLinks {
+		errorsFound += validateRequiredLinkPresence(root, relPath, links, report)
+		errorsFound += validateMarkdownLocalLinks(root, relPath, report)
+	}
+
+	errorsFound += validateMarkdownLocalLinks(root, "docs/stages/expert-layer/tasks/README.md", report)
+	errorsFound += validateMarkdownLocalLinks(root, "docs/stages/flagship-project/checkpoints/README.md", report)
+	errorsFound += validateMarkdownLocalLinks(root, "docs/stages/flagship-project/slices/README.md", report)
+
+	errorsFound += validateRubricSurfaceDirectory(root, "docs/stages/expert-layer/tasks", report)
+	errorsFound += validateRubricSurfaceDirectory(root, "docs/stages/flagship-project/checkpoints", report)
+
+	return errorsFound
+}
+
+func validateRubricSurfaceDirectory(root, relDir string, report func(string)) int {
+	errorsFound := 0
+	fullDir := filepath.Join(root, relDir)
+	entries, err := os.ReadDir(fullDir)
+	if err != nil {
+		report(fmt.Sprintf("Missing pressure-doc directory: %s", filepath.ToSlash(relDir)))
+		return 1
+	}
+
+	itemCount := 0
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".md" || entry.Name() == "README.md" {
+			continue
+		}
+		itemCount++
+		relPath := filepath.ToSlash(filepath.Join(relDir, entry.Name()))
+		errorsFound += validateRequiredHeadings(root, relPath, rubricSurfaceHeadings, report)
+		errorsFound += validateMarkdownLocalLinks(root, relPath, report)
+	}
+
+	if itemCount == 0 {
+		report(fmt.Sprintf("Missing pressure-doc items in: %s", filepath.ToSlash(relDir)))
+		errorsFound++
+	}
+
+	return errorsFound
+}
+
+func validateRequiredHeadings(root, relPath string, headings []string, report func(string)) int {
+	data, err := os.ReadFile(filepath.Join(root, relPath))
+	if err != nil {
+		report(fmt.Sprintf("Failed to read pressure-doc surface: %s -> %v", filepath.ToSlash(relPath), err))
+		return 1
+	}
+
+	text := string(data)
+	errorsFound := 0
+	for _, heading := range headings {
+		if !strings.Contains(text, heading) {
+			report(fmt.Sprintf("Invalid rubric/checkpoint surface headings: %s missing %s", filepath.ToSlash(relPath), heading))
+			errorsFound++
+		}
+	}
+
+	return errorsFound
+}
+
+func validateRequiredLinkPresence(root, relPath string, links []string, report func(string)) int {
+	data, err := os.ReadFile(filepath.Join(root, relPath))
+	if err != nil {
+		report(fmt.Sprintf("Failed to read pressure-doc link surface: %s -> %v", filepath.ToSlash(relPath), err))
+		return 1
+	}
+
+	text := string(data)
+	errorsFound := 0
+	for _, link := range links {
+		if !strings.Contains(text, "("+link+")") {
+			report(fmt.Sprintf("Missing required pressure-doc link: %s -> %s", filepath.ToSlash(relPath), link))
+			errorsFound++
+		}
+	}
+
+	return errorsFound
+}
+
+func validateMarkdownLocalLinks(root, relPath string, report func(string)) int {
+	data, err := os.ReadFile(filepath.Join(root, relPath))
+	if err != nil {
+		report(fmt.Sprintf("Failed to read markdown surface: %s -> %v", filepath.ToSlash(relPath), err))
+		return 1
+	}
+
+	errorsFound := 0
+	for _, match := range markdownLinkPattern.FindAllStringSubmatch(string(data), -1) {
+		if len(match) < 2 {
+			continue
+		}
+
+		target := strings.TrimSpace(match[1])
+		if target == "" ||
+			strings.HasPrefix(target, "http://") ||
+			strings.HasPrefix(target, "https://") ||
+			strings.HasPrefix(target, "#") ||
+			strings.HasPrefix(target, "mailto:") {
+			continue
+		}
+
+		target = strings.SplitN(target, "#", 2)[0]
+		resolved := filepath.Clean(filepath.Join(filepath.Dir(relPath), filepath.FromSlash(target)))
+		if !pathExists(root, resolved) {
+			report(fmt.Sprintf("Broken local doc link: %s -> %s", filepath.ToSlash(relPath), target))
 			errorsFound++
 		}
 	}

--- a/scripts/internal/curriculumvalidator/validator_test.go
+++ b/scripts/internal/curriculumvalidator/validator_test.go
@@ -11,6 +11,7 @@ func TestValidateAcceptsValidV2Fixture(t *testing.T) {
 	root := t.TempDir()
 
 	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
 	writeFile(t, root, "curriculum.v2.json", `{
   "schema_version": 1,
   "sections": [
@@ -84,6 +85,7 @@ func TestValidateRejectsUnknownSectionPrerequisite(t *testing.T) {
 	root := t.TempDir()
 
 	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
 	writeFile(t, root, "curriculum.v2.json", `{
   "schema_version": 1,
   "sections": [
@@ -122,6 +124,7 @@ func TestValidateRejectsMixedContractWithoutCommands(t *testing.T) {
 	root := t.TempDir()
 
 	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
 	writeFile(t, root, "curriculum.v2.json", `{
   "schema_version": 1,
   "sections": [
@@ -178,6 +181,7 @@ func TestValidateRejectsLessonNavigationFooterMismatch(t *testing.T) {
 	root := t.TempDir()
 
 	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
 	writeFile(t, root, "curriculum.v2.json", `{
   "schema_version": 1,
   "sections": [
@@ -257,6 +261,7 @@ func TestValidateRejectsWrongSectionLabelInV2Source(t *testing.T) {
 	root := t.TempDir()
 
 	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
 	writeFile(t, root, "curriculum.v2.json", `{
   "schema_version": 1,
   "sections": [
@@ -318,6 +323,7 @@ func TestValidateRejectsMojibakeInV2TextSurface(t *testing.T) {
 	root := t.TempDir()
 
 	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
 	writeFile(t, root, "curriculum.v2.json", `{
   "schema_version": 1,
   "sections": [
@@ -370,6 +376,88 @@ func TestValidateRejectsMojibakeInV2TextSurface(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsRubricSurfaceMissingRequiredHeading(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
+	writeFile(t, root, "docs/stages/expert-layer/tasks/review-db6-repository-boundary.md", `# DB.6 Repository Boundary Review
+
+## Mission
+
+Review the surface.
+
+## Type
+
+- review task
+
+## Level
+
+- core
+
+## Prerequisites
+
+- item
+
+## Task
+
+1. do the review
+
+## Evidence
+
+- show evidence
+
+## Common Weak Answers
+
+- weak answer
+
+## Next Step
+
+next
+`)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount != 1 {
+		t.Fatalf("expected 1 validation error, got %d with reports %v", result.ErrorCount, reports)
+	}
+	if !containsReport(reports, "Invalid rubric/checkpoint surface headings: docs/stages/expert-layer/tasks/review-db6-repository-boundary.md missing ## Rubric") {
+		t.Fatalf("expected missing-rubric-heading error in reports: %v", reports)
+	}
+}
+
+func TestValidateRejectsBrokenFlagshipCheckpointLink(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
+	writeFile(t, root, "docs/stages/flagship-project/checkpoint-guidance.md", `# Flagship Project Checkpoint Guidance
+
+Use the checkpoint set:
+
+- [Checkpoint set index](./checkpoints/README.md)
+`)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount != 1 {
+		t.Fatalf("expected 1 validation error, got %d with reports %v", result.ErrorCount, reports)
+	}
+	if !containsReport(reports, "Missing required pressure-doc link: docs/stages/flagship-project/checkpoint-guidance.md -> ./slices/README.md") {
+		t.Fatalf("expected missing-checkpoint-link error in reports: %v", reports)
+	}
+}
+
 func writeFile(t *testing.T, root, relativePath, contents string) {
 	t.Helper()
 
@@ -398,4 +486,96 @@ func containsReport(reports []string, want string) bool {
 	}
 
 	return false
+}
+
+func writeValidPressureDocs(t *testing.T, root string) {
+	t.Helper()
+
+	writeFile(t, root, "docs/templates/rubric-checkpoint-template.md", "# Template\n")
+	writeFile(t, root, "docs/stages/expert-layer/README.md", "# Expert\n\n[Task index](./tasks/README.md)\n")
+	writeFile(t, root, "docs/stages/expert-layer/stage-map.md", "# Stage Map\n\n[Task index](./tasks/README.md)\n")
+	writeFile(t, root, "docs/stages/expert-layer/pressure-guidance.md", "# Guidance\n\n[Task index](./tasks/README.md)\n")
+	writeFile(t, root, "docs/stages/expert-layer/tasks/README.md", "# Tasks\n\n- [Task](./review-db6-repository-boundary.md)\n")
+	writeFile(t, root, "docs/stages/expert-layer/tasks/review-db6-repository-boundary.md", `# Review
+
+## Mission
+
+mission
+
+## Type
+
+- review task
+
+## Level
+
+- core
+
+## Prerequisites
+
+- item
+
+## Task
+
+1. task
+
+## Evidence
+
+- evidence
+
+## Rubric
+
+rubric
+
+## Common Weak Answers
+
+- weak
+
+## Next Step
+
+next
+`)
+	writeFile(t, root, "docs/stages/flagship-project/README.md", "# Flagship\n\n[Checkpoint set](./checkpoints/README.md)\n[Implementation slices](./slices/README.md)\n")
+	writeFile(t, root, "docs/stages/flagship-project/stage-map.md", "# Stage Map\n\n[Checkpoint set](./checkpoints/README.md)\n[Implementation slices](./slices/README.md)\n")
+	writeFile(t, root, "docs/stages/flagship-project/checkpoint-guidance.md", "# Guidance\n\n[Checkpoint set index](./checkpoints/README.md)\n[Implementation slices](./slices/README.md)\n")
+	writeFile(t, root, "docs/stages/flagship-project/checkpoints/README.md", "# Checkpoints\n\n- [Foundation](./foundation-checkpoint.md)\n")
+	writeFile(t, root, "docs/stages/flagship-project/checkpoints/foundation-checkpoint.md", `# Foundation
+
+## Mission
+
+mission
+
+## Type
+
+- flagship checkpoint
+
+## Level
+
+- foundation
+
+## Prerequisites
+
+- item
+
+## Task
+
+1. task
+
+## Evidence
+
+- evidence
+
+## Rubric
+
+rubric
+
+## Common Weak Answers
+
+- weak
+
+## Next Step
+
+[Implementation slice](../slices/foundation-slice.md)
+`)
+	writeFile(t, root, "docs/stages/flagship-project/slices/README.md", "# Slices\n\n- [Foundation](./foundation-slice.md)\n")
+	writeFile(t, root, "docs/stages/flagship-project/slices/foundation-slice.md", "# Slice\n")
 }


### PR DESCRIPTION
## Summary
- add validator enforcement for rubric and checkpoint surfaces plus required doc links
- expand the Expert Layer task bank with new review and redesign tasks
- connect flagship checkpoints to concrete implementation slices

## Verification
- go test ./scripts/internal/curriculumvalidator
- go run ./scripts/validate_curriculum.go
- git diff --check

Closes #263
Closes #264
Closes #265

Part of #262