### PR TITLE
Freeze README-first lesson delivery standard

### DIFF
--- a/docs/v2/02-LEARNER-MODEL.md
+++ b/docs/v2/02-LEARNER-MODEL.md
@@ -30,7 +30,8 @@ Profile:
 Needs:
 
 - careful pacing
-- readable inline comments
+- lesson READMEs that explain code line by line or in very small chunks, with depth adjusted by stage
+- readable inline comments for local mechanics inside the code itself
 - repeated reinforcement
 - small but visible exercises
 - fewer hidden assumptions
@@ -142,6 +143,7 @@ The curriculum should assume extra support is needed at these transitions:
 This learner model implies the following product rules:
 
 - early sections must stay concrete and confidence-building
+- learner-facing lessons should use README-first explanation while keeping runnable code clean
 - advanced sections must clearly state prerequisites
 - projects should grow in complexity gradually
 - fast-track learners should be able to skip repetition without skipping validation

--- a/docs/v2/04-LESSON-SPEC.md
+++ b/docs/v2/04-LESSON-SPEC.md
@@ -71,7 +71,7 @@ The default lesson layout should be:
 NN-section-name/
   [optional-subgraph/]N-lesson-name/
     main.go
-    README.md        # optional for complex lessons
+    README.md        # required for learner-facing lessons
     main_test.go     # optional when testable behavior adds value
     testdata/        # optional when fixtures matter
 ```
@@ -116,29 +116,71 @@ Tell the learner what to do next:
 - exercise
 - section checkpoint
 
+## Teaching Surface Rule
+
+For beta, the teaching surface should change with learner needs.
+
+Use this rule:
+
+- `main.go` is the runnable and inspectable code surface
+- `README.md` is the primary explanation surface for learner-facing lessons
+- inline comments should explain local mechanics, boundaries, and non-obvious reasoning
+- deep walkthroughs, line-by-line explanation, runtime-model framing, and "why this line exists"
+  guidance should live in the README rather than bloating the source header
+
+This keeps the code readable while still giving beginners enough explanation to answer:
+
+- what is happening
+- why it is happening
+- how the code changes behavior
+- what would break if a line or step changed
+
 ## Code Header Contract
 
-Every lesson entry file should keep the existing project strengths and include:
+Every lesson entry file should stay lean and include:
 
+- copyright line
+- license pointer
 - section and lesson title
-- level
-- "what you'll learn"
-- "engineering depth"
+- one short mental-model or focus note
 - run command
 
-The current code standards are a good baseline. v2 should standardize them rather than replacing
-them with a totally new style.
+Do not use the code header as the main home for:
+
+- long objective lists
+- level labels
+- engineering-depth prose
+- repeated section-level background
+
+Those explanations belong in the learner-facing README and metadata.
 
 ## When A Lesson Needs A README
 
-A lesson should include `README.md` when:
+A lesson must include `README.md` when:
+
+- the lesson is part of the learner-facing curriculum
+- the learner benefits from line-by-line or small-chunk explanation to follow the example
+- the lesson introduces a new mental model, runtime behavior, boundary, or design move that needs
+  more than short inline comments
+
+A lesson should also include `README.md` when:
 
 - runtime setup is non-trivial
 - the lesson has multiple files or commands
 - diagrams, tables, or structured comparisons help understanding
 - the learner needs troubleshooting help beyond inline comments
 
-Otherwise, the code file should remain the primary teaching surface.
+For lessons with a README, the README should usually own:
+
+- mission and prerequisites
+- mental model
+- the walkthrough of the code line by line or in small logical chunks
+- common questions and failure points
+- production relevance and next step
+
+The code file should remain mandatory and runnable after the docs.
+README-first does not mean prose-only. It means the explanation comes first and the code remains the
+required proof surface.
 
 ## When A Lesson Needs Tests
 
@@ -183,4 +225,5 @@ A lesson is ready for v2 when:
 - the metadata matches the lesson reality
 - the next step is obvious
 - the production relevance is explicit
+- the explanation depth matches the intended learner, with README support where needed
 - the lesson is small enough to be teachable and large enough to matter

--- a/docs/v2/10-DOCS-NAVIGATION-SYSTEM.md
+++ b/docs/v2/10-DOCS-NAVIGATION-SYSTEM.md
@@ -135,8 +135,8 @@ Primary job:
 
 - teach one item and point clearly to the next step
 
-The code file remains the primary teaching surface for most lessons.
-An additional `README.md` exists only when the lesson needs more structured context.
+The lesson README should be the primary explanation surface for learner-facing lessons.
+The runnable code file remains the primary execution surface.
 
 Every lesson should still expose:
 
@@ -144,6 +144,11 @@ Every lesson should still expose:
 - how to run or verify it
 - why it matters
 - what to do next
+
+Practical rule:
+
+- `README.md` should carry the deeper walkthrough first
+- `main.go` should stay readable, runnable, and required
 
 ### 6. Exercise, Checkpoint, And Project README
 
@@ -172,7 +177,7 @@ Use these ownership boundaries to reduce duplication.
 | `LEARNING-PATH.md` or v2 equivalent | route selection, path rules, skip rules, validation floors | full curriculum inventory, contributor internals |
 | `docs/curriculum/README.md` or v2 equivalent | phase and section map, high-level structure | path-selection advice in detail |
 | `NN-section/README.md` | section entry guidance, outputs, section flow | full repo overview |
-| lesson header / lesson README | item-specific teaching and next step | full section map |
+| lesson README + lesson code file | item-specific teaching, walkthrough, and next step | full section map |
 | exercise/checkpoint/project README | requirements, verification, milestone meaning | unrelated section-wide background |
 
 ## Required Section README Contract

--- a/docs/v2/appendix/DECISION-LOG.md
+++ b/docs/v2/appendix/DECISION-LOG.md
@@ -15,6 +15,18 @@ Each decision should capture:
 
 ## Working Decisions
 
+### 2026-04-12: learner-facing lessons should use README-first explanation with cleaner code files
+
+- Status: Working decision
+- Why it matters: the zero-to-engineer learner promise requires more explanation than source-file
+  headers and scattered inline comments can carry cleanly
+- Alternatives:
+  - keep code-first lessons as the default everywhere and rely on inline comments
+    - make learner-facing READMEs the primary explanation surface while keeping runnable code
+      smaller, clearer, and still mandatory
+- Follow-up: revise the lesson spec and lesson template, add a canonical lesson README template, and
+  retrofit rebuilt sections to the new contract
+
 ### 2026-04-09: beta is a learner-facing architecture redesign, not just alpha plus polish
 
 - Status: Working decision

--- a/docs/v2/prototype/LESSON-FEP-4-CUSTOM-ERRORS-WRAPPING.md
+++ b/docs/v2/prototype/LESSON-FEP-4-CUSTOM-ERRORS-WRAPPING.md
@@ -161,6 +161,13 @@ This does **not** mean pattern lessons never need READMEs.
 It means this particular prototype lesson proves that the default v2 lesson can still live in code
 when the scope is well bounded.
 
+Beta note:
+
+- this prototype decision remains valid as a prototype proof
+- later beta implementation may still adopt README-first explanation for learner-facing lessons
+  where line-by-line support and clearer delivery are more important than proving a code-first
+  default
+
 ## Canonical Anatomy
 
 This lesson should prove the five required anatomy layers.
@@ -266,6 +273,11 @@ For this canonical lesson, use:
 This establishes an important v2 default:
 
 - if the code can teach clearly on its own, keep the lesson lightweight
+
+Beta adjustment:
+
+- for learner-facing lessons, the teaching system may still prefer a README-first walkthrough while
+  keeping the source file itself lean and runnable
 
 ## Lesson-Spec Validation Result
 

--- a/docs/v2/templates/LESSON-README-TEMPLATE.md
+++ b/docs/v2/templates/LESSON-README-TEMPLATE.md
@@ -1,0 +1,125 @@
+# V2 Lesson README Template
+
+## Purpose
+
+This document defines the canonical learner-facing README shape for beta lessons.
+
+It exists because learner-facing lessons should not force the source file to carry all of the
+explanation. The README is where we answer the learner's "what", "why", and "how" questions
+without making `main.go` louder than the lesson itself.
+
+## When To Use This Template
+
+Use this template for:
+
+- learner-facing lessons
+- any lesson where learners benefit from line-by-line or very small chunk explanation
+
+The explanation depth can change by stage, but the overall division of labor should stay the same:
+
+- code file = runnable implementation
+- README = teaching walkthrough
+
+## Canonical README Shape
+
+Every beta lesson README should usually include:
+
+1. mission
+2. prerequisites
+3. mental model
+4. why this lesson exists now
+5. run instructions
+6. code walkthrough
+7. common questions or mistakes
+8. production relevance
+9. next step
+
+## Canonical README Skeleton
+
+~~~md
+# Lesson Title
+
+## Mission
+
+One short paragraph explaining what the learner is about to understand and why it matters here.
+
+## Prerequisites
+
+- the prior lesson or concepts the learner should already know
+
+## Mental Model
+
+Name the framing idea the learner should hold while reading the code.
+
+## Why This Lesson Exists Now
+
+Explain why this lesson appears at this point in the section or stage and what later confusion it
+prevents.
+
+## Run Instructions
+
+~~~bash
+go run ./NN-section-name/N-lesson-name
+~~~
+
+Optional:
+
+~~~bash
+go test ./NN-section-name/N-lesson-name
+~~~
+
+## Code Walkthrough
+
+Walk through the code line by line or in small logical chunks.
+
+Recommended rule:
+
+- explain each line when the step matters on its own
+- only group lines when they form one inseparable statement or one tiny setup step
+
+Useful subheadings:
+
+### Imports And Setup
+
+What each import or setup line is doing.
+
+### Main Flow
+
+Walk the learner through the example in order.
+
+### Why This Update, Check, Loop, Or Branch Exists
+
+Explain the non-obvious behavior and what would happen if it changed.
+
+## Common Questions
+
+- one likely beginner confusion
+- one runtime-model confusion
+- one "what if I changed this line?" answer
+
+## Production Relevance
+
+State where this idea appears in real Go work and what bad habit or failure mode it helps prevent.
+
+## Next Step
+
+Point to the next lesson, drill, exercise, or checkpoint.
+~~~
+
+## Authoring Rules
+
+- keep the code walkthrough concrete
+- answer "what", "why", and "how", not just "what"
+- prefer small chunks over giant prose walls
+- keep the README honest to the code that actually exists
+- do not turn the README into a second unrelated textbook chapter
+- do not skip the code after the docs; the code is still the required runnable proof surface
+
+## Success Signal
+
+This template is working when a complete beginner can:
+
+- read the code without guessing what each part is doing
+- connect the code to the section mental model
+- tell why the lesson exists at this point in the curriculum
+- move to the next item without feeling like the example contained hidden magic

--- a/docs/v2/templates/LESSON-TEMPLATE.md
+++ b/docs/v2/templates/LESSON-TEMPLATE.md
@@ -10,7 +10,7 @@ contributors can copy without improvising:
 - lesson metadata
 - code header structure
 - lesson anatomy
-- README decision rules
+- README-first explanation rules
 - validator expectations
 
 This template is derived primarily from:
@@ -47,10 +47,13 @@ Default lesson layout:
 ```text
 N-lesson-name/
   main.go
