### PR TITLE
Finish Section 03 zero-magic cleanup

### DIFF
--- a/03-data-structures/1-array/main.go
+++ b/03-data-structures/1-array/main.go
@@ -1,100 +1,56 @@
 // Copyright (c) 2026 Rasel Hossen
-// Licensed under The Go Engineer License v1.0
-// Commercial use is prohibited without permission.
+// See LICENSE for usage terms.
 
 package main
 
 import "fmt"
 
-// ============================================================================
-// Section 03: Data Structures — Arrays
-// Level: Beginner
-// ============================================================================
+// Section 03: Data Structures - Arrays
 //
-// WHAT YOU'LL LEARN:
-//   - Arrays are FIXED-SIZE, value-type collections
-//   - Declaring arrays with explicit size
-//   - Array literals and zero values
-//   - Why arrays are rarely used directly (slices are preferred)
-//   - Multi-dimensional arrays
+// Mental model:
+// Arrays are fixed-size values. If you copy one array into another, Go copies
+// all of the elements.
 //
-// ENGINEERING DEPTH:
-//   An Array in Go is a contiguous block of memory allocated strictly at compile
-//   time. Because the size is baked into the type itself (`[3]int`), the Go scheduler
-//   can optimize memory layout on the Stack rather than the Heap. However, because
-//   they are "Value Types", passing a `[1000]int` array to a function copies all
-//   1000 integers sequentially in RAM—which is why Slices are used 99% of the time.
+// In this lesson:
+// - declare arrays with an explicit size
+// - compare zero values and literals
+// - iterate with index and range
+// - observe copy-by-value behavior
 //
