### PR TITLE
Retrofit Section 03 to README-first lesson delivery

### DIFF
--- a/03-data-structures/1-array/README.md
+++ b/03-data-structures/1-array/README.md
@@ -1,0 +1,115 @@
+# DS.1 Arrays
+
+## Mission
+
+Learn what an array is in Go and why arrays matter even though slices become the more common tool
+later.
+
+This lesson exists because arrays make one important rule visible early:
+
+- fixed-size values are copied by value
+
+That rule helps the learner understand slices by contrast in the next lesson.
+
+## Prerequisites
+
+- Section entry for `03-data-structures`
+
+## Mental Model
+
+An array is a fixed-size value.
+Its size is part of its type, and copying an array copies all of its elements.
+
+## Run Instructions
+
+```bash
+go run ./03-data-structures/1-array
+```
+
+## Code Walkthrough
+
+### `import "fmt"`
+
+This lesson prints values to the terminal, so it imports the formatting package.
+
+### `fmt.Println("=== Arrays ===")`
+
+The first print gives the lesson output a clear starting label.
+
+### `var numbers [2]int`
+
+This line declares an array named `numbers`.
+
+Important details:
+
+- `[2]int` means "an array with exactly two `int` values"
+- the `2` is not only a size hint; it is part of the type
+- `[2]int` and `[3]int` are different types
+
+### `fmt.Printf("Zero value array: %v\n", numbers)`
+
+This prints the zero value of the array.
+Because the array holds `int` values, the zero value is `[0 0]`.
+
+### `numbers[0] = 1` and `numbers[1] = 2`
+
+These two lines update the array by index.
+The valid indices are `0` and `1` because the array length is `2`.
+
+### `primes := [4]int{2, 3, 5, 7}`
+
+This line shows an array literal.
+Instead of declaring and then assigning one element at a time, the code creates the whole array in
+one step.
+
+### `for i, value := range primes`
+
+This loop walks over the array.
+
+- `i` is the index
+- `value` is the copied value at that position
+
+This is the first reminder that iteration gives you access to both position and value.
+
+### `original := [3]int{10, 20, 30}`
+
+This creates the first array for the copy demonstration.
+
+### `copied := original`
+
+This is the key line in the lesson.
+Go copies the whole array here.
+
+After this line:
+
+- `copied` has the same contents as `original`
+- `copied` is not another name for `original`
+- changing `copied` does not change `original`
+
+### `copied[0] = 99`
+
+This updates only the copied array.
+
+### The final two `Printf` lines
+
+These prove that the original array stayed `[10 20 30]` while the copied array became
+`[99 20 30]`.
+
+That is the real lesson outcome.
+
+## Common Questions
+
+- Why teach arrays if slices are more common?
+  Arrays make value-copy behavior obvious, which helps the next slice lesson make sense.
+
+- Why are `[2]int` and `[3]int` different?
+  Because array size is part of the type in Go.
+
+## Production Relevance
+
+You will not model most dynamic collections with arrays, but the value-copy rule matters whenever
+you reason about what gets copied and what stays shared.
+
+## Next Step
+
+Continue to `DS.2` slices.

--- a/03-data-structures/1-array/main.go
+++ b/03-data-structures/1-array/main.go
@@ -11,16 +11,6 @@ import "fmt"
 // Arrays are fixed-size values. If you copy one array into another, Go copies
 // all of the elements.
 //
