### PR TITLE
Finalize Section 03 README-first learning surfaces

### DIFF
--- a/03-data-structures/1-array/README.md
+++ b/03-data-structures/1-array/README.md
@@ -20,6 +20,25 @@ That rule helps the learner understand slices by contrast in the next lesson.
 An array is a fixed-size value.
 Its size is part of its type, and copying an array copies all of its elements.
 
+## Visual Model
+
+```text
+numbers := [2]int{1, 2}
+
+index:   0   1
+value:   1   2
+```
+
+```text
+original = [10 20 30]
+copied   = original
+
+change copied[0] -> 99
+
+original = [10 20 30]
+copied   = [99 20 30]
+```
+
 ## Run Instructions
 
 ```bash
@@ -96,6 +115,12 @@ These prove that the original array stayed `[10 20 30]` while the copied array b
 `[99 20 30]`.
 
 That is the real lesson outcome.
+
+## Try It
+
+1. Change `var numbers [2]int` to `var numbers [3]int` and add one more assignment.
+2. Change `copied[0] = 99` to `original[0] = 99` and run the lesson again.
+3. Try declaring `other := [2]int{1, 2}` and compare it mentally with `[3]int{1, 2, 3}`.
 
 ## Common Questions
 

--- a/03-data-structures/2-slices/README.md
+++ b/03-data-structures/2-slices/README.md
@@ -18,6 +18,32 @@ It tracks:
 - how many elements are currently in the slice
 - how much capacity remains before growth needs a new backing array
 
+## Visual Model
+
+```text
+items := make([]int, 0, 3)
+
+slice header:
+- pointer -> backing array
+- len     -> 0
+- cap     -> 3
+```
+
+```text
+after append 10, 20, 30
+
+backing array: [10 20 30]
+len = 3
+cap = 3
+```
+
+```text
+after append 40
+
+Go may allocate a larger backing array
+so the slice can keep growing
+```
+
 ## Run Instructions
 
 ```bash
@@ -82,6 +108,12 @@ This creates another view, starting from index `2` to the end.
 
 These two lines teach the learner that slicing syntax makes views, not independent new collections
 by default.
+
+## Try It
+
+1. Change the `make` call to `make([]int, 1, 3)` and watch how the starting length changes.
+2. Comment out one `items =` reassignment and see why `append` must be captured.
+3. Change `firstTwo := items[:2]` to `firstThree := items[:3]` and inspect the output again.
 
 ## Common Questions
 

--- a/03-data-structures/3-maps/README.md
+++ b/03-data-structures/3-maps/README.md
@@ -14,6 +14,23 @@ key would otherwise be ambiguous.
 A map connects keys to values.
 Use it when finding something by name, ID, or label matters more than keeping items in order.
 
+## Visual Model
+
+```text
+studentGrades
+
+"Alice" -> 95
+"James" -> 85
+"Mary"  -> 88
+```
+
+```text
+lookup rules
+
+existing key -> value + exists=true
+missing key  -> zero value + exists=false
+```
+
 ## Run Instructions
 
 ```bash
@@ -70,6 +87,12 @@ This removes a key from the map.
 
 This creates an empty map that can be filled later.
 Use `make` when the map should start empty and grow step by step.
+
+## Try It
+
+1. Add another student and print the map again.
+2. Read a missing key without comma-ok, then with comma-ok, and compare the difference.
+3. Delete a key that is already missing and notice that Go stays calm.
 
 ## Common Questions
 

--- a/03-data-structures/4-pointers/README.md
+++ b/03-data-structures/4-pointers/README.md
@@ -15,6 +15,29 @@ change the original stored value rather than only a copy.
 A pointer stores the address of a value.
 You use it when you need to reach the original value and update it directly.
 
+## Visual Model
+
+```text
+score    = 50
+scorePtr = &score
+
+scorePtr --> score
+```
+
+```text
+*scorePtr = 95
+
+pointer follows the address
+and updates the original stored value
+```
+
+```text
+phones := []string{"111-2222", "333-4444", "555-6666"}
+bobPhone := &phones[1]
+
+bobPhone --> phones[1]
+```
+
 ## Run Instructions
 
 ```bash
@@ -90,6 +113,12 @@ This is the safety check.
 Dereferencing a nil pointer would panic, so the lesson shows the right habit first:
 
 - check before dereferencing when nil is possible
+
+## Try It
+
+1. Change `scoreCopy = 95` to another number and confirm that `score` still does not change.
+2. Change `*scorePtr = 95` to a different number and watch the original update again.
+3. Point at a different slice element, like `&phones[0]`, and update that instead.
 
 ## Common Questions
 

--- a/03-data-structures/5-slices-2/README.md
+++ b/03-data-structures/5-slices-2/README.md
@@ -15,6 +15,29 @@ ways that surprise beginners.
 A sub-slice is usually another view over the same backing array.
 That makes slicing cheap, but it also means two slices can still touch the same stored data.
 
