### PR TITLE
Link stage milestones to pressure tasks

### DIFF
--- a/docs/stages/04-backend-engineering.md
+++ b/docs/stages/04-backend-engineering.md
@@ -111,6 +111,12 @@ The current live milestone backbone is:
 
 - `DB.6` repository pattern project
 
+## Pressure Follow-Through
+
+Once `DB.6` feels runnable, move one layer deeper with the seeded Expert Layer review task:
+
+- [Review DB.6 repository boundary](./expert-layer/tasks/review-db6-repository-boundary.md)
+
 That single live milestone is intentional for now.
 This stage is still promoting the databases path first before the broader Section `10` inventory is
 fully regrouped into beta surfaces.

--- a/docs/stages/05-concurrency-system.md
+++ b/docs/stages/05-concurrency-system.md
@@ -123,6 +123,13 @@ The current live milestone backbone is:
 - `TM.7` console reminder
 - `CP.5` URL health checker
 
+## Pressure Follow-Through
+
+After `CP.5`, use the seeded diagnosis task that turns the milestone into a failure-analysis
+exercise:
+
+- [Diagnose CP.5 health checker failure](./expert-layer/tasks/diagnose-cp5-health-checker-failure.md)
+
 `CP.4` remains an important promoted exercise inside this stage because it is the first place where
 bounded-concurrency pressure becomes explicit.
 

--- a/docs/stages/08-production-engineering.md
+++ b/docs/stages/08-production-engineering.md
@@ -113,6 +113,14 @@ The current live milestone backbone is:
 - `SL.5` PII redactor exercise
 - `GS.3` shutdown capstone
 
+## Pressure Follow-Through
+
+After the stage milestones, use the seeded Expert Layer tasks that turn runtime safety into review
+and redesign pressure:
+
+- [Review SL.5 redaction boundary](./expert-layer/tasks/review-sl5-redaction-boundary.md)
+- [Redesign GS.3 shutdown order](./expert-layer/tasks/redesign-gs3-shutdown-order.md)
+
 `docker-and-deployment` is an important production surface, but it is currently a reference layer
 instead of the main public beta proof path.
 

--- a/docs/stages/backend-engineering/milestone-guidance.md
+++ b/docs/stages/backend-engineering/milestone-guidance.md
@@ -39,6 +39,12 @@ You are likely ready to leave this stage when:
 - you can reason about transaction boundaries and context-aware execution clearly
 - you can describe which Section `10` surfaces are live beta path versus reference-only
 
+## Pressure Follow-Through
+
+After `DB.6`, use the next pressure surface instead of treating the project as a dead end:
+
+- [Review DB.6 repository boundary](../expert-layer/tasks/review-db6-repository-boundary.md)
+
 ## If The Milestone Feels Too Hard
 
 That is usually a routing signal, not a failure signal.

--- a/docs/stages/concurrency-system/milestone-guidance.md
+++ b/docs/stages/concurrency-system/milestone-guidance.md
@@ -27,6 +27,12 @@ This is the strongest current stage proof.
 It asks you to combine cancellation, bounded concurrency, and failure-aware coordination in one
 small system.
 
+## Pressure Follow-Through
+
+After `CP.5`, use the seeded diagnosis task to practice evidence-based failure analysis:
+
+- [Diagnose CP.5 health checker failure](../expert-layer/tasks/diagnose-cp5-health-checker-failure.md)
+
 ## Bridge Path Check
 
 If you are moving quickly through this stage, make sure you can still explain:

--- a/docs/stages/production-engineering/milestone-guidance.md
+++ b/docs/stages/production-engineering/milestone-guidance.md
@@ -17,6 +17,14 @@ of ad hoc debug strings.
 This proves that lifecycle behavior can be designed deliberately instead of being left to process
 termination luck.
 
+## Pressure Follow-Through
+
+After the milestone path, use the seeded Expert Layer tasks to turn the stage into review and
+redesign pressure:
+
+- [Review SL.5 redaction boundary](../expert-layer/tasks/review-sl5-redaction-boundary.md)
+- [Redesign GS.3 shutdown order](../expert-layer/tasks/redesign-gs3-shutdown-order.md)
+
 ## Bridge Path Check
 
 If you are moving quickly through this stage, make sure you can still explain:


### PR DESCRIPTION
## Summary
- link seeded Expert Layer tasks from the relevant beta stage entry docs
- add the same pressure follow-through links to milestone-guidance docs for backend, concurrency, and production
- keep the rollout in beta-facing shell docs without patching alpha inventory content

## Verification
- git diff --check

Closes #268
Part of #267