-  README.md        # optional
+  README.md
   main_test.go     # optional
   testdata/        # optional
 ```
+
+The canonical beta lesson template assumes a learner-facing README exists.
+The explanation depth may change by stage, but the README-first teaching contract stays the same.
 
 Use a larger multi-file layout only when the teaching goal genuinely requires it.
 Lesson complexity should not grow just because the file layout allows it.
@@ -100,68 +103,42 @@ Every v2 lesson should start with a metadata draft like this:
 Every lesson entry file should begin with a header shaped like this:
 
 ```go
-// ============================================================================
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+//
 // Section NN: Section Name - Lesson Title
-// Level: Foundation | Core | Stretch | Production
-// ============================================================================
 //
-// WHAT YOU'LL LEARN:
-//   - Primary concept or pattern
-//   - Important supporting concept
-//   - One meaningful tradeoff or habit
+// Mental model:
+// One short sentence naming the learner's framing idea.
 //
-// ENGINEERING DEPTH:
-//   Why this matters in production Go. What failure mode, habit, or workflow
-//   does this lesson prepare the learner for?
-//
-// RUN: go run ./NN-section-name/N-lesson-name
-// ============================================================================
+// Run: go run ./NN-section-name/N-lesson-name
 ```
 
-Keep this header consistent with `CODE-STANDARDS.md`, but prefer v2 field language such as
-`Foundation | Core | Stretch | Production` over the older `Beginner | Intermediate | Advanced`
-labels when drafting new v2 content.
+Keep the header short.
+Do not move the README's deep explanation into the file header.
 
 ## Canonical Lesson Skeleton
 
-Use this as the default code-first lesson shape:
+Use this as the default beta lesson code shape:
 
 ```go
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
 package main
 
 import "fmt"
 