-// RUN: go run ./03-data-structures/1-array
-// ============================================================================
+// Watch for:
+// - [2]int and [3]int are different types
+// - arrays are mostly useful here as the contrast point for slices
+//
+// Run: go run ./03-data-structures/1-array
 
 func main() {
+	fmt.Println("=== Arrays ===")
 
-	// --- DECLARING AN ARRAY ---
-	// Syntax: var name [SIZE]Type
-	//
-	// The SIZE is part of the TYPE. [2]int and [3]int are DIFFERENT TYPES.
-	// You cannot assign a [2]int to a [3]int variable.
-	//
-	// Zero values: all elements are initialized to the type's zero value.
-	// For int, that's 0. For string, that's "".
+	// The size is part of the array type.
 	var numbers [2]int
-	fmt.Printf("Zero value array: %+v\n", numbers) // [0 0]
+	fmt.Printf("Zero value array: %v\n", numbers)
 
-	// Set individual elements by index (0-based)
 	numbers[0] = 1
 	numbers[1] = 2
-	fmt.Printf("After assignment: %+v\n", numbers) // [1 2]
+	fmt.Printf("After assignment: %v\n", numbers)
 
-	// --- ARRAY LITERALS ---
-	// Initialize with values directly. Go counts the elements for you.
 	primes := [4]int{2, 3, 5, 7}
-	fmt.Printf("Primes: %+v\n", primes)
+	fmt.Printf("\nLiteral: %v\n", primes)
 
-	// You can modify individual elements
-	primes[3] = 11                        // Replace 7 with 11
-	fmt.Printf("Modified: %+v\n", primes) // [2 3 5 11]
-
-	// --- ITERATING AN ARRAY ---
-	// Method 1: Classic for loop with len()
-	// len(array) returns the number of elements.
-	fmt.Println("\nIterating with index:")
-	for i := 0; i < len(primes); i++ {
-		fmt.Printf("  primes[%d] = %d\n", i, primes[i])
+	fmt.Println("Range iteration:")
+	for i, value := range primes {
+		fmt.Printf("  primes[%d] = %d\n", i, value)
 	}
 
-	// Method 2: range (preferred — cleaner and safer)
-	fmt.Println("\nIterating with range:")
-	for i, v := range primes {
-		fmt.Printf("  primes[%d] = %d\n", i, v)
-	}
-
-	// --- MULTI-DIMENSIONAL ARRAYS ---
-	// Arrays of arrays — useful for grids, matrices, game boards.
-	// [2][3]int = 2 rows, 3 columns.
-	var matrix [2][3]int
-	matrix[0][0] = 1
-	matrix[0][1] = 2
-	matrix[1][2] = 3
-
-	fmt.Printf("\nMatrix: %+v\n", matrix) // [[1 2 0] [0 0 3]]
-
-	// --- ARRAYS ARE VALUE-TYPES ---
-	// When you assign an array to another variable, Go makes a FULL COPY.
-	// Modifying the copy does NOT affect the original.
 	original := [3]int{10, 20, 30}
-	copied := original // Full copy — NOT a reference
+	copied := original
 	copied[0] = 99
-	fmt.Printf("\nOriginal: %v (unchanged)\n", original) // [10 20 30]
-	fmt.Printf("Copy:     %v (modified)\n", copied)      // [99 20 30]
 
-	// KEY TAKEAWAY:
-	// - Arrays have FIXED size — the size is part of the type
-	// - Arrays are VALUE TYPES — assignment creates a full copy
-	// - In practice, Go programmers almost always use SLICES (next lesson)
-	//   because slices are dynamic and pass by reference to the underlying data
+	fmt.Printf("\nOriginal: %v\n", original)
+	fmt.Printf("Copy:     %v\n", copied)
+
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("🚀 NEXT UP: DS.2 slices")
-	fmt.Println("   Current: DS.1 (arrays)")
+	fmt.Println("NEXT UP: DS.2 slices")
+	fmt.Println("Current: DS.1 (arrays)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/03-data-structures/2-slices/main.go
+++ b/03-data-structures/2-slices/main.go
@@ -1,96 +1,58 @@
 // Copyright (c) 2026 Rasel Hossen
-// Licensed under The Go Engineer License v1.0
-// Commercial use is prohibited without permission.
+// See LICENSE for usage terms.
 
 package main
 
 import "fmt"
 
-// ============================================================================
-// Section 03: Data Structures — Slices
-// Level: Beginner → Intermediate
-// ============================================================================
+// Section 03: Data Structures - Slices
 //
-// WHAT YOU'LL LEARN:
-//   - Slices are Go's primary collection type (used 100x more than arrays)
-//   - Slice internals: pointer + length + capacity (the slice header)
-//   - make() for pre-allocating slices
-//   - append() for growing slices dynamically
-//   - Slice expressions (sub-slicing)
-//   - How capacity growth works under the hood
+// Mental model:
+// A slice is a small descriptor that points at an underlying array. It tracks
+// a current length and a capacity for growth.
 //
-// ENGINEERING DEPTH:
-//   A Slice is purely a 24-byte struct (known as a Slice Header) containing:
-//   a Pointer to an underlying contiguous array, an `int` for the Length, and an
-//   `int` for the Capacity. This allows slices to be passed into functions incredibly
-//   cheaply (copying just 24 bytes), while still allowing the function to mutate
-//   the underlying shared memory. This is Go's secret to lightning-fast
-//   data processing.
+// In this lesson:
+// - create slice literals
+// - use len and cap
+// - use make to pre-allocate space
+// - grow a slice with append
+// - take a smaller view with slicing syntax
 //
-// RUN: go run ./03-data-structures/2-slices
-// ============================================================================
+// Watch for:
+// - append returns the updated slice value
+// - slicing a slice does not copy the data by default
+//
+// Run: go run ./03-data-structures/2-slices
 
 func main() {
+	fmt.Println("=== Slices ===")
 
-	// --- SLICE LITERAL ---
-	// A slice looks like an array literal but WITHOUT a size in the brackets.
-	// []string (slice) vs [3]string (array) — the absence of a number is key.
-	//
-	// Under the hood, a slice is a HEADER with 3 fields:
-	//   1. Pointer — to the first element of the underlying array
-	//   2. Length  — number of elements currently in the slice
-	//   3. Capacity — total space allocated in the underlying array
 	names := []string{"Alice", "John", "Mark"}
-	fmt.Println("Names:", names)
-	fmt.Printf("  len=%d, cap=%d\n", len(names), cap(names))
+	fmt.Printf("names: %v\n", names)
+	fmt.Printf("len=%d cap=%d\n", len(names), cap(names))
 
-	// --- MAKE: Pre-allocate with length and capacity ---
-	// Syntax: make([]Type, length, capacity)
-	//
-	// - length: how many elements exist RIGHT NOW (initialized to zero values)
-	// - capacity: how much space is pre-allocated (avoids re-allocations)
-	//
-	// WHY PRE-ALLOCATE?
-	// If you know you'll store ~1000 items, pre-allocate with make([]int, 0, 1000).
-	// Without it, Go will re-allocate and copy the data every time the slice grows,
-	// which is expensive for large collections.
-	items := make([]int, 3, 5) // 3 elements exist (all 0), space for 5 total
-	fmt.Printf("\nItems: %+v, Len: %d, Cap: %d\n", items, len(items), cap(items))
+	// make creates the backing array and the first slice view.
+	items := make([]int, 0, 3)
+	fmt.Printf("\nitems: %v len=%d cap=%d\n", items, len(items), cap(items))
 
-	// --- APPEND: Growing a slice ---
-	// append() adds elements to the end of a slice.
-	// IMPORTANT: append() returns a NEW slice header. Always reassign:
-	//   items = append(items, value)   ← correct
-	//   append(items, value)           ← WRONG! returned slice is discarded
-	items = append(items, 1) // len=4, cap=5 (fits within capacity)
-	items = append(items, 2) // len=5, cap=5 (fits within capacity)
-	items = append(items, 3) // len=6, cap=10! Capacity DOUBLED
+	items = append(items, 10)
+	items = append(items, 20)
+	items = append(items, 30)
+	fmt.Printf("after three appends: %v len=%d cap=%d\n", items, len(items), cap(items))
 
-	// CAPACITY GROWTH: When append exceeds capacity, Go allocates a NEW
-	// underlying array (roughly 2x the size) and copies all elements over.
-	// This is O(n) when it happens, but amortized O(1) over many appends.
-	items = append(items, 4) // len=7, cap=10 (still fits)
-	fmt.Printf("Items: %+v, Len: %d, Cap: %d\n", items, len(items), cap(items))
+	// This append forces growth because the original capacity was 3.
+	items = append(items, 40)
+	fmt.Printf("after growth append: %v len=%d cap=%d\n", items, len(items), cap(items))
 
-	// --- SLICE EXPRESSIONS (Sub-slicing) ---
-	// Syntax: slice[low:high]
-	//   - low: starting index (inclusive)
-	//   - high: ending index (exclusive)
-	//   - Omit low = 0, Omit high = len(slice)
-	//
-	// CRITICAL: Sub-slices SHARE the same underlying array.
-	// Modifying the sub-slice modifies the original!
-	sub := items[3:7]
-	fmt.Printf("\nSub-slice items[3:7]: %+v\n", sub)
+	// Slicing creates a smaller view.
+	firstTwo := items[:2]
+	fmt.Printf("\nfirstTwo := items[:2] -> %v\n", firstTwo)
 
-	// KEY TAKEAWAY:
-	// - Slices are dynamic, reference-based collections — USE THESE, not arrays
-	// - The slice header has 3 fields: pointer, length, capacity
-	// - Always reassign when using append: s = append(s, value)
-	// - Pre-allocate with make() when you know the approximate size
-	// - Sub-slices share memory — be careful with mutations
+	lastTwo := items[2:]
+	fmt.Printf("lastTwo := items[2:] -> %v\n", lastTwo)
+
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("🚀 NEXT UP: DS.3 maps")
-	fmt.Println("   Current: DS.2 (slices)")
+	fmt.Println("NEXT UP: DS.3 maps")
+	fmt.Println("Current: DS.2 (slices)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/03-data-structures/3-maps/main.go
+++ b/03-data-structures/3-maps/main.go
@@ -1,75 +1,62 @@
 // Copyright (c) 2026 Rasel Hossen
-// Licensed under The Go Engineer License v1.0
-// Commercial use is prohibited without permission.
+// See LICENSE for usage terms.
 
-// RUN: go run ./03-data-structures/3-maps
 package main
 
 import "fmt"
 
-/*
-=============================================================================
-ENGINEERING DEPTH: Maps Internal Mechanics
-=============================================================================
-- TIME COMPLEXITY: $O(1)$ amortized lookup/insert.
-- MEMORY MODEL: Under the hood, a Go map is a pointer to an `hmap` struct.
-  It manages an array of buckets (each holding up to 8 key-value pairs).
-- HASH COLLISIONS: If a bucket overflows, Go chains a new bucket to it.
-- GROWING: When the load factor hits 6.5 (6.5 items per bucket), the map
-  allocates a new underlying array double the size and incrementally migrates
-  keys to avoid latency spikes (evacuation).
-- CONCURRENCY: Maps are NOT thread-safe. A concurrent read/write will trigger
-  a fatal panic. Use `sync.Mutex` or `sync.Map` for concurrent access.
-=============================================================================
-*/
+// Section 03: Data Structures - Maps
+//
+// Mental model:
+// A map connects keys to values. You use it when lookup by name matters more
+// than keeping items in order.
+//
+// In this lesson:
+// - create map literals
+// - add and update entries
+// - check whether a key exists with comma-ok
+// - remove an entry with delete
+// - build an empty map with make
+//
+// Watch for:
+// - reading a missing key gives the zero value
+// - use comma-ok when you need to know whether the key was really present
+//
+// Run: go run ./03-data-structures/3-maps
 
 func main() {
+	fmt.Println("=== Maps ===")
 
-	// Idiomatic pattern: make(map[KeyType]ValueType, capacityHint)
-	// Providing a capacity hint prevents expensive runtime re-allocations
-	// when you know roughly how many items will be stored.
-	// 1. Map Literal Initialization
-	// This directly allocates the `hmap` struct and hashes the initial keys.
 	studentGrades := map[string]int{
 		"Alice": 90,
 		"James": 85,
 		"Dan":   60,
 	}
-	fmt.Printf("%+v\n", studentGrades)
+	fmt.Printf("initial: %v\n", studentGrades)
 
-	// 2. Map Assignment
-	// Go hashes "Alice", finds her bucket, and overwrites the integer bytes.
 	studentGrades["Alice"] = 95
-	fmt.Printf("%+v\n", studentGrades)
+	studentGrades["Mary"] = 88
+	fmt.Printf("after updates: %v\n", studentGrades)
 
-	// 3. The "Comma-Ok" Idiom
-	// Accessing a missing key returns the zero-value (0 for int).
-	// To distinguish between "Alice scored a 0" and "Alice is not in the map",
-	// Go returns a secondary boolean.
-	alice, ok := studentGrades["Alice"]
-	if ok {
-		fmt.Printf("Alice: %+v\n", alice)
-	}
+	// Missing keys return the zero value for the value type.
+	fmt.Printf("\nMissing score without comma-ok: %d\n", studentGrades["Zack"])
 
-	// 4. Inline Comma-Ok Check
-	// This scopes the `value` and `ok` variables strictly to the `if` block,
-	// preventing namespace pollution.
-	key := "James"
-	if value, ok := studentGrades[key]; ok {
-		fmt.Printf("%s: %+v\n", key, value)
-	}
+	aliceScore, aliceExists := studentGrades["Alice"]
+	fmt.Printf("Alice exists? %v, score: %d\n", aliceExists, aliceScore)
 
-	// 5. The Builtin delete() Function
-	// This doesn't shrink the map's capacity! It merely flags the bucket
-	// slot as "empty", keeping the memory allocated for future inserts.
-	delete(studentGrades, "Alice")
+	zackScore, zackExists := studentGrades["Zack"]
+	fmt.Printf("Zack exists? %v, score: %d\n", zackExists, zackScore)
 
-	fmt.Printf("%+v\n", studentGrades)
+	delete(studentGrades, "Dan")
+	fmt.Printf("\nafter delete(\"Dan\"): %v\n", studentGrades)
 
-	configs := make(map[string]int)
-	fmt.Printf("%+v %T\n", configs, configs)
+	settings := make(map[string]string)
+	settings["theme"] = "dark"
+	settings["timezone"] = "UTC"
+	fmt.Printf("settings: %v\n", settings)
+
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("🚀 NEXT UP: DS.4 pointers")
-	fmt.Println("   Current: DS.3 (maps)")
+	fmt.Println("NEXT UP: DS.4 pointers")
+	fmt.Println("Current: DS.3 (maps)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/03-data-structures/4-pointers/main.go
+++ b/03-data-structures/4-pointers/main.go
@@ -1,122 +1,62 @@
 // Copyright (c) 2026 Rasel Hossen
-// Licensed under The Go Engineer License v1.0
-// Commercial use is prohibited without permission.
+// See LICENSE for usage terms.
 
 package main
 
 import "fmt"
 
-// ============================================================================
-// Section 03: Data Structures — Pointers
-// Level: Beginner → Intermediate
-// ============================================================================
+// Section 03: Data Structures - Pointers
 //
-// WHAT YOU'LL LEARN:
-//   - What a pointer IS: a variable that stores a memory address
-//   - The & operator (address-of) and * operator (dereference)
-//   - Pass-by-value vs pass-by-reference
-//   - Why pointers exist: mutation, large struct efficiency, nil-ability
-//   - Pointer safety in Go (no pointer arithmetic)
+// Mental model:
+// A pointer stores the address of a value. You use it when you need to update
+// the original stored value instead of a copy.
 //
-// ENGINEERING DEPTH:
-//   A pointer is just an integer holding the numeric hexadecimal address of a
-//   byte in your computer's RAM (e.g. `0xc0000a6018`). In C++, you can freely
-//   add or subtract from this integer (Pointer Arithmetic), which is incredibly
-//   fast but is the #1 cause of catastrophic security exploits globally (buffer
-//   overflows). Go explicitly bans Pointer Arithmetic. You get raw memory performance
-//   without the devastating security risks.
+// In this lesson:
+// - create a pointer with &
+// - read and write through a pointer with *
+// - compare copy-based updates with pointer-based updates
+// - handle a nil pointer safely
+// - connect pointers to slice elements, which the Section 03 milestone needs
 //
-// RUN: go run ./03-data-structures/4-pointers
-// ============================================================================
-
-// modifyValue receives a COPY of the int.
-// Any changes to "val" inside this function do NOT affect the original.
-// This is "pass by value" — Go's default behavior for all types.
-func modifyValue(val int) {
-	val = val * 10
-	fmt.Printf("  Inside modifyValue: val = %d (this is a copy)\n", val)
-}
-
-// modifyPointer receives a POINTER to the int.
-// The pointer holds the MEMORY ADDRESS of the original variable.
-// Using *val (dereference) modifies the original variable.
-func modifyPointer(val *int) {
-	// Always check for nil before dereferencing.
-	// Dereferencing a nil pointer causes a runtime PANIC (crash).
-	if val == nil {
-		fmt.Println("  val is nil — cannot dereference")
-		return
-	}
-	*val = *val * 10 // *val reads/writes the value AT the address
-	fmt.Printf("  Inside modifyPointer: *val = %d (original modified!)\n", *val)
-}
+// Watch for:
+// - dereferencing a nil pointer will panic
+// - pointers are useful, but not every value needs one
+//
+// Run: go run ./03-data-structures/4-pointers
 
 func main() {
+	fmt.Println("=== Pointers ===")
 
-	// --- PASS BY VALUE (Default) ---
-	fmt.Println("=== Pass by Value ===")
-	num := 10
-	modifyValue(num)
-	fmt.Printf("  After modifyValue: num = %d (unchanged!)\n", num) // Still 10
+	score := 50
+	scorePtr := &score
 
-	fmt.Println()
+	fmt.Printf("score value:   %d\n", score)
+	fmt.Printf("score address: %p\n", &score)
+	fmt.Printf("scorePtr:      %p\n", scorePtr)
+	fmt.Printf("*scorePtr:     %d\n", *scorePtr)
 
-	// --- PASS BY POINTER (Reference) ---
-	// The & operator gets the MEMORY ADDRESS of a variable.
-	// &num means "the address where num is stored in memory"
-	fmt.Println("=== Pass by Pointer ===")
-	modifyPointer(&num)                                             // Pass the ADDRESS of num
-	fmt.Printf("  After modifyPointer: num = %d (changed!)\n", num) // Now 100
+	// Changing a copied value does not affect the original.
+	scoreCopy := score
+	scoreCopy = 95
+	fmt.Printf("\nAfter changing the copy: score=%d scoreCopy=%d\n", score, scoreCopy)
 
-	fmt.Println()
+	// Changing through the pointer updates the original.
+	*scorePtr = 95
+	fmt.Printf("After changing through the pointer: score=%d\n", score)
 
-	// --- POINTER BASICS ---
-	// A pointer variable stores a memory address, not a value.
-	//
-	// Type notation:
-	//   *int   = "pointer to an int" (the type)
-	//   &grade = "address of grade"  (create a pointer)
-	//   *ptr   = "value at address"  (dereference — read/write the value)
-	fmt.Println("=== Pointer Basics ===")
-	grade := 50
-	gradePtr := &grade // gradePtr now holds the memory address of grade
+	// Pointers work well with slice elements too.
+	phones := []string{"111-2222", "333-4444", "555-6666"}
+	bobPhone := &phones[1]
+	*bobPhone = "333-9999"
+	fmt.Printf("\nPhones after pointer update: %v\n", phones)
 
-	fmt.Printf("  grade value:   %d\n", grade)                    // 50
-	fmt.Printf("  grade address: %p\n", &grade)                   // 0xc0000b4008 (varies)
-	fmt.Printf("  gradePtr:      %p (same address)\n", gradePtr)  // Same as above
-	fmt.Printf("  *gradePtr:     %d (dereferenced)\n", *gradePtr) // 50
+	var optionalScore *int
+	if optionalScore == nil {
+		fmt.Println("optionalScore is nil, so there is nothing to dereference yet.")
+	}
 
-	// Modifying through the pointer changes the original
-	*gradePtr = 95
-	fmt.Printf("  After *gradePtr = 95: grade = %d\n", grade) // 95
-
-	// --- WHEN TO USE POINTERS ---
-	//
-	// 1. MUTATION: When a function needs to modify the caller's variable
-	//      func UpdateUser(u *User) { u.Name = "new" }
-	//
-	// 2. LARGE STRUCTS: Passing a 1MB struct by value copies 1MB to the stack.
-	//      Passing a pointer copies only 8 bytes (the address).
-	//      Rule of thumb: if a struct has more than 3-4 fields, use a pointer.
-	//
-	// 3. NIL-ABILITY: Pointers can be nil. Regular values cannot.
-	//      var p *int = nil  ← valid (means "no value")
-	//      var n int = nil   ← COMPILE ERROR
-	//
-	// 4. SHARING: When multiple parts of the code need the same data.
-	//
-	// SAFETY: Go has NO pointer arithmetic (unlike C/C++).
-	// You cannot do p++ to move to the next memory address.
-	// This eliminates an entire class of memory corruption bugs.
-
-	// KEY TAKEAWAY:
-	// - & creates a pointer (gets the address)
-	// - * dereferences a pointer (accesses the value at the address)
-	// - Go is pass-by-value by default. Use pointers to modify originals.
-	// - Always check for nil before dereferencing.
-	// - Go pointers are safe — no arithmetic, no manual memory management.
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("🚀 NEXT UP: DS.5 slices-2")
-	fmt.Println("   Current: DS.4 (pointers)")
+	fmt.Println("NEXT UP: DS.5 slice-sharing")
+	fmt.Println("Current: DS.4 (pointers)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/03-data-structures/5-slices-2/main.go
+++ b/03-data-structures/5-slices-2/main.go
@@ -1,30 +1,28 @@
 // Copyright (c) 2026 Rasel Hossen
-// Licensed under The Go Engineer License v1.0
-// Commercial use is prohibited without permission.
+// See LICENSE for usage terms.
 
 package main
 
 import "fmt"
 
-// ============================================================================
 // Section 03: Data Structures - Slice Sharing and Capacity
-// Level: Intermediate
-// ============================================================================
 //
-// WHAT YOU'LL LEARN:
-//   - How sub-slices share a backing array
-//   - How len and cap change when you slice a slice
-//   - How append can still mutate the original data when capacity remains
-//   - How to break the shared link by copying into a new slice
+// Mental model:
+// A sub-slice is usually just another view over the same backing array.
+// That keeps slicing cheap, but it also means two slices can still affect the
+// same stored data.
 //
-// ENGINEERING DEPTH:
-//   When you create a sub-slice like `s[2:5]`, Go usually allocates no new
-//   memory. It creates a new slice header that still points into the same
-//   backing array. That is why slicing is cheap and also why a small view can
-//   accidentally mutate or keep alive a much larger block of data.
+// In this lesson:
+// - inspect len and cap after slicing
+// - watch a sub-slice mutate the original data
+// - watch append reuse spare capacity
+// - break the shared link by copying into a new slice
 //
-// RUN: go run ./03-data-structures/5-slices-2
-// ============================================================================
+// Watch for:
+// - a small sub-slice can still have a large capacity
+// - if append fits, it can still write into the original array
+//
+// Run: go run ./03-data-structures/5-slices-2
 
 func main() {
 	fmt.Println("=== Slice Sharing and Capacity ===")
@@ -50,20 +48,18 @@ func main() {
 	fmt.Printf("After append(growth, 200), original: %v\n", original)
 
 	// Copying into a new slice breaks the shared link.
-	independent := append([]int(nil), original[2:4]...)
+	independent := make([]int, len(original[2:4]))
+	for i, value := range original[2:4] {
+		independent[i] = value
+	}
 	fmt.Printf("\nIndependent copy before change: %v\n", independent)
 
 	independent[0] = 500
 	fmt.Printf("Independent copy after change:  %v\n", independent)
 	fmt.Printf("Original after copy change:     %v\n", original)
 
-	// KEY TAKEAWAY:
-	// - Sub-slicing is fast because it usually shares the original backing array.
-	// - len tells you how much of the view you can read now; cap tells you how far the shared array extends.
-	// - append can still mutate the original if the sub-slice has spare capacity.
-	// - Copy into a new slice when you need an isolated view.
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("NEXT UP: DS.6 contact-manager")
+	fmt.Println("NEXT UP: DS.6 contact-directory")
 	fmt.Println("Current: DS.5 (slice sharing and capacity)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/03-data-structures/6-contact-manager/README.md
+++ b/03-data-structures/6-contact-manager/README.md
@@ -17,7 +17,7 @@ Complete these first:
 - `DS.2` slices
 - `DS.3` maps
 - `DS.4` pointers
-- `DS.5` advanced slicing
+- `DS.5` slice sharing and capacity
 
 ## What You Will Build
 
@@ -28,6 +28,14 @@ Implement a small contact directory that:
 3. updates stored data through a pointer to a slice element
 4. prints a small demonstration flow in `main()`
 5. stays inside the concepts already taught in Section 03
+
+## Why This Milestone Avoids Structs
+
+Structs matter, but they belong to a later section.
+
+This milestone is intentionally simpler than a real application because the goal here is to prove
+that the learner understands slices, maps, pointers, shared indexing, and persistent updates before
+adding new modeling tools.
 
 ## Files
 

--- a/03-data-structures/6-contact-manager/_starter/main.go
+++ b/03-data-structures/6-contact-manager/_starter/main.go
@@ -1,6 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// Licensed under The Go Engineer License v1.0
-// Commercial use is prohibited without permission.
+// See LICENSE for usage terms.
 
 package main
 

--- a/03-data-structures/6-contact-manager/main.go
+++ b/03-data-structures/6-contact-manager/main.go
@@ -1,30 +1,27 @@
 // Copyright (c) 2026 Rasel Hossen
-// Licensed under The Go Engineer License v1.0
-// Commercial use is prohibited without permission.
+// See LICENSE for usage terms.
 
 package main
 
 import "fmt"
 
-// ============================================================================
 // Section 03: Data Structures - Contact Directory (Exercise)
-// Level: Beginner -> Intermediate
-// ============================================================================
 //
-// WHAT YOU'LL LEARN:
-//   - Combining slices, maps, and pointers in one small program
-//   - Using a map to find slice positions quickly
-//   - Taking a pointer to a slice element so an update persists
-//   - Keeping the exercise inside Section 03 concepts only
+// Mental model:
+// This milestone is intentionally plain. It proves slices, maps, and pointers
+// directly before the curriculum moves on to functions, structs, and more
+// layered design.
 //
-// ENGINEERING DEPTH:
-//   This exercise intentionally does NOT use helper functions, methods, or a
-//   struct-heavy design yet. The goal is to prove today's tools directly:
-//   slices for ordered storage, a map for O(1) lookup of slice positions, and
-//   pointers for updates that must stick.
+// In this lesson:
+// - keep one contact's data aligned across parallel slices
+// - use a map for O(1) lookup of the slice index
+// - update a stored phone number through a pointer
 //
-// RUN: go run ./03-data-structures/6-contact-manager
-// ============================================================================
+// Watch for:
+// - all three slices must stay index-aligned
+// - only take the pointer after you know the lookup succeeded
+//
+// Run: go run ./03-data-structures/6-contact-manager
 
 func main() {
 	fmt.Println("=== Contact Directory ===")
@@ -89,9 +86,8 @@ func main() {
 		fmt.Println("Zack not found.")
 	}
 
-	// KEY TAKEAWAY:
-	// - Slices hold the ordered contact data.
-	// - The map tells us where each contact lives in those slices.
-	// - A pointer to a slice element lets an update persist.
-	// - This milestone stays intentionally simple so the data-structure choices stay visible.
+	fmt.Println("\n---------------------------------------------------")
+	fmt.Println("SECTION COMPLETE: DS.6 contact-directory")
+	fmt.Println("NEXT UP: FE.1 functions")
+	fmt.Println("---------------------------------------------------")
 }

--- a/03-data-structures/README.md
+++ b/03-data-structures/README.md
@@ -13,6 +13,14 @@ By the end of Section 03, you should be comfortable with:
 - pointers for mutation and nil-aware references
 - combining those pieces in one small in-memory program without leaning on later-section abstractions
 
+## Zero-Magic Rule
+
+This section intentionally stops before later-section abstractions like helper-function design,
+struct-heavy modeling, methods, and package layering.
+
+That means the Section 03 milestone should prove slices, maps, and pointers directly rather than
+smuggling in ideas from later sections.
+
 ## Beta Stage Ownership
 
 This section belongs to [1 Language Fundamentals](../docs/stages/01-language-fundamentals.md).
@@ -42,7 +50,7 @@ If you only want the live milestone, review these first:
 - `DS.2` slices
 - `DS.3` maps
 - `DS.4` pointers
-- `DS.5` advanced slicing
+- `DS.5` slice sharing and capacity
 
 ## Section Map
 

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -557,8 +557,8 @@
     {
       "id": "DS.5",
       "section_id": "s03",
-      "slug": "advanced-slicing",
-      "title": "Advanced Slicing",
+      "slug": "slice-sharing-and-capacity",
+      "title": "Slice Sharing and Capacity",
       "type": "lesson",
       "subtype": "pattern",
       "level": "core",
@@ -590,8 +590,8 @@
     {
       "id": "DS.6",
       "section_id": "s03",
-      "slug": "contact-manager",
-      "title": "Contact Manager",
+      "slug": "contact-directory",
+      "title": "Contact Directory",
       "type": "exercise",
       "subtype": "",
       "level": "core",


### PR DESCRIPTION
## Summary
- normalize the Section 03 inline lesson headers around mental model, lesson goals, and watch-fors
- remove hidden future-section concepts from the DS.4 and DS.5 teaching surfaces
- replace the redundant commercial-use line with a LICENSE reference and align the Section 03 metadata/docs with the rebuilt lesson names

## Verification
- go run ./03-data-structures/1-array
- go run ./03-data-structures/2-slices
- go run ./03-data-structures/3-maps
- go run ./03-data-structures/4-pointers
- go run ./03-data-structures/5-slices-2
- go run ./03-data-structures/6-contact-manager
- go run ./03-data-structures/6-contact-manager/_starter
- go run ./scripts/validate_curriculum.go
- git diff --check

Closes #273
Part of #274