-// In this lesson:
-// - declare arrays with an explicit size
-// - compare zero values and literals
-// - iterate with index and range
-// - observe copy-by-value behavior
-//
-// Watch for:
-// - [2]int and [3]int are different types
-// - arrays are mostly useful here as the contrast point for slices
-//
 // Run: go run ./03-data-structures/1-array
 
 func main() {

--- a/03-data-structures/2-slices/README.md
+++ b/03-data-structures/2-slices/README.md
@@ -1,0 +1,102 @@
+# DS.2 Slices
+
+## Mission
+
+Learn how Go represents dynamic collections through slices, and why `len`, `cap`, `make`, and
+`append` are all part of one connected idea.
+
+## Prerequisites
+
+- `DS.1` arrays
+
+## Mental Model
+
+A slice is a small view over an underlying array.
+It tracks:
+
+- which array data it points to
+- how many elements are currently in the slice
+- how much capacity remains before growth needs a new backing array
+
+## Run Instructions
+
+```bash
+go run ./03-data-structures/2-slices
+```
+
+## Code Walkthrough
+
+### `names := []string{"Alice", "John", "Mark"}`
+
+This line creates a slice literal.
+Unlike the array lesson, there is no fixed size written in the type.
+
+That tells the learner:
+
+- this is a slice, not an array
+- slices are the normal collection tool for variable-length lists
+
+### `fmt.Printf("len=%d cap=%d\n", len(names), cap(names))`
+
+This prints the two slice measurements:
+
+- `len`: how many elements are currently visible
+- `cap`: how much space is available in the current backing array view
+
+### `items := make([]int, 0, 3)`
+
+This is one of the most important slice lines in the lesson.
+
+It means:
+
+- make a slice of `int`
+- start with length `0`
+- reserve capacity `3`
+
+The slice starts empty, but it already has room to grow.
+
+### `items = append(items, 10)` and the next two append lines
+
+Each `append` returns the updated slice, so the result must be assigned back into `items`.
+
+That is why the code does not write only `append(items, 10)`.
+If the learner forgets the reassignment, they lose the updated slice value.
+
+### `items = append(items, 40)`
+
+This append matters because it grows beyond the original capacity of `3`.
+
+That is the first hint that:
+
+- slices can grow
+- growth may require a different backing array
+
+### `firstTwo := items[:2]`
+
+This creates a smaller view over the same data.
+It does not make a copy.
+
+### `lastTwo := items[2:]`
+
+This creates another view, starting from index `2` to the end.
+
+These two lines teach the learner that slicing syntax makes views, not independent new collections
+by default.
+
+## Common Questions
+
+- Why does `append` return a slice?
+  Because growth may change the slice header or even the backing array.
+
+- Does `items[:2]` copy the first two values?
+  No. It usually creates another view over the same underlying data.
+
+## Production Relevance
+
+Slices are everywhere in Go.
+Understanding `len`, `cap`, `make`, and `append` prevents a huge amount of confusion later in file
+processing, HTTP work, concurrency, and general application code.
+
+## Next Step
+
+Continue to `DS.3` maps.

--- a/03-data-structures/2-slices/main.go
+++ b/03-data-structures/2-slices/main.go
@@ -11,17 +11,6 @@ import "fmt"
 // A slice is a small descriptor that points at an underlying array. It tracks
 // a current length and a capacity for growth.
 //
-// In this lesson:
-// - create slice literals
-// - use len and cap
-// - use make to pre-allocate space
-// - grow a slice with append
-// - take a smaller view with slicing syntax
-//
-// Watch for:
-// - append returns the updated slice value
-// - slicing a slice does not copy the data by default
-//
 // Run: go run ./03-data-structures/2-slices
 
 func main() {

--- a/03-data-structures/3-maps/README.md
+++ b/03-data-structures/3-maps/README.md
@@ -1,0 +1,89 @@
+# DS.3 Maps
+
+## Mission
+
+Learn how Go performs keyed lookup with maps and why the comma-ok pattern matters whenever a missing
+key would otherwise be ambiguous.
+
+## Prerequisites
+
+- `DS.2` slices
+
+## Mental Model
+
+A map connects keys to values.
+Use it when finding something by name, ID, or label matters more than keeping items in order.
+
+## Run Instructions
+
+```bash
+go run ./03-data-structures/3-maps
+```
+
+## Code Walkthrough
+
+### `studentGrades := map[string]int{ ... }`
+
+This line creates a map literal.
+
+Important parts:
+
+- keys are `string`
+- values are `int`
+- each key maps to one value
+
+### `studentGrades["Alice"] = 95`
+
+This updates an existing key.
+
+### `studentGrades["Mary"] = 88`
+
+This adds a new key-value pair.
+
+These two lines show that the same bracket syntax handles both update and insert.
+
+### `studentGrades["Zack"]`
+
+This line reads a key that does not exist.
+Go returns the zero value of the value type, which is `0` here.
+
+That is useful, but also dangerous when `0` could be a real value.
+
+### `aliceScore, aliceExists := studentGrades["Alice"]`
+
+This is the comma-ok pattern.
+
+It answers two questions at once:
+
+- what is the value?
+- did the key really exist?
+
+### `zackScore, zackExists := studentGrades["Zack"]`
+
+This repeats the same pattern for a missing key so the learner can compare the results honestly.
+
+### `delete(studentGrades, "Dan")`
+
+This removes a key from the map.
+
+### `settings := make(map[string]string)`
+
+This creates an empty map that can be filled later.
+Use `make` when the map should start empty and grow step by step.
+
+## Common Questions
+
+- Why not use a slice for grades?
+  A slice is best when position and order matter. A map is best when lookup by key matters.
+
+- Why is comma-ok important?
+  Because a missing key returns the zero value, and that can look like a real stored value.
+
+## Production Relevance
+
+Maps appear constantly in Go for configuration, lookup tables, indexing, request classification,
+and in-memory caches. The comma-ok habit prevents subtle bugs around missing data.
+
+## Next Step
+
+Continue to `DS.4` pointers.

--- a/03-data-structures/3-maps/main.go
+++ b/03-data-structures/3-maps/main.go
@@ -11,17 +11,6 @@ import "fmt"
 // A map connects keys to values. You use it when lookup by name matters more
 // than keeping items in order.
 //
-// In this lesson:
-// - create map literals
-// - add and update entries
-// - check whether a key exists with comma-ok
-// - remove an entry with delete
-// - build an empty map with make
-//
-// Watch for:
-// - reading a missing key gives the zero value
-// - use comma-ok when you need to know whether the key was really present
-//
 // Run: go run ./03-data-structures/3-maps
 
 func main() {

--- a/03-data-structures/4-pointers/README.md
+++ b/03-data-structures/4-pointers/README.md
@@ -1,0 +1,110 @@
+# DS.4 Pointers
+
+## Mission
+
+Learn what a pointer is, how dereferencing works, and why pointers matter when an update must
+change the original stored value rather than only a copy.
+
+## Prerequisites
+
+- `DS.1` arrays
+- `DS.2` slices
+
+## Mental Model
+
+A pointer stores the address of a value.
+You use it when you need to reach the original value and update it directly.
+
+## Run Instructions
+
+```bash
+go run ./03-data-structures/4-pointers
+```
+
+## Code Walkthrough
+
+### `score := 50`
+
+This creates the original integer value.
+
+### `scorePtr := &score`
+
+`&score` means "the address of `score`."
+This line creates a pointer that points at the original variable.
+
+### The first `Printf` group
+
+These lines print:
+
+- the value in `score`
+- the address of `score`
+- the pointer value
+- the value reached by dereferencing the pointer
+
+`*scorePtr` means "go to the value stored at this address."
+
+### `scoreCopy := score`
+
+This copies the integer value.
+It does not create another pointer.
+
+### `scoreCopy = 95`
+
+This changes only the copied value.
+That is why the original `score` stays unchanged at that moment.
+
+### `*scorePtr = 95`
+
+This is the key pointer line in the lesson.
+
+It means:
+
+- go to the original value through the pointer
+- change that original value directly
+
+That is why `score` changes after this line.
+
+### `phones := []string{...}`
+
+This creates a slice so the lesson can connect pointers to stored collection elements.
+
+### `bobPhone := &phones[1]`
+
+This takes the address of the second phone number inside the slice.
+
+That matters for the milestone because later the contact-directory exercise updates one stored phone
+value through a pointer.
+
+### `*bobPhone = "333-9999"`
+
+This updates the slice element through the pointer.
+The final print proves the stored slice data changed.
+
+### `var optionalScore *int`
+
+This declares a pointer whose zero value is `nil`.
+
+### `if optionalScore == nil`
+
+This is the safety check.
+Dereferencing a nil pointer would panic, so the lesson shows the right habit first:
+
+- check before dereferencing when nil is possible
+
+## Common Questions
+
+- Why not use pointers everywhere?
+  Because many values do not need shared mutation. Use pointers when the original value must be
+  reached directly.
+
+- Why show a slice element pointer here?
+  Because Section 03 ends with a milestone that updates stored slice data through a pointer.
+
+## Production Relevance
+
+Pointers matter whenever a Go program must mutate stored state intentionally and safely. They also
+help learners stop confusing "copied value" with "original value."
+
+## Next Step
+
+Continue to `DS.5` slice sharing and capacity.

--- a/03-data-structures/4-pointers/main.go
+++ b/03-data-structures/4-pointers/main.go
@@ -11,17 +11,6 @@ import "fmt"
 // A pointer stores the address of a value. You use it when you need to update
 // the original stored value instead of a copy.
 //
-// In this lesson:
-// - create a pointer with &
-// - read and write through a pointer with *
-// - compare copy-based updates with pointer-based updates
-// - handle a nil pointer safely
-// - connect pointers to slice elements, which the Section 03 milestone needs
-//
-// Watch for:
-// - dereferencing a nil pointer will panic
-// - pointers are useful, but not every value needs one
-//
 // Run: go run ./03-data-structures/4-pointers
 
 func main() {

--- a/03-data-structures/5-slices-2/README.md
+++ b/03-data-structures/5-slices-2/README.md
@@ -1,0 +1,94 @@
+# DS.5 Slice Sharing And Capacity
+
+## Mission
+
+Learn why sub-slices can still affect the original data and why `append` can reuse spare capacity in
+ways that surprise beginners.
+
+## Prerequisites
+
+- `DS.2` slices
+- `DS.4` pointers
+
+## Mental Model
+
+A sub-slice is usually another view over the same backing array.
+That makes slicing cheap, but it also means two slices can still touch the same stored data.
+
+## Run Instructions
+
+```bash
+go run ./03-data-structures/5-slices-2
+```
+
+## Code Walkthrough
+
+### `original := []int{0, 1, 2, 3, 4, 5}`
+
+This creates the base slice that the rest of the lesson will inspect.
+
+### `shared := original[1:4]`
+
+This creates a sub-slice view.
+It does not copy values into a separate collection.
+
+### `len(shared)` and `cap(shared)`
+
+The lesson prints both measurements so the learner can see that a sub-slice may have:
+
+- a smaller length
+- but still a larger capacity than expected
+
+That spare capacity is what makes later `append` behavior surprising.
+
+### `shared[0] = 100`
+
+This changes the first visible element of `shared`.
+Because `shared` and `original` still share the same backing array, `original` changes too.
+
+That is the first big warning in the lesson:
+
+- a new slice view is not the same as a copied slice
+
+### `growth := original[2:4]`
+
+This creates another sub-slice to demonstrate append behavior.
+
+### `growth = append(growth, 200)`
+
+This is the second big warning.
+
+If the append fits inside the available capacity, Go can reuse the backing array.
+That means the append can overwrite part of the original data.
+
+The next print proves that the original slice changed.
+
+### `independent := make([]int, len(original[2:4]))`
+
+This line starts the safe copy approach.
+Instead of sharing, the code allocates a new slice with its own backing storage.
+
+### `for i, value := range original[2:4]`
+
+This loop copies values one by one into the new independent slice.
+
+### `independent[0] = 500`
+
+This final mutation proves the new slice no longer shares storage with the original.
+
+## Common Questions
+
+- Why did `append` change the original slice?
+  Because the sub-slice still had spare capacity in the same backing array.
+
+- How do I avoid accidental sharing?
+  Copy the values into a new slice before making independent changes.
+
+## Production Relevance
+
+This lesson prevents one of the most common slice bugs in Go: changing shared data accidentally
+because two slices still point at the same backing array.
+
+## Next Step
+
+Continue to `DS.6` contact directory.

--- a/03-data-structures/5-slices-2/main.go
+++ b/03-data-structures/5-slices-2/main.go
@@ -12,16 +12,6 @@ import "fmt"
 // That keeps slicing cheap, but it also means two slices can still affect the
 // same stored data.
 //
-// In this lesson:
-// - inspect len and cap after slicing
-// - watch a sub-slice mutate the original data
-// - watch append reuse spare capacity
-// - break the shared link by copying into a new slice
-//
-// Watch for:
-// - a small sub-slice can still have a large capacity
-// - if append fits, it can still write into the original array
-//
 // Run: go run ./03-data-structures/5-slices-2
 
 func main() {

--- a/03-data-structures/6-contact-manager/README.md
+++ b/03-data-structures/6-contact-manager/README.md
@@ -39,7 +39,7 @@ adding new modeling tools.
 
 ## Files
 
-- [main.go](./main.go): complete solution with teaching comments
+- [main.go](./main.go): complete runnable solution
 - [_starter/main.go](./_starter/main.go): starter file with TODOs
 
 ## Run Instructions
@@ -56,6 +56,99 @@ Run the starter scaffold:
 go run ./03-data-structures/6-contact-manager/_starter
 ```
 
+## Recommended Learning Flow
+
+1. Read this README first.
+2. Open [_starter/main.go](./_starter/main.go) and list the pieces you need.
+3. Try to build the milestone yourself.
+4. Run the starter and your solution often.
+5. Compare your result with [main.go](./main.go) only after you have attempted the design.
+
+## Solution Walkthrough
+
+The solution stays inside Section 03 concepts on purpose.
+
+### 1. Parallel slices set the storage model
+
+The solution starts with:
+
+- `names`
+- `emails`
+- `phones`
+
+Each contact uses the same index in all three slices.
+That is why the first design rule is "keep the indices aligned."
+
+### 2. The map turns a name into an index
+
+`indexByName` is a `map[string]int`.
+
+It does not store the contact data itself.
+It stores the slice position where that contact's data lives.
+
+That lets the solution answer:
+
+- "Where is Bob?"
+
+before it answers:
+
+- "What is Bob's phone number?"
+
+### 3. Each append must keep all slices in sync
+
+When the solution adds Alice, Bob, and Charlie, it appends to:
+
+- `names`
+- `emails`
+- `phones`
+
+Then it stores `len(names) - 1` in the map.
+
+That line matters because the newly added contact always lands at the last valid index.
+
+### 4. The duplicate check uses the map first
+
+The duplicate guard asks:
+
+```go
+if _, exists := indexByName["Alice Wonderland"]; exists {
+```
+
+This uses the comma-ok pattern from the maps lesson.
+It avoids creating a second contact entry with the same name.
+
+### 5. Listing proves the shared index model
+
+The `for i := 0; i < len(names); i++ { ... }` loop is deliberately simple.
+
+It prints:
+
+- `names[i]`
+- `emails[i]`
+- `phones[i]`
+
+side by side so the learner can see that one contact is really "one index across several slices."
+
+### 6. Pointer-based update is the real milestone proof
+
+The important sequence is:
+
+1. use the map to get Bob's index
+2. take `&phones[bobIndex]`
+3. write through that pointer
+4. read the slice again to prove the update persisted
+
+That is the exact Section 03 idea chain:
+
+- maps find the right position
+- slices hold the stored values
+- pointers let the update stick
+
+### 7. Missing lookup still uses comma-ok
+
+The final `Zack` check reminds the learner that not every key exists.
+The map lesson still matters here, even inside the milestone.
+
 ## Success Criteria
 
 Your finished solution should:
@@ -71,6 +164,13 @@ Your finished solution should:
 - using a pointer before you are sure the lookup index exists
 - letting one contact's slice positions drift out of sync with the others
 - hiding the data-structure lesson under architecture that has not been taught yet
+
+## Questions This Milestone Should Answer
+
+- Why use slices and a map together instead of only one of them?
+- Why is the map value an index instead of a phone number?
+- Why does taking `&phones[index]` let the update persist?
+- Why does this milestone stop before structs and helper functions?
 
 ## Next Step
 

--- a/03-data-structures/6-contact-manager/_starter/main.go
+++ b/03-data-structures/6-contact-manager/_starter/main.go
@@ -5,28 +5,13 @@ package main
 
 import "fmt"
 
-// ============================================================================
 // Section 03: Data Structures - Contact Directory (Exercise Starter)
-// Level: Beginner
-// ============================================================================
 //
-// EXERCISE: Build an In-Memory Contact Directory
-//
-// REQUIREMENTS:
-//  1. [ ] Create parallel `names`, `emails`, and `phones` slices
-//  2. [ ] Keep a `map[string]int` for name lookup
-//  3. [ ] Add at least three contacts in `main()`
-//  4. [ ] Use the map to find one contact's slice index
-//  5. [ ] Take a pointer to a stored phone number and prove the update persists
-//
-// HINTS:
-//   - Use `append()` to grow each slice
-//   - Keep the same index for one contact across all three slices
-//   - `phones[index]` is a real slice element, so `&phones[index]` gives you a pointer
+// Mental model:
+// Keep one contact's data aligned across parallel slices, then use a map and
+// a pointer to prove the update sticks.
 //
 // RUN: go run ./03-data-structures/6-contact-manager/_starter
-// SOLUTION: See the main.go file in the parent directory
-// ============================================================================
 
 func main() {
 	fmt.Println("=== Contact Directory Exercise ===")

--- a/03-data-structures/6-contact-manager/main.go
+++ b/03-data-structures/6-contact-manager/main.go
@@ -12,15 +12,6 @@ import "fmt"
 // directly before the curriculum moves on to functions, structs, and more
 // layered design.
 //
-// In this lesson:
-// - keep one contact's data aligned across parallel slices
-// - use a map for O(1) lookup of the slice index
-// - update a stored phone number through a pointer
-//
-// Watch for:
-// - all three slices must stay index-aligned
-// - only take the pointer after you know the lookup succeeded
-//
 // Run: go run ./03-data-structures/6-contact-manager
 
 func main() {

--- a/03-data-structures/README.md
+++ b/03-data-structures/README.md
@@ -66,7 +66,8 @@ If you only want the live milestone, review these first:
 ## Suggested Order
 
 1. Work through `DS.1` to `DS.5` in order.
-2. Complete `DS.6` without copying the finished solution line by line.
+2. For each lesson, read the lesson `README.md` first and then run `main.go`.
+3. Complete `DS.6` without copying the finished solution line by line.
 
 ## Section Milestone
 


### PR DESCRIPTION
## Summary
- add learner-facing walkthrough READMEs for DS.1 through DS.5
- slim the lesson code headers so `main.go` stays cleaner and the docs carry the deeper explanation
- deepen the DS.6 milestone README and starter framing so the whole section follows the README-first contract

## Why
Section 03 had become more zero-magic, but it was still explanation-light for the README-first lesson system we want.
This PR makes the docs the primary teaching surface while keeping every lesson runnable.

## Linked work
- closes #280
- supports #278

## Checks
- git diff --check
- go run ./03-data-structures/1-array
- go run ./03-data-structures/2-slices
- go run ./03-data-structures/3-maps
- go run ./03-data-structures/4-pointers
- go run ./03-data-structures/5-slices-2
- go run ./03-data-structures/6-contact-manager
- go run ./03-data-structures/6-contact-manager/_starter