-// ============================================================================
 // Section NN: Section Name - Lesson Title
-// Level: Core
-// ============================================================================
 //
-// WHAT YOU'LL LEARN:
-//   - Primary teaching objective
-//   - Supporting concept
-//
-// ENGINEERING DEPTH:
-//   One practical explanation of where this lesson matters in real Go work.
+// Mental model:
+// One short framing line.
 //
 // RUN: go run ./NN-section-name/N-lesson-name
-// ============================================================================
 
 func main() {
-	// Framing:
-	// Explain what the learner is about to see and why it matters here.
-
-	// Core example:
-	// Show one bounded example that expresses the main idea clearly.
-
-	// Explanation:
-	// Use comments around the example to explain tradeoffs, gotchas, and why
-	// the code is shaped this way.
-
-	// Production relevance:
-	// Connect the example to a real workflow, boundary, or failure mode.
-
-	// Exit ramp:
-	// Point the learner to the next lesson, drill, exercise, or checkpoint.
+	// Use local comments only where they genuinely help the learner understand
+	// a non-obvious mechanic, boundary, or reasoning step.
 
 	fmt.Println("replace with lesson output")
 }
@@ -221,20 +198,35 @@ Default shape:
 - explicit relationship to prior lessons
 - clear warning against overexpansion
 