+## Visual Model
+
+```text
+original := [0 1 2 3 4 5]
+shared   := original[1:4]
+
+original: 0 1 2 3 4 5
+shared:     1 2 3
+```
+
+```text
+shared[0] = 100
+
+original: 0 100 2 3 4 5
+shared:     100 2 3
+```
+
+```text
+growth := original[2:4]
+append may still write into the original backing array
+if spare capacity exists
+```
+
 ## Run Instructions
 
 ```bash
@@ -75,6 +98,13 @@ This loop copies values one by one into the new independent slice.
 ### `independent[0] = 500`
 
 This final mutation proves the new slice no longer shares storage with the original.
+
+## Try It
+
+1. Change the sub-slice ranges and watch how `len` and `cap` change.
+2. Append more than one value to `growth` and inspect whether the original still changes.
+3. Change the manual copy loop to copy a different slice range and confirm the independent slice
+   stays separate.
 
 ## Common Questions
 

--- a/03-data-structures/6-contact-manager/README.md
+++ b/03-data-structures/6-contact-manager/README.md
@@ -29,6 +29,23 @@ Implement a small contact directory that:
 4. prints a small demonstration flow in `main()`
 5. stays inside the concepts already taught in Section 03
 
+## Visual Model
+
+```text
+index  name               email                phone
+0      Alice Wonderland  alice@example.com    111-2222
+1      Bob The Builder   bob@example.com      333-4444
+2      Charlie Brown     charlie@example.com  555-6666
+```
+
+```text
+indexByName
+
+"Alice Wonderland" -> 0
+"Bob The Builder"  -> 1
+"Charlie Brown"    -> 2
+```
+
 ## Why This Milestone Avoids Structs
 
 Structs matter, but they belong to a later section.
@@ -54,6 +71,12 @@ Run the starter scaffold:
 
 ```bash
 go run ./03-data-structures/6-contact-manager/_starter
+```
+
+Run the automated verification surface:
+
+```bash
+go test ./03-data-structures/6-contact-manager
 ```
 
 ## Recommended Learning Flow
@@ -149,6 +172,13 @@ That is the exact Section 03 idea chain:
 The final `Zack` check reminds the learner that not every key exists.
 The map lesson still matters here, even inside the milestone.
 
+## Try It
+
+1. Add one more contact and update the map with the new index.
+2. Change the contact you update from Bob to Charlie.
+3. Break the alignment on purpose by skipping one append, then explain why the output becomes wrong.
+4. Change the duplicate check to another name and watch how the guard behaves.
+
 ## Success Criteria
 
 Your finished solution should:
@@ -164,6 +194,17 @@ Your finished solution should:
 - using a pointer before you are sure the lookup index exists
 - letting one contact's slice positions drift out of sync with the others
 - hiding the data-structure lesson under architecture that has not been taught yet
+
+## Verification Surface
+
+Use these three proof surfaces together:
+
+1. `go run ./03-data-structures/6-contact-manager`
+2. `go run ./03-data-structures/6-contact-manager/_starter`
+3. `go test ./03-data-structures/6-contact-manager`
+
+The tests are not the lesson.
+They are a confidence check that the visible milestone behavior still matches the README contract.
 
 ## Questions This Milestone Should Answer
 

--- a/03-data-structures/6-contact-manager/main_test.go
+++ b/03-data-structures/6-contact-manager/main_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestContactDirectoryOutput(t *testing.T) {
+	cmd := exec.Command("go", "run", ".")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run failed: %v\n%s", err, string(out))
+	}
+
+	output := string(out)
+
+	expected := []string{
+		"Duplicate add skipped for Alice Wonderland.",
+		"Found Bob at index 1 with phone 333-4444",
+		"Updated Bob through pointer: 333-9999",
+		"Persisted Bob phone: 333-9999",
+		"Zack not found.",
+	}
+
+	for _, fragment := range expected {
+		if !strings.Contains(output, fragment) {
+			t.Fatalf("expected output to contain %q\nfull output:\n%s", fragment, output)
+		}
+	}
+}

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -595,12 +595,12 @@
       "type": "exercise",
       "subtype": "",
       "level": "core",
-      "verification_mode": "run",
+      "verification_mode": "mixed",
       "estimated_time": 40,
-      "summary": "Build a small in-memory contact manager that combines slices, maps, pointers, and a simple data model.",
+      "summary": "Build a small in-memory contact directory that combines parallel slices, map lookup, and pointer-based updates without relying on later-section abstractions.",
       "objectives": [
-        "Model contacts with a struct and in-memory collections",
-        "Combine slices, maps, and pointers in one coherent runnable exercise"
+        "Keep parallel slices aligned while storing contact data in memory",
+        "Use a map and a pointer together to locate and persist one contact update"
       ],
       "prerequisites": [
         "DS.1",
@@ -612,7 +612,7 @@
       "production_relevance": "Real applications routinely layer multiple data structures together to balance readability, lookup speed, and mutation behavior.",
       "path": "03-data-structures/6-contact-manager",
       "run_command": "go run ./03-data-structures/6-contact-manager",
-      "test_command": "",
+      "test_command": "go test ./03-data-structures/6-contact-manager",
       "starter_path": "03-data-structures/6-contact-manager/_starter",
       "next_items": [],
       "tags": [


### PR DESCRIPTION
## Summary
- add simple visual models and Try It prompts across the Section 03 lesson READMEs
- add a real DS.6 test surface and wire the metadata to reflect mixed verification honestly
- tighten the milestone README so learners have clearer proof and experimentation paths

## Why
This is the final-form follow-up wave for Section 03.
The first README-first rebuild improved the section a lot, but it still lacked diagrams, experimentation prompts, and a proper verification surface for the milestone.

## Linked work
- closes #284
- supports #283

## Checks
- git diff --check
- go test ./03-data-structures/6-contact-manager
- go run ./03-data-structures/6-contact-manager
- go run ./03-data-structures/6-contact-manager/_starter
- go run ./scripts/validate_curriculum.go