+## Canonical Lesson README
+
+The beta lesson template requires a learner-facing README.
+
+Use the README to carry the explanation load that would otherwise make the code noisy.
+
+Every lesson README should usually include:
+
+1. mission
+2. prerequisites
+3. mental model
+4. what problem this lesson solves now
+5. run instructions
+6. code walkthrough
+7. common questions or failure points
+8. production relevance
+9. next step
+
+The walkthrough should explain the code line by line or in small logical chunks.
+Group lines only when they belong to one inseparable step.
+
+See `LESSON-README-TEMPLATE.md` for the default shape.
+
 ## README Decision Rules
 
-The default v2 lesson should be:
+Use a full README for learner-facing beta lessons.
 
-- code-first
-
-Add `README.md` only when at least one of these is true:
-
-- runtime setup is non-trivial
-- the lesson uses multiple files or commands
-- a table, diagram, or structured comparison materially helps understanding
-- troubleshooting guidance is necessary beyond inline comments
-
-Do not add a README just to satisfy ceremony.
+README-first does not remove the code requirement.
+The learner should read the explanation first, then run and inspect the code itself.
 
 ## Test Decision Rules
 
@@ -269,7 +261,9 @@ Before calling a lesson draft complete, confirm:
 - the run or test command is real
 - the production relevance is explicit
 - the next step is named clearly in `next_items`
-- README support is intentional, not automatic
+- the README explains the code at the right depth for the intended learner
+- the source file stays readable instead of absorbing the whole explanation burden
+- the code remains a required runnable proof surface after the README
 
 ## Validator Notes
 
@@ -309,6 +303,6 @@ guessing:
 - the metadata shape
 - the file header
 - the lesson anatomy
-- whether a README is needed
+- how the README and code file divide the teaching work
 - what validator expectations the lesson should satisfy
 

--- a/docs/v2/templates/README.md
+++ b/docs/v2/templates/README.md
@@ -12,6 +12,7 @@ implementation work is approved.
 ## Current Templates
 
 - [LESSON-TEMPLATE.md](./LESSON-TEMPLATE.md) - canonical v2 lesson template
+- [LESSON-README-TEMPLATE.md](./LESSON-README-TEMPLATE.md) - canonical learner-facing lesson walkthrough template
 - [EXERCISE-TEMPLATE.md](./EXERCISE-TEMPLATE.md) - canonical v2 guided exercise template
 - [CHECKPOINT-TEMPLATE.md](./CHECKPOINT-TEMPLATE.md) - canonical v2 checkpoint template
 - [MINI-PROJECT-TEMPLATE.md](./MINI-PROJECT-TEMPLATE.md) - canonical v2 mini-project template


### PR DESCRIPTION
## Summary
- freeze the learner-facing lesson contract as README-first across beta lesson delivery
- add a canonical lesson README template and tighten the lesson/header split
- update the learner model, docs navigation, prototype note, and decision log to match

## Why
The current planning docs still leaned too far toward code-first lessons.
For a zero-to-expert learning system, learner-facing lessons need explanation-first docs while keeping code runnable and clean.

## Linked work
- closes #279
- supports #278
- unblocks #280

## Checks
- git diff --check
