### PR TITLE
Add advanced curriculum reference templates

### DIFF
--- a/01-foundations/03-control-flow/5-pricing-checkout/README.md
+++ b/01-foundations/03-control-flow/5-pricing-checkout/README.md
@@ -110,6 +110,13 @@ Your program is successful when it:
 - skips unknown items safely
 - prints a final subtotal
 
+## Verification Surface
+
+Use these proof surfaces together:
+
+1. `go run ./01-foundations/03-control-flow/5-pricing-checkout`
+2. `go run ./01-foundations/03-control-flow/5-pricing-checkout/_starter`
+
 ## Next Step
 
 After this milestone, continue to `04-data-structures`.

--- a/01-foundations/05-functions-and-errors/1-functions-basics/README.md
+++ b/01-foundations/05-functions-and-errors/1-functions-basics/README.md
@@ -1,0 +1,143 @@
+# FE.1 Functions Basics
+
+## Mission
+
+Learn what a function boundary is and why naming a piece of work is better than leaving everything
+inline in `main()`.
+
+## Prerequisites
+
+- `DS.6` contact directory
+
+## Mental Model
+
+A function gives a piece of work a name.
+
+Instead of keeping every step directly in `main()`, you move one small responsibility into a
+separate function and let `main()` ask for that work when it needs it.
+
+## Visual Model
+
+```text
+main()
+  |
+  +--> printBanner()
+  |
+  +--> printGoal()
+  |
+  +--> printChecklist()
+```
+
+```text
+main stays readable
+
+instead of:
+line
+line
+line
+line
+line
+
+you get:
+main() -> named steps
+```
+
+## Machine View
+
+When `main()` calls another function, Go pauses `main()` at that line, starts running the called
+function, and then returns to the next line in `main()` when that function finishes.
+
+At this stage, the important machine truth is simple:
+
+- control jumps into the function body
+- the function runs its own lines in order
+- control returns to the caller when the function ends
+
+You do **not** need to think about exact RAM usage here.
+What matters first is understanding the flow of execution.
+
+## Run Instructions
+
+```bash
+go run ./01-foundations/05-functions-and-errors/1-functions-basics
+```
+
+## Code Walkthrough
+
+### `func printBanner() {`
+
+This line defines a function named `printBanner`.
+
+- `func` means "we are declaring a function"
+- `printBanner` is the function name
+- `()` is empty here because this function does not need any input yet
+
+### `fmt.Println("=== Functions Basics ===")`
+
+This line is the work done by `printBanner`.
+
+Right now the job is intentionally small: print one clear heading.
+
+### `func printGoal() {`
+
+This second function shows the same shape again.
+That repetition is useful because the learner sees that functions are not special one-off tricks.
+They are normal named blocks of work.
+
+### `func printChecklist() {`
+
+This function prints several lines, which makes one more important point:
+
+- a function can hold one line
+- or several related lines
+
+The real question is not "how many lines are allowed?"
+The real question is "does this block do one recognizable job?"
+
+### `func main() {`
+
+`main()` is still the entry point.
+The difference now is that `main()` does not carry every print statement directly.
+
+### `printBanner()`
+
+This line calls the function.
+
+The `()` matters.
+Without it, you are naming the function.
+With it, you are asking Go to run the function.
+
+### `printGoal()`
+
+This line shows that `main()` can call another named step immediately after the first one.
+
+That is the first taste of structured program flow through functions.
+
+### `printChecklist()`
+
+This finishes the small program with another named step.
+The important thing is not the printed text.
+The important thing is that `main()` now reads like a short list of jobs.
+
+## Try It
+
+1. Rename `printGoal` to `printMission` and update the call in `main()`.
+2. Add one more function called `printNextStep()` and call it from `main()`.
+3. Move one line out of `printChecklist()` back into `main()` and compare readability.
+
+## Common Questions
+
+- Why use a function if it only prints one line?
+  Because the lesson is about naming a job first. Later lessons will make the job more useful.
+
+- Does a function always need input?
+  No. Some functions only perform one fixed action.
+
+## Production Relevance
+
+Real programs become hard to read when every action stays inline.
+Small named functions are the first step toward readable application flow.
+
+## Next Step
+
+Continue to `FE.2` parameters and returns.

--- a/01-foundations/05-functions-and-errors/1-functions-basics/main.go
+++ b/01-foundations/05-functions-and-errors/1-functions-basics/main.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import "fmt"
+
+// 05 Functions and Errors - Functions Basics
+//
+// Mental model:
+// A function gives one piece of work a name so main() can stay readable.
+//
+// Run: go run ./01-foundations/05-functions-and-errors/1-functions-basics
+
+func printBanner() {
+	fmt.Println("=== Functions Basics ===")
+}
+
+func printGoal() {
+	fmt.Println("A function gives a piece of work a name.")
+}
+
+func printChecklist() {
+	fmt.Println("- main() can call other functions")
+	fmt.Println("- each function can do one small job")
+	fmt.Println("- named steps are easier to read than one long inline block")
+}
+
+func main() {
+	printBanner()
+	printGoal()
+	printChecklist()
+
+	fmt.Println("\n---------------------------------------------------")
+	fmt.Println("NEXT UP: FE.2 parameters-and-returns")
+	fmt.Println("Current: FE.1 (functions basics)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/01-foundations/05-functions-and-errors/2-parameters-and-returns/README.md
+++ b/01-foundations/05-functions-and-errors/2-parameters-and-returns/README.md
@@ -1,0 +1,141 @@
+# FE.2 Parameters and Returns
+
+## Mission
+
+Learn how a function receives input and gives a result back to the caller.
+
+## Prerequisites
+
+- `FE.1` functions basics
+
+## Mental Model
+
+Parameters are the values a function needs to do its job.
+Return values are the results it gives back.
+
+## Visual Model
+
+```text
+prices ----------------------+
+                             |
+main() ---> sumPrices(prices)|
+                             v
+                         total = 55
+```
+
+```text
+labelPrice("starter cart", 55)
+          |              |
+       input 1        input 2
+
+returns:
+"starter cart total: 55"
+```
+
+## Machine View
+
+When a function is called, the caller passes values into the function parameters.
+
+Important early machine truths:
+
+- basic values like `int` are copied into the function parameter
+- a slice parameter copies the slice header, not the whole backing array
+- the function computes its result and returns a new value to the caller
+
+So in this lesson:
+
+- `labelPrice` receives copied input values
+- `sumPrices` receives a copy of the slice header, then reads the same underlying slice data
+
+## Run Instructions
+
+```bash
+go run ./01-foundations/05-functions-and-errors/2-parameters-and-returns
+```
+
+## Code Walkthrough
+
+### `func announceCart(name string) {`
+
+This function has one parameter: `name string`.
+
+That means:
+
+- the function expects one input
+- the input is called `name`
+- the input type is `string`
+
+### `func sumPrices(prices []int) int {`
+
+This line adds a second important idea:
+
+- the function accepts a slice parameter
+- the function promises to return one `int`
+
+The return type appears after the parameter list.
+
+### `total := 0`
+
+This creates the running total inside the function body.
+It exists only while `sumPrices` is running.
+
+### `for _, price := range prices {`
+
+This line loops through the slice parameter.
+The function does not care where the slice came from.
+It only cares that it received a slice named `prices`.
+
+### `total += price`
+
+This is the work of the function:
+combine each price into the running total.
+
+### `return total`
+
+This line sends the final result back to the caller.
+Without `return`, the caller would not receive the computed total.
+
+### `func labelPrice(name string, total int) string {`
+
+This function shows two parameters and one returned value.
+It takes input, formats a sentence, and returns a new string.
+
+### `announceCart("starter cart")`
+
+This call passes a string argument into `announceCart`.
+
+### `total := sumPrices(prices)`
+
+This line is one of the main lesson lines.
+
+- call `sumPrices`
+- receive the returned `int`
+- store that result in `total`
+
+### `summary := labelPrice("starter cart", total)`
+
+This line passes two values into a function and receives one string back.
+That is the full parameter-and-return contract in one readable line.
+
+## Try It
+
+1. Add one more number to `prices` and run the lesson again.
+2. Change the cart name from `"starter cart"` to another label.
+3. Rename `total` in `main()` to `subtotal` and keep the program working.
+
+## Common Questions
+
+- Why is the return type after the parameters?
+  That is Go's function signature style.
+
+- Does passing a slice mean Go copies the whole slice data?
+  No. It copies the slice header, which still points to the same underlying data.
+
+## Production Relevance
+
+Most useful code is "input in, result out."
+Clear parameters and return values are the first step toward dependable business logic.
+
+## Next Step
+
+Continue to `FE.3` multiple return values.

--- a/01-foundations/05-functions-and-errors/2-parameters-and-returns/main.go
+++ b/01-foundations/05-functions-and-errors/2-parameters-and-returns/main.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import "fmt"
+
+// 05 Functions and Errors - Parameters and Returns
+//
+// Mental model:
+// Parameters bring values into a function, and return values send results back.
+//
+// Run: go run ./01-foundations/05-functions-and-errors/2-parameters-and-returns
+
+func announceCart(name string) {
+	fmt.Printf("Checking %s\n", name)
+}
+
+func sumPrices(prices []int) int {
+	total := 0
+
+	for _, price := range prices {
+		total += price
+	}
+
+	return total
+}
+
+func labelPrice(name string, total int) string {
+	return fmt.Sprintf("%s total: %d", name, total)
+}
+
+func main() {
+	prices := []int{12, 18, 25}
+
+	announceCart("starter cart")
+
+	total := sumPrices(prices)
+	summary := labelPrice("starter cart", total)
+
+	fmt.Println(summary)
+
+	fmt.Println("\n---------------------------------------------------")
+	fmt.Println("NEXT UP: FE.3 multiple-return-values")
+	fmt.Println("Current: FE.2 (parameters and returns)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/01-foundations/05-functions-and-errors/3-multiple-return-values/README.md
+++ b/01-foundations/05-functions-and-errors/3-multiple-return-values/README.md
@@ -1,0 +1,145 @@
+# FE.3 Multiple Return Values
+
+## Mission
+
+Learn how one function can return more than one value and why that matters before errors enter the
+picture.
+
+## Prerequisites
+
+- `FE.2` parameters and returns
+
+## Mental Model
+
+Sometimes one result is not enough.
+A function may need to return:
+
+- a value and a success signal
+- two related values
+- a result and some extra context
+
+## Visual Model
+
+```text
+findItem(items, "tea")
+        |
+        +--> returns (1, true)
+```
+
+```text
+splitName("Ava Stone")
+        |
+        +--> returns ("Ava", "Stone")
+```
+
+```text
+caller chooses what each returned value means
+```
+
+## Machine View
+
+Go lets a function hand multiple values back to the caller directly.
+
+The important machine truth here is not “where each byte goes.”
+It is that the caller receives more than one result and must decide what to do with each one.
+
+That prepares the learner for the next lesson, where the second value becomes an `error`.
+
+## Run Instructions
+
+```bash
+go run ./01-foundations/05-functions-and-errors/3-multiple-return-values
+```
+
+## Code Walkthrough
+
+### `func findItem(items []string, target string) (int, bool) {`
+
+This function returns two values:
+
+- an `int` index
+- a `bool` that says whether the search succeeded
+
+This is the most important line in the lesson because it changes the learner's idea of what a
+function result can be.
+
+### `for i, item := range items {`
+
+The function loops through the slice one item at a time.
+
+### `if item == target {`
+
+This checks whether the current item matches what the caller wants.
+
+### `return i, true`
+
+This line returns immediately with:
+
+- the matching index
+- a success signal
+
+### `return -1, false`
+
+This is the fallback path.
+The function still returns two values, but they now mean:
+
+- no usable index
+- search failed
+
+### `func splitName(fullName string) (string, string) {`
+
+This second function returns two related values without using a boolean.
+
+That proves multiple return values are broader than only “success or failure.”
+
+### `parts := strings.SplitN(fullName, " ", 2)`
+
+This splits the full name into at most two pieces.
+The lesson keeps the string handling simple so the main topic stays on return shape.
+
+### `if len(parts) < 2 {`
+
+This guard keeps the function honest when the input does not contain a space.
+
+### `return fullName, ""`
+
+If the input has only one visible part, the function still returns two values:
+
+- the original input as the first name slot
+- an empty string as the second slot
+
+### `return parts[0], parts[1]`
+
+If the split succeeded, the function returns the first and last name directly.
+
+### `index, found := findItem(items, "tea")`
+
+This line is the caller-side version of the lesson.
+It receives two values and gives both of them names.
+
+### `firstName, lastName := splitName("Ava Stone")`
+
+This line shows the same pattern again with a different meaning.
+
+## Try It
+
+1. Search for a different item in `findItem`.
+2. Change `"Ava Stone"` to another two-part name.
+3. Change the missing return from `-1` to another sentinel value and explain why `found` still matters.
+
+## Common Questions
+
+- Why not return only the index from `findItem`?
+  Because `0` could be a real index. The second value makes success explicit.
+
+- Is this already the same as `(value, error)`?
+  Not yet, but it prepares you for that pattern.
+
+## Production Relevance
+
+Multiple return values let Go functions communicate more honestly.
+They make success, failure, and extra context visible to the caller.
+
+## Next Step
+
+Continue to `FE.4` errors as values.

--- a/01-foundations/05-functions-and-errors/3-multiple-return-values/main.go
+++ b/01-foundations/05-functions-and-errors/3-multiple-return-values/main.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// 05 Functions and Errors - Multiple Return Values
+//
+// Mental model:
+// A function can return more than one value when one result is not enough.
+//
+// Run: go run ./01-foundations/05-functions-and-errors/3-multiple-return-values
+
+func findItem(items []string, target string) (int, bool) {
+	for i, item := range items {
+		if item == target {
+			return i, true
+		}
+	}
+
+	return -1, false
+}
+
+func splitName(fullName string) (string, string) {
+	parts := strings.SplitN(fullName, " ", 2)
+	if len(parts) < 2 {
+		return fullName, ""
+	}
+
+	return parts[0], parts[1]
+}
+
+func main() {
+	items := []string{"bread", "tea", "rice"}
+
+	index, found := findItem(items, "tea")
+	fmt.Printf("tea found? %t at index %d\n", found, index)
+
+	firstName, lastName := splitName("Ava Stone")
+	fmt.Printf("first=%s last=%s\n", firstName, lastName)
+
+	fmt.Println("\n---------------------------------------------------")
+	fmt.Println("NEXT UP: FE.4 errors-as-values")
+	fmt.Println("Current: FE.3 (multiple return values)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/01-foundations/05-functions-and-errors/4-errors-as-values/README.md
+++ b/01-foundations/05-functions-and-errors/4-errors-as-values/README.md
@@ -1,0 +1,145 @@
+# FE.4 Errors as Values
+
+## Mission
+
+Learn the core Go rule for ordinary failure: return an error value instead of hiding the failure.
+
+## Prerequisites
+
+- `FE.3` multiple return values
+
+## Mental Model
+
+In Go, an error is a value returned to the caller.
+
+That means:
+
+- the function does not hide failure
+- the caller sees the failure directly
+- the caller decides what to do next
+
+## Visual Model
+
+```text
+divide(12, 3)
+    |
+    +--> returns (4, nil)
+```
+
+```text
+divide(12, 0)
+    |
+    +--> returns (0, error)
+```
+
+```text
+caller:
+result, err := divide(...)
+if err != nil {
+    handle it
+}
+```
+
+## Machine View
+
+An `error` is not magic control flow.
+It is just another returned value.
+
+The important machine truth is:
+
+- the function returns normally
+- one returned slot holds the main result
+- one returned slot holds either `nil` or an error value
+- the caller must inspect that second value before trusting the result
+
+This is why Go error handling stays visible in the code.
+
+## Run Instructions
+
+```bash
+go run ./01-foundations/05-functions-and-errors/4-errors-as-values
+```
+
+## Code Walkthrough
+
+### `func divide(total int, parts int) (int, error) {`
+
+This signature says the function returns:
+
+- one `int` result
+- one `error`
+
+That is the foundations version of Go's most important contract pattern.
+
+### `if parts == 0 {`
+
+This is the failure guard.
+The function checks the bad input before attempting the operation.
+
+### `return 0, errors.New("cannot divide by zero")`
+
+This line is the heart of the lesson.
+
+It returns:
+
+- a placeholder result
+- a non-`nil` error value that explains the failure
+
+### `return total / parts, nil`
+
+This is the success path.
+
+- the integer result is meaningful
+- the error is `nil`
+
+### `func lookupPrice(catalog map[string]int, item string) (int, error) {`
+
+This second function proves the same contract pattern in a different setting.
+Errors are not only for math problems.
+
+### `price, exists := catalog[item]`
+
+This line uses the map comma-ok pattern from the previous section.
+
+### `return 0, fmt.Errorf("price not found for %q", item)`
+
+This returns a formatted error when the requested item is missing.
+
+### `result, err := divide(12, 0)`
+
+This is the caller-side pattern.
+The caller receives both values and keeps them separate.
+
+### `if err != nil {`
+
+This is the discipline the learner needs to build now:
+check the error before trusting the result.
+
+### `teaPrice, err := lookupPrice(catalog, "tea")`
+
+This repeats the same pattern in a data-lookup example so the idea does not stay stuck to only one
+toy function.
+
+## Try It
+
+1. Change `divide(12, 0)` to `divide(12, 4)` and watch the success path.
+2. Ask for a missing catalog item like `"milk"` and observe the returned error.
+3. Add one more item to the catalog and look it up successfully.
+
+## Common Questions
+
+- Why return `0` on failure?
+  Because the real signal is the non-`nil` error. The caller must not trust the result when `err`
+  is non-`nil`.
+
+- Why not use panic here?
+  Because ordinary failure should stay in the normal return path.
+
+## Production Relevance
+
+Go services rely on visible error handling.
+Returning errors as values keeps the success path and failure path readable.
+
+## Next Step
+
+Continue to `FE.5` validation.

--- a/01-foundations/05-functions-and-errors/4-errors-as-values/main.go
+++ b/01-foundations/05-functions-and-errors/4-errors-as-values/main.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// 05 Functions and Errors - Errors as Values
+//
+// Mental model:
+// An error is a returned value that tells the caller the work did not succeed.
+//
+// Run: go run ./01-foundations/05-functions-and-errors/4-errors-as-values
+
+func divide(total int, parts int) (int, error) {
+	if parts == 0 {
+		return 0, errors.New("cannot divide by zero")
+	}
+
+	return total / parts, nil
+}
+
+func lookupPrice(catalog map[string]int, item string) (int, error) {
+	price, exists := catalog[item]
+	if !exists {
+		return 0, fmt.Errorf("price not found for %q", item)
+	}
+
+	return price, nil
+}
+
+func main() {
+	result, err := divide(12, 0)
+	if err != nil {
+		fmt.Println("divide error:", err)
+	} else {
+		fmt.Println("divide result:", result)
+	}
+
+	catalog := map[string]int{
+		"bread": 40,
+		"tea":   25,
+	}
+
+	teaPrice, err := lookupPrice(catalog, "tea")
+	if err != nil {
+		fmt.Println("lookup error:", err)
+	} else {
+		fmt.Println("tea price:", teaPrice)
+	}
+
+	fmt.Println("\n---------------------------------------------------")
+	fmt.Println("NEXT UP: FE.5 validation")
+	fmt.Println("Current: FE.4 (errors as values)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/01-foundations/05-functions-and-errors/5-validation/README.md
+++ b/01-foundations/05-functions-and-errors/5-validation/README.md
@@ -1,0 +1,124 @@
+# FE.5 Validation
+
+## Mission
+
+Learn how a function rejects bad input before the program does the real work.
+
+## Prerequisites
+
+- `FE.4` errors as values
+
+## Mental Model
+
+Validation is the first gate before useful work begins.
+
+If the input is clearly wrong, the function should say so immediately instead of pretending the work
+can continue safely.
+
+## Visual Model
+
+```text
+cart name -----------+
+prices --------------+--> validation gate --> ok --> continue
+```
+
+```text
+cart name -----------+
+prices --------------+--> validation gate --> error --> stop early
+```
+
+## Machine View
+
+Validation changes control flow very early.
+
+The important machine truth is:
+
+- the function reads the input
+- it checks the input against a rule
+- if the rule fails, the function returns immediately with an error value
+- later lines in that function do not run on the failure path
+
+That “return early” behavior is the real engineering habit this lesson is building.
+
+## Run Instructions
+
+```bash
+go run ./01-foundations/05-functions-and-errors/5-validation
+```
+
+## Code Walkthrough
+
+### `func validateCartName(name string) error {`
+
+This function takes one input and returns one `error`.
+
+That alone teaches a useful shape:
+
+- some functions do not return business data
+- some functions return only “did this pass or fail?”
+
+### `strings.TrimSpace(name) == ""`
+
+This line treats blank spaces as empty input too.
+That makes the validation rule more honest than checking only `name == ""`.
+
+### `return errors.New("cart name is required")`
+
+This is the failure path.
+The function does not continue because the input is not valid enough.
+
+### `return nil`
+
+This is the success path.
+`nil` means “no validation error.”
+
+### `func validatePrices(prices []int) error {`
+
+This second validator shows that one section can have several input checks, each with one clear job.
+
+### `if len(prices) == 0 {`
+
+This rejects an empty slice before any loop begins.
+
+### `for i, price := range prices {`
+
+This line checks each input value one by one.
+
+### `if price < 0 {`
+
+This is the specific rule for “bad price data.”
+
+### `return fmt.Errorf("price at index %d cannot be negative", i)`
+
+This builds an error that tells the caller exactly which input failed.
+
+### `err := validateCartName("starter cart")`
+
+This shows the caller-side pattern again:
+
+- call the validator
+- receive the error
+- inspect the error before moving on
+
+## Try It
+
+1. Change the first cart name to an empty string and watch the failure path.
+2. Change one of the prices to a negative number and observe the returned error.
+3. Replace `"starter cart"` with `"   "` and confirm that whitespace-only input still fails.
+
+## Common Questions
+
+- Why validate before the real work starts?
+  Because bad input should stop the flow before it can create a misleading result.
+
+- Why return `error` instead of `bool`?
+  Because the caller needs a reason, not only a yes/no signal.
+
+## Production Relevance
+
+Validation is one of the earliest places where engineering discipline shows up.
+It protects the rest of the program from clearly broken input.
+
+## Next Step
+
+Continue to `FE.6` orchestration.

--- a/01-foundations/05-functions-and-errors/5-validation/main.go
+++ b/01-foundations/05-functions-and-errors/5-validation/main.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// 05 Functions and Errors - Validation
+//
+// Mental model:
+// Validation rejects bad input early so the rest of the program can stay honest.
+//
+// Run: go run ./01-foundations/05-functions-and-errors/5-validation
+
+func validateCartName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("cart name is required")
+	}
+
+	return nil
+}
+
+func validatePrices(prices []int) error {
+	if len(prices) == 0 {
+		return errors.New("at least one price is required")
+	}
+
+	for i, price := range prices {
+		if price < 0 {
+			return fmt.Errorf("price at index %d cannot be negative", i)
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	err := validateCartName("starter cart")
+	fmt.Println("name check:", err)
+
+	err = validateCartName("   ")
+	fmt.Println("blank name check:", err)
+
+	err = validatePrices([]int{12, 18, 25})
+	fmt.Println("price check:", err)
+
+	err = validatePrices([]int{12, -3, 25})
+	fmt.Println("negative price check:", err)
+
+	fmt.Println("\n---------------------------------------------------")
+	fmt.Println("NEXT UP: FE.6 orchestration")
+	fmt.Println("Current: FE.5 (validation)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/01-foundations/05-functions-and-errors/6-orchestration/README.md
+++ b/01-foundations/05-functions-and-errors/6-orchestration/README.md
@@ -1,0 +1,134 @@
+# FE.6 Orchestration
+
+## Mission
+
+Learn how one function can coordinate several smaller helpers without losing readability.
+
+## Prerequisites
+
+- `FE.5` validation
+
+## Mental Model
+
+Orchestration means one function controls the order of several smaller jobs.
+
+It does not do every detail itself.
+It decides:
+
+- what should happen first
+- what should happen next
+- when the whole flow should stop early
+
+## Visual Model
+
+```text
+processCart(name, prices)
+   |
+   +--> validateCartName(name)
+   |
+   +--> validatePrices(prices)
+   |
+   +--> sumPrices(prices)
+   |
+   +--> buildSummary(name, total)
+   |
+   +--> return summary
+```
+
+```text
+if any validation step returns an error
+processCart stops immediately
+and returns that error to the caller
+```
+
+## Machine View
+
+Orchestration is mostly about control flow between functions.
+
+The important machine truth is:
+
+- the caller enters one top-level function
+- that function calls helpers one at a time
+- each helper returns control to the orchestrator
+- the orchestrator decides whether to continue or return early
+
+This is how programs start growing without becoming one giant `main()`.
+
+## Run Instructions
+
+```bash
+go run ./01-foundations/05-functions-and-errors/6-orchestration
+```
+
+## Code Walkthrough
+
+### `func processCart(name string, prices []int) (string, error) {`
+
+This is the orchestration function.
+It does not own every small detail.
+It owns the order of the work.
+
+### `if err := validateCartName(name); err != nil {`
+
+This line says:
+
+- run the validation helper
+- if it failed, stop immediately
+- return the error to the caller
+
+That is the cleanest early example of short-circuit control flow across functions.
+
+### `if err := validatePrices(prices); err != nil {`
+
+This repeats the same pattern for the second validation rule.
+
+The repetition is useful because it teaches a readable contract:
+
+- validate
+- stop if invalid
+- continue only if safe
+
+### `total := sumPrices(prices)`
+
+Only after validation succeeds does the orchestrator continue to the real work.
+
+### `summary := buildSummary(name, total)`
+
+This delegates the formatting step to another helper instead of mixing it into the control logic.
+
+### `return summary, nil`
+
+This returns a successful result only after every earlier step passed.
+
+### `summary, err := processCart("starter cart", []int{12, 18, 25})`
+
+This is the caller-side pattern:
+
+- one function call
+- one summary result
+- one error result
+
+The caller does not need to know every internal helper step.
+
+## Try It
+
+1. Change the cart name to an empty string and watch the early return path.
+2. Add a negative price and confirm that `sumPrices` is no longer reached.
+3. Add one more price and see how the summary changes on the success path.
+
+## Common Questions
+
+- Why not call `sumPrices` directly from `main()`?
+  Because `processCart` is teaching how one function can own the whole flow.
+
+- Is orchestration the same as abstraction?
+  Not exactly. This lesson is about ordering helper steps clearly.
+
+## Production Relevance
+
+Real application code often becomes readable because one function coordinates smaller helpers
+instead of doing everything in one place.
+
+## Next Step
+
+Continue to `FE.7` order summary.

--- a/01-foundations/05-functions-and-errors/6-orchestration/main.go
+++ b/01-foundations/05-functions-and-errors/6-orchestration/main.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// 05 Functions and Errors - Orchestration
+//
+// Mental model:
+// One function can coordinate several helpers and stop early when a step fails.
+//
+// Run: go run ./01-foundations/05-functions-and-errors/6-orchestration
+
+func validateCartName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("cart name is required")
+	}
+
+	return nil
+}
+
+func validatePrices(prices []int) error {
+	if len(prices) == 0 {
+		return errors.New("at least one price is required")
+	}
+
+	for i, price := range prices {
+		if price < 0 {
+			return fmt.Errorf("price at index %d cannot be negative", i)
+		}
+	}
+
+	return nil
+}
+
+func sumPrices(prices []int) int {
+	total := 0
+
+	for _, price := range prices {
+		total += price
+	}
+
+	return total
+}
+
+func buildSummary(name string, total int) string {
+	return fmt.Sprintf("%s total: %d", name, total)
+}
+
+func processCart(name string, prices []int) (string, error) {
+	if err := validateCartName(name); err != nil {
+		return "", err
+	}
+
+	if err := validatePrices(prices); err != nil {
+		return "", err
+	}
+
+	total := sumPrices(prices)
+	summary := buildSummary(name, total)
+
+	return summary, nil
+}
+
+func main() {
+	summary, err := processCart("starter cart", []int{12, 18, 25})
+	if err != nil {
+		fmt.Println("error:", err)
+	} else {
+		fmt.Println(summary)
+	}
+
+	summary, err = processCart("", []int{12, 18, 25})
+	if err != nil {
+		fmt.Println("error:", err)
+	} else {
+		fmt.Println(summary)
+	}
+
+	fmt.Println("\n---------------------------------------------------")
+	fmt.Println("NEXT UP: FE.7 order-summary")
+	fmt.Println("Current: FE.6 (orchestration)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/01-foundations/05-functions-and-errors/7-order-summary/README.md
+++ b/01-foundations/05-functions-and-errors/7-order-summary/README.md
@@ -1,0 +1,195 @@
+# FE.7 Order Summary
+
+## Mission
+
+Build one small order-summary program that proves the learner can combine functions, validation,
+multiple return values, and explicit errors in one readable flow.
+
+This is the foundations milestone for the section.
+
+## Prerequisites
+
+Complete these first:
+
+- `FE.1` functions basics
+- `FE.2` parameters and returns
+- `FE.3` multiple return values
+- `FE.4` errors as values
+- `FE.5` validation
+- `FE.6` orchestration
+
+## What You Will Build
+
+Implement a small order-summary program that:
+
+1. validates an order name
+2. validates a slice of item prices
+3. validates a shipping value
+4. sums the prices with one helper
+5. orchestrates the whole flow with `processOrder`
+6. returns either a readable summary or an explicit error
+
+## Visual Model
+
+```text
+order name ---+
+prices -------+--> processOrder(...)
+shipping -----+
+```
+
+```text
+processOrder
+   |
+   +--> validateOrderName
+   +--> validatePrices
+   +--> validateShipping
+   +--> sumPrices
+   +--> buildSummary
+   +--> return (summary, nil)
+```
+
+```text
+failure path:
+one validation fails
+processOrder returns ("", error)
+```
+
+## Machine View
+
+This milestone is about function coordination more than low-level memory detail.
+
+The important machine truth is:
+
+- `main()` calls one top-level function
+- `processOrder` calls helpers in order
+- each helper either returns success or returns an error
+- the first error stops the flow
+- only the success path reaches the summary builder
+
+That is how a readable application flow grows out of smaller functions.
+
+## Files
+
+- [main.go](./main.go): complete runnable solution
+- [_starter/main.go](./_starter/main.go): starter scaffold with TODOs
+- [main_test.go](./main_test.go): automated proof surface for the milestone
+
+## Run Instructions
+
+Run the completed solution:
+
+```bash
+go run ./01-foundations/05-functions-and-errors/7-order-summary
+```
+
+Run the starter scaffold:
+
+```bash
+go run ./01-foundations/05-functions-and-errors/7-order-summary/_starter
+```
+
+Run the automated verification surface:
+
+```bash
+go test ./01-foundations/05-functions-and-errors/7-order-summary
+```
+
+## Recommended Learning Flow
+
+1. Read this README first.
+2. Open [_starter/main.go](./_starter/main.go) and list the functions you need.
+3. Build the validators first.
+4. Add `sumPrices`, `buildSummary`, and `processOrder` after that.
+5. Compare with [main.go](./main.go) only after your own attempt.
+
+## Code Walkthrough
+
+### `func validateOrderName(name string) error {`
+
+This first validator checks whether the order name is meaningful enough to continue.
+
+### `func validatePrices(prices []int) error {`
+
+This validator rejects:
+
+- an empty slice
+- any negative price
+
+That keeps the later math honest.
+
+### `func validateShipping(shipping int) error {`
+
+This validator is intentionally small.
+It teaches that not every helper needs to be complex to be useful.
+
+### `func sumPrices(prices []int) int {`
+
+This helper does one job only:
+add all prices together.
+
+### `func buildSummary(name string, subtotal int, shipping int) string {`
+
+This helper keeps formatting separate from validation and calculation.
+
+### `func processOrder(name string, prices []int, shipping int) (string, error) {`
+
+This is the milestone's most important function.
+It owns the sequence of the work:
+
+1. validate the name
+2. validate the prices
+3. validate shipping
+4. calculate subtotal
+5. build the final summary
+
+### `return "", err`
+
+Whenever validation fails, the function returns immediately with:
+
+- an empty summary
+- the real error
+
+That is the foundations version of honest failure handling.
+
+### `return buildSummary(name, subtotal, shipping), nil`
+
+This success line makes the final contract clear:
+
+- summary on success
+- `nil` error on success
+
+## Try It
+
+1. Add one more price to the success case and observe the total.
+2. Change shipping to a negative number and follow the failure path.
+3. Replace the order name with only spaces and confirm the name validation still fails.
+
+## Success Criteria
+
+Your finished solution should:
+
+- reject empty or invalid input before calculating
+- keep validation, calculation, and formatting in separate helpers
+- return explicit errors instead of hiding failure
+- keep `main()` readable by delegating to `processOrder`
+- pass the supplied tests
+
+## Common Failure Modes
+
+- trying to calculate totals before validating the inputs
+- returning a misleading summary when an error should stop the flow
+- mixing formatting and validation into one giant function
+- forgetting to check `err` before using the returned summary
+
+## Verification Surface
+
+Use these three proof surfaces together:
+
+1. `go run ./01-foundations/05-functions-and-errors/7-order-summary`
+2. `go run ./01-foundations/05-functions-and-errors/7-order-summary/_starter`
+3. `go test ./01-foundations/05-functions-and-errors/7-order-summary`
+
+## Next Step
+
+After this milestone, move to
+[2 Types and Design](../../../docs/stages/02-types-and-design.md).

--- a/01-foundations/05-functions-and-errors/7-order-summary/_starter/main.go
+++ b/01-foundations/05-functions-and-errors/7-order-summary/_starter/main.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import "fmt"
+
+// 05 Functions and Errors - Order Summary (Exercise Starter)
+//
+// Mental model:
+// Build small helpers first, then let one function coordinate the whole flow.
+//
+// Run: go run ./01-foundations/05-functions-and-errors/7-order-summary/_starter
+
+// TODO: Implement validateOrderName(name string) error
+// TODO: Implement validatePrices(prices []int) error
+// TODO: Implement validateShipping(shipping int) error
+// TODO: Implement sumPrices(prices []int) int
+// TODO: Implement buildSummary(name string, subtotal int, shipping int) string
+// TODO: Implement processOrder(name string, prices []int, shipping int) (string, error)
+
+func main() {
+	fmt.Println("=== Order Summary Exercise ===")
+	fmt.Println()
+	fmt.Println("TODO: Build the order summary using foundations-level functions and errors.")
+	fmt.Println("Start with the validators, then add sumPrices, buildSummary, and processOrder.")
+	fmt.Println()
+	fmt.Println("When finished, compare your solution with ../main.go")
+}

--- a/01-foundations/05-functions-and-errors/7-order-summary/main.go
+++ b/01-foundations/05-functions-and-errors/7-order-summary/main.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// 05 Functions and Errors - Order Summary (Exercise)
+//
+// Mental model:
+// Smaller helpers validate and calculate, and one orchestration function keeps
+// the whole flow readable.
+//
+// Run: go run ./01-foundations/05-functions-and-errors/7-order-summary
+
+func validateOrderName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("order name is required")
+	}
+
+	return nil
+}
+
+func validatePrices(prices []int) error {
+	if len(prices) == 0 {
+		return errors.New("at least one price is required")
+	}
+
+	for i, price := range prices {
+		if price < 0 {
+			return fmt.Errorf("price at index %d cannot be negative", i)
+		}
+	}
+
+	return nil
+}
+
+func validateShipping(shipping int) error {
+	if shipping < 0 {
+		return errors.New("shipping cannot be negative")
+	}
+
+	return nil
+}
+
+func sumPrices(prices []int) int {
+	total := 0
+
+	for _, price := range prices {
+		total += price
+	}
+
+	return total
+}
+
+func buildSummary(name string, subtotal int, shipping int) string {
+	total := subtotal + shipping
+	return fmt.Sprintf("%s -> subtotal: %d, shipping: %d, total: %d", name, subtotal, shipping, total)
+}
+
+func processOrder(name string, prices []int, shipping int) (string, error) {
+	if err := validateOrderName(name); err != nil {
+		return "", err
+	}
+
+	if err := validatePrices(prices); err != nil {
+		return "", err
+	}
+
+	if err := validateShipping(shipping); err != nil {
+		return "", err
+	}
+
+	subtotal := sumPrices(prices)
+	return buildSummary(name, subtotal, shipping), nil
+}
+
+func main() {
+	fmt.Println("=== Order Summary ===")
+
+	summary, err := processOrder("starter cart", []int{12, 18, 25}, 10)
+	if err != nil {
+		fmt.Println("error:", err)
+	} else {
+		fmt.Println(summary)
+	}
+
+	summary, err = processOrder(" ", []int{12, 18, 25}, 10)
+	if err != nil {
+		fmt.Println("error:", err)
+	} else {
+		fmt.Println(summary)
+	}
+
+	summary, err = processOrder("starter cart", []int{12, -3, 25}, 10)
+	if err != nil {
+		fmt.Println("error:", err)
+	} else {
+		fmt.Println(summary)
+	}
+
+	fmt.Println("\n---------------------------------------------------")
+	fmt.Println("SECTION COMPLETE: FE.7 order-summary")
+	fmt.Println("NEXT UP: 02-engineering-core")
+	fmt.Println("---------------------------------------------------")
+}

--- a/01-foundations/05-functions-and-errors/7-order-summary/main_test.go
+++ b/01-foundations/05-functions-and-errors/7-order-summary/main_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateOrderNameRejectsBlank(t *testing.T) {
+	err := validateOrderName("   ")
+	if err == nil {
+		t.Fatal("expected blank order name to fail validation")
+	}
+}
+
+func TestValidatePricesRejectsNegative(t *testing.T) {
+	err := validatePrices([]int{10, -2, 5})
+	if err == nil {
+		t.Fatal("expected negative price to fail validation")
+	}
+}
+
+func TestProcessOrderSuccess(t *testing.T) {
+	summary, err := processOrder("starter cart", []int{12, 18, 25}, 10)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	if !strings.Contains(summary, "total: 65") {
+		t.Fatalf("expected total 65 in summary, got %q", summary)
+	}
+}
+
+func TestProcessOrderRejectsNegativeShipping(t *testing.T) {
+	_, err := processOrder("starter cart", []int{12, 18, 25}, -1)
+	if err == nil {
+		t.Fatal("expected negative shipping to fail")
+	}
+}

--- a/01-foundations/05-functions-and-errors/README.md
+++ b/01-foundations/05-functions-and-errors/README.md
@@ -71,12 +71,9 @@ The canonical foundations order for this section is:
 | `FE.2` | Lesson | [parameters and returns](./2-parameters-and-returns) | teach input/output contracts |
 | `FE.3` | Lesson | [multiple return values](./3-multiple-return-values) | introduce Go's multi-result style |
 | `FE.4` | Lesson | [errors as values](./4-errors-as-values) | teach explicit failure handling |
-
-The next lessons in this rebuild are:
-
-- `FE.5` validation
-- `FE.6` orchestration
-- `FE.7` milestone project
+| `FE.5` | Lesson | [validation](./5-validation) | teach early input checks and explicit rejection |
+| `FE.6` | Lesson | [orchestration](./6-orchestration) | teach how one function coordinates smaller helpers |
+| `FE.7` | Exercise | [order summary](./7-order-summary) | prove reusable logic plus explicit failure handling in one small milestone |
 
 ## Current Rebuild Goal
 
@@ -98,8 +95,6 @@ This section is being rebuilt so that:
 
 ## Next Step
 
-The next implementation moves are:
-
-- finish the foundations lesson flow through validation and orchestration
-- rebuild the milestone around earned concepts only
-- leave later-section ideas on the legacy path instead of mixing them into the foundations route
+After `FE.7`, the learner should be ready to move into
+[2 Types and Design](../../docs/stages/02-types-and-design.md).
+That is where richer type modeling and design boundaries become the main topic.

--- a/01-foundations/05-functions-and-errors/README.md
+++ b/01-foundations/05-functions-and-errors/README.md
@@ -1,0 +1,91 @@
+# 05 Functions and Errors
+
+## Mission
+
+This section teaches learners how to turn inline logic into reusable functions and how to treat
+failure as an explicit part of a function contract.
+
+By the end of this section, a learner should be able to:
+
+- write small functions with clear parameters and return values
+- combine data-structure and control-flow knowledge inside reusable logic
+- return `(value, error)` when a result can fail
+- validate inputs before doing work
+- sequence a few small functions into one honest milestone flow
+
+## Why This Section Exists Now
+
+The learner already knows:
+
+- values and expressions
+- branching and loops
+- slices, maps, and pointer-aware mutation
+
+That is enough to ask the next engineering questions:
+
+- when should logic stop living directly inside `main()`?
+- how should one piece of code give a result back to another?
+- how should a program describe failure without hiding it?
+
+Those are function-and-error questions.
+
+## Zero-Magic Boundary
+
+This section intentionally stays inside foundations-ready ideas:
+
+- plain functions
+- parameters and return values
+- multiple return values
+- errors as values
+- validation and orchestration
+
+It does **not** make later concepts part of the foundations-critical path:
+
+- custom error types that depend on richer type modeling
+- panic / recover as ordinary program flow
+- functional options
+- package architecture and cross-file system design
+
+Those may remain in the repo as legacy or later-stage material, but they are not the primary
+foundations route.
+
+## Beta Stage Ownership
+
+This section belongs to [1 Language Fundamentals](../../docs/stages/01-language-fundamentals.md).
+
+Inside the new repo architecture, it is the fifth foundations section:
+
+1. `01-getting-started`
+2. `02-language-basics`
+3. `03-control-flow`
+4. `04-data-structures`
+5. `05-functions-and-errors`
+
+## Planned Section Shape
+
+The canonical foundations order for this section is:
+
+| ID | Planned Surface | Core Job |
+| --- | --- | --- |
+| `FE.1` | functions basics | teach what a function boundary is |
+| `FE.2` | parameters and returns | teach input/output contracts |
+| `FE.3` | multiple return values | introduce Go's multi-result style |
+| `FE.4` | errors as values | teach explicit failure handling |
+| `FE.5` | validation | teach early input checks and honest failure |
+| `FE.6` | orchestration | combine small functions into one readable flow |
+| `FE.7` | milestone project | prove reusable logic plus explicit failure handling |
+
+## Current Migration Goal
+
+This section is being rebuilt so that:
+
+- learner-facing explanation stays in lesson `README.md` files
+- `main.go` stays runnable and clean
+- the milestone proves earned foundations concepts only
+- old Section `04` material can be kept as legacy reference where helpful without confusing the new
+  primary path
+
+## Next Step
+
+The next implementation move is to rebuild the first lesson group under this section and then align
+the milestone around the new foundations scope.

--- a/01-foundations/05-functions-and-errors/README.md
+++ b/01-foundations/05-functions-and-errors/README.md
@@ -61,21 +61,24 @@ Inside the new repo architecture, it is the fifth foundations section:
 4. `04-data-structures`
 5. `05-functions-and-errors`
 
-## Planned Section Shape
+## Section Map
 
 The canonical foundations order for this section is:
 
-| ID | Planned Surface | Core Job |
-| --- | --- | --- |
-| `FE.1` | functions basics | teach what a function boundary is |
-| `FE.2` | parameters and returns | teach input/output contracts |
-| `FE.3` | multiple return values | introduce Go's multi-result style |
-| `FE.4` | errors as values | teach explicit failure handling |
-| `FE.5` | validation | teach early input checks and honest failure |
-| `FE.6` | orchestration | combine small functions into one readable flow |
-| `FE.7` | milestone project | prove reusable logic plus explicit failure handling |
+| ID | Type | Surface | Core Job |
+| --- | --- | --- | --- |
+| `FE.1` | Lesson | [functions basics](./1-functions-basics) | teach what a function boundary is |
+| `FE.2` | Lesson | [parameters and returns](./2-parameters-and-returns) | teach input/output contracts |
+| `FE.3` | Lesson | [multiple return values](./3-multiple-return-values) | introduce Go's multi-result style |
+| `FE.4` | Lesson | [errors as values](./4-errors-as-values) | teach explicit failure handling |
 
-## Current Migration Goal
+The next lessons in this rebuild are:
+
+- `FE.5` validation
+- `FE.6` orchestration
+- `FE.7` milestone project
+
+## Current Rebuild Goal
 
 This section is being rebuilt so that:
 
@@ -85,7 +88,18 @@ This section is being rebuilt so that:
 - old Section `04` material can be kept as legacy reference where helpful without confusing the new
   primary path
 
+## Suggested Learning Flow
+
+1. Read each lesson `README.md` first.
+2. Open `main.go` only after the lesson mission and machine view are clear.
+3. Run the code and compare the output with the walkthrough.
+4. Change one thing at a time using the `Try It` prompts.
+5. Move to the milestone only after the early lessons stop feeling mechanical.
+
 ## Next Step
 
-The next implementation move is to rebuild the first lesson group under this section and then align
-the milestone around the new foundations scope.
+The next implementation moves are:
+
+- finish the foundations lesson flow through validation and orchestration
+- rebuild the milestone around earned concepts only
+- leave later-section ideas on the legacy path instead of mixing them into the foundations route

--- a/01-foundations/README.md
+++ b/01-foundations/README.md
@@ -56,21 +56,22 @@ clearly and explained later in the proper section.
 
 ## Current Priority
 
-The next real rebuild under this architecture is `04-data-structures`.
+The next real rebuild under this architecture is `05-functions-and-errors`.
 
-That section is where the learner stops treating lists and lookups as tiny preview tools and starts
-working with:
+That section is where the learner stops leaving logic inline in `main()` and starts working with:
 
-- fixed-size values
-- dynamic collections
-- keyed lookup
-- pointer-based mutation
-- one small milestone that proves those ideas together
+- reusable function boundaries
+- clear parameters and return values
+- explicit failure handling
+- validation before work
+- one small milestone that proves logic plus failure together
 
 ## Next Step
 
-After `04-data-structures`, the next foundations section to make real is:
+After `05-functions-and-errors`, the foundations layer is ready for the remaining early-path
+retrofits:
 
-- `05-functions-and-errors`
+- `01-getting-started`
+- `02-language-basics`
 
 Those three sections together are the main bridge from syntax exposure to engineering thinking.

--- a/04-functions-and-errors/README.md
+++ b/04-functions-and-errors/README.md
@@ -1,5 +1,10 @@
 # Section 04: Functions and Errors
 
+> Canonical learner-facing content for this section now lives at
+> [01-foundations/05-functions-and-errors](../01-foundations/05-functions-and-errors/).
+> This legacy path remains in the repo during the architecture migration, but it is no longer the
+> primary foundations route.
+
 ## Mission
 
 This section teaches you to turn functions into explicit contracts and failures into explicit

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Each stage now has a dedicated public entry page under [docs/stages](./docs/stag
 | Beta stage | Focus | Current source content |
 | --- | --- | --- |
 | [0 Foundation](./docs/stages/00-foundation.md) | tools, execution, terminal confidence, first-run mental models | [01-core-foundations/getting-started](./01-core-foundations/getting-started/) |
-| [1 Language Fundamentals](./docs/stages/01-language-fundamentals.md) | syntax, control flow, data structures, functions, errors | [01-core-foundations/language-basics](./01-core-foundations/language-basics/), [01-foundations/03-control-flow](./01-foundations/03-control-flow/), [01-foundations/04-data-structures](./01-foundations/04-data-structures/), [04-functions-and-errors](./04-functions-and-errors/) |
+| [1 Language Fundamentals](./docs/stages/01-language-fundamentals.md) | syntax, control flow, data structures, functions, errors | [01-core-foundations/language-basics](./01-core-foundations/language-basics/), [01-foundations/03-control-flow](./01-foundations/03-control-flow/), [01-foundations/04-data-structures](./01-foundations/04-data-structures/), [01-foundations/05-functions-and-errors](./01-foundations/05-functions-and-errors/) |
 | [2 Types and Design](./docs/stages/02-types-and-design.md) | structs, interfaces, composition, text and data modeling | [05-types-and-interfaces](./05-types-and-interfaces/), [06-composition](./06-composition/), [07-strings-and-text](./07-strings-and-text/) |
 | [3 Modules and IO](./docs/stages/03-modules-and-io.md) | packages, modules, encoding, filesystems, CLI boundaries | [08-modules-and-packages](./08-modules-and-packages/), [09-io-and-cli](./09-io-and-cli/) |
 | [4 Backend Engineering](./docs/stages/04-backend-engineering.md) | HTTP, databases, handlers, application boundaries | [10-web-and-database](./10-web-and-database/) |
@@ -135,10 +135,10 @@ For the full explanation of that relationship, see
 go run ./01-core-foundations/getting-started/2-hello-world
 
 # run a starter exercise
-go run ./04-functions-and-errors/8-error-handling/_starter
+go run ./01-foundations/05-functions-and-errors/7-order-summary/_starter
 
 # compare with the canonical solution
-go run ./04-functions-and-errors/8-error-handling
+go run ./01-foundations/05-functions-and-errors/7-order-summary
 ```
 
 ## Validate The Repo

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -63,15 +63,17 @@
       "slug": "functions-and-errors",
       "title": "Functions and Errors",
       "phase": "foundations",
-      "summary": "Teach learners to shape behavior with functions, handle failure explicitly, and prepare for more structured project work.",
+      "summary": "Teach learners to turn inline logic into reusable functions, validate inputs honestly, and treat failure as an explicit return path.",
       "status": "pilot",
-      "prerequisites": [],
-      "path_prefix": "04-functions-and-errors",
+      "prerequisites": [
+        "s03"
+      ],
+      "path_prefix": "01-foundations/05-functions-and-errors",
       "entry_points": [
         "FE.1"
       ],
       "outputs": [
-        "FE.9"
+        "FE.7"
       ]
     },
     {
@@ -910,22 +912,22 @@
     {
       "id": "FE.1",
       "section_id": "s04",
-      "slug": "functions",
-      "title": "Functions",
+      "slug": "functions-basics",
+      "title": "Functions Basics",
       "type": "lesson",
       "subtype": "concept",
       "level": "foundation",
       "verification_mode": "run",
       "estimated_time": 25,
-      "summary": "Introduce basic function signatures, parameters, and return values.",
+      "summary": "Introduce named function boundaries so learners can stop leaving every step inline in main().",
       "objectives": [
-        "Define small functions with clear inputs and outputs",
-        "Read parameter and return contracts without guessing hidden behavior"
+        "Explain what a function boundary is in a beginner-friendly way",
+        "Call small named functions from main() without confusion"
       ],
       "prerequisites": [],
-      "production_relevance": "Small, explicit function contracts are the foundation for readable Go code and later error-return patterns.",
-      "path": "04-functions-and-errors/1-function",
-      "run_command": "go run ./04-functions-and-errors/1-function",
+      "production_relevance": "Readable Go programs stop scaling when every action stays inline, so named function boundaries matter early.",
+      "path": "01-foundations/05-functions-and-errors/1-functions-basics",
+      "run_command": "go run ./01-foundations/05-functions-and-errors/1-functions-basics",
       "test_command": "",
       "starter_path": "",
       "next_items": [
@@ -933,31 +935,31 @@
       ],
       "tags": [
         "functions",
-        "signatures",
+        "boundaries",
         "foundations"
       ]
     },
     {
       "id": "FE.2",
       "section_id": "s04",
-      "slug": "closures-recursion",
-      "title": "Closures and Recursion",
+      "slug": "parameters-and-returns",
+      "title": "Parameters and Returns",
       "type": "lesson",
       "subtype": "concept",
-      "level": "core",
+      "level": "foundation",
       "verification_mode": "run",
-      "estimated_time": 35,
-      "summary": "Show how functions can capture state and call themselves when the problem shape needs it.",
+      "estimated_time": 30,
+      "summary": "Teach how functions receive inputs and hand results back to the caller.",
       "objectives": [
-        "Explain how closures retain access to surrounding variables",
-        "Use recursion deliberately without losing track of the call flow"
+        "Use parameters to give a function the data it needs",
+        "Return a computed result to the caller clearly"
       ],
       "prerequisites": [
         "FE.1"
       ],
-      "production_relevance": "Closures and recursion appear in handlers, callbacks, and traversal logic, but they need disciplined readability to stay maintainable.",
-      "path": "04-functions-and-errors/2-function-2",
-      "run_command": "go run ./04-functions-and-errors/2-function-2",
+      "production_relevance": "Inputs and outputs are the base contract of application logic, helpers, handlers, and later interfaces.",
+      "path": "01-foundations/05-functions-and-errors/2-parameters-and-returns",
+      "run_command": "go run ./01-foundations/05-functions-and-errors/2-parameters-and-returns",
       "test_command": "",
       "starter_path": "",
       "next_items": [
@@ -965,45 +967,12 @@
       ],
       "tags": [
         "functions",
-        "closures",
-        "recursion"
+        "parameters",
+        "returns"
       ]
     },
     {
       "id": "FE.3",
-      "section_id": "s04",
-      "slug": "variadic-functions",
-      "title": "Variadic Functions",
-      "type": "lesson",
-      "subtype": "concept",
-      "level": "foundation",
-      "verification_mode": "run",
-      "estimated_time": 25,
-      "summary": "Introduce variadic parameters and the spread form for passing slices into function calls.",
-      "objectives": [
-        "Write functions that accept a flexible number of values",
-        "Recognize when variadic APIs improve clarity and when a slice is clearer"
-      ],
-      "prerequisites": [
-        "FE.1",
-        "FE.2"
-      ],
-      "production_relevance": "Variadic APIs are common in formatting, logging, and helpers, but they work best when the call shape stays obvious.",
-      "path": "04-functions-and-errors/3-variadic-func",
-      "run_command": "go run ./04-functions-and-errors/3-variadic-func",
-      "test_command": "",
-      "starter_path": "",
-      "next_items": [
-        "FE.4"
-      ],
-      "tags": [
-        "functions",
-        "variadic",
-        "api-design"
-      ]
-    },
-    {
-      "id": "FE.4",
       "section_id": "s04",
       "slug": "multiple-return-values",
       "title": "Multiple Return Values",
@@ -1012,18 +981,49 @@
       "level": "core",
       "verification_mode": "run",
       "estimated_time": 30,
-      "summary": "Teach Go's multi-return style and the path toward returning explicit errors as values.",
+      "summary": "Teach how one function can return more than one value when one result is not enough.",
       "objectives": [
-        "Return multiple values from a function intentionally",
-        "Explain why Go pairs useful results with explicit error returns"
+        "Return more than one value from a function intentionally",
+        "Explain why a success signal or paired value can matter as much as the main result"
       ],
       "prerequisites": [
-        "FE.1",
+        "FE.2"
+      ],
+      "production_relevance": "Multiple return values make Go contracts more explicit and prepare learners for the `(value, error)` pattern.",
+      "path": "01-foundations/05-functions-and-errors/3-multiple-return-values",
+      "run_command": "go run ./01-foundations/05-functions-and-errors/3-multiple-return-values",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "FE.4"
+      ],
+      "tags": [
+        "functions",
+        "multiple-returns",
+        "contracts"
+      ]
+    },
+    {
+      "id": "FE.4",
+      "section_id": "s04",
+      "slug": "errors-as-values",
+      "title": "Errors as Values",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "core",
+      "verification_mode": "run",
+      "estimated_time": 30,
+      "summary": "Teach the core Go rule for ordinary failure: return an error value instead of hiding the failure.",
+      "objectives": [
+        "Use `(value, error)` as a visible function contract",
+        "Check errors before trusting the returned result"
+      ],
+      "prerequisites": [
         "FE.3"
       ],
       "production_relevance": "Multiple return values are the base contract for idiomatic Go error handling and explicit control flow.",
-      "path": "04-functions-and-errors/4-function-multi-values",
-      "run_command": "go run ./04-functions-and-errors/4-function-multi-values",
+      "path": "01-foundations/05-functions-and-errors/4-errors-as-values",
+      "run_command": "go run ./01-foundations/05-functions-and-errors/4-errors-as-values",
       "test_command": "",
       "starter_path": "",
       "next_items": [
@@ -1038,24 +1038,24 @@
     {
       "id": "FE.5",
       "section_id": "s04",
-      "slug": "custom-errors",
-      "title": "Custom Errors",
+      "slug": "validation",
+      "title": "Validation",
       "type": "lesson",
-      "subtype": "pattern",
+      "subtype": "concept",
       "level": "core",
       "verification_mode": "run",
-      "estimated_time": 35,
-      "summary": "Show how to define custom error values that expose stable failure meaning.",
+      "estimated_time": 25,
+      "summary": "Teach early input checks that return explicit errors before the real work begins.",
       "objectives": [
-        "Implement custom error types that carry useful context",
-        "Use stable error identity instead of fragile string matching"
+        "Reject invalid input before calculation or formatting begins",
+        "Return helpful validation errors from small helper functions"
       ],
       "prerequisites": [
         "FE.4"
       ],
-      "production_relevance": "Stable custom errors make branching, retries, and user-safe handling easier across real Go services and tools.",
-      "path": "04-functions-and-errors/5-custom-error",
-      "run_command": "go run ./04-functions-and-errors/5-custom-error",
+      "production_relevance": "Validation keeps later logic honest by stopping clearly broken input before it spreads through the program.",
+      "path": "01-foundations/05-functions-and-errors/5-validation",
+      "run_command": "go run ./01-foundations/05-functions-and-errors/5-validation",
       "test_command": "",
       "starter_path": "",
       "next_items": [
@@ -1063,174 +1063,77 @@
       ],
       "tags": [
         "errors",
-        "custom-errors",
-        "error-identity"
+        "validation",
+        "guard-clauses"
       ]
     },
     {
       "id": "FE.6",
       "section_id": "s04",
-      "slug": "error-wrapping",
-      "title": "Error Wrapping",
+      "slug": "orchestration",
+      "title": "Orchestration",
       "type": "lesson",
-      "subtype": "pattern",
+      "subtype": "integration",
       "level": "core",
       "verification_mode": "run",
       "estimated_time": 30,
-      "summary": "Teach how to wrap low-level failures with more context while preserving inspectable error chains.",
+      "summary": "Teach how one function can coordinate validation, calculation, and formatting helpers in a readable order.",
       "objectives": [
-        "Wrap errors with contextual information using idiomatic Go patterns",
-        "Inspect wrapped errors safely with the standard library helpers"
+        "Build one orchestrating function that calls smaller helpers in order",
+        "Return early when one helper reports an error"
       ],
       "prerequisites": [
         "FE.5"
       ],
-      "production_relevance": "Wrapped errors let logs, callers, and retry logic keep context without destroying the underlying failure identity.",
-      "path": "04-functions-and-errors/5b-error-wrapping",
-      "run_command": "go run ./04-functions-and-errors/5b-error-wrapping",
+      "production_relevance": "Readable application flow often comes from one coordinating function rather than one giant block of inline logic.",
+      "path": "01-foundations/05-functions-and-errors/6-orchestration",
+      "run_command": "go run ./01-foundations/05-functions-and-errors/6-orchestration",
       "test_command": "",
       "starter_path": "",
       "next_items": [
         "FE.7"
       ],
       "tags": [
-        "errors",
-        "wrapping",
-        "inspection"
+        "functions",
+        "orchestration",
+        "flow"
       ]
     },
     {
       "id": "FE.7",
       "section_id": "s04",
-      "slug": "defer",
-      "title": "Defer",
-      "type": "lesson",
-      "subtype": "integration",
-      "level": "core",
-      "verification_mode": "run",
-      "estimated_time": 25,
-      "summary": "Introduce defer as a cleanup and completion tool that keeps function exits disciplined.",
-      "objectives": [
-        "Use defer for cleanup and completion tracking",
-        "Explain when deferred work improves reliability and when it obscures intent"
-      ],
-      "prerequisites": [
-        "FE.1",
-        "FE.5"
-      ],
-      "production_relevance": "Defer is central to cleanup in file, lock, and transaction workflows where correctness depends on predictable exit behavior.",
-      "path": "04-functions-and-errors/6-defer",
-      "run_command": "go run ./04-functions-and-errors/6-defer",
-      "test_command": "",
-      "starter_path": "",
-      "next_items": [
-        "FE.8"
-      ],
-      "tags": [
-        "defer",
-        "cleanup",
-        "control-flow"
-      ]
-    },
-    {
-      "id": "FE.8",
-      "section_id": "s04",
-      "slug": "panic-recover",
-      "title": "Panic and Recover",
-      "type": "lesson",
-      "subtype": "integration",
-      "level": "core",
-      "verification_mode": "run",
-      "estimated_time": 35,
-      "summary": "Show where panic belongs, where it does not, and how recover works only at controlled defer boundaries.",
-      "objectives": [
-        "Explain why panic is not a replacement for ordinary error returns",
-        "Recover only at deliberate safety boundaries inside deferred code"
-      ],
-      "prerequisites": [
-        "FE.7"
-      ],
-      "production_relevance": "Reliable Go code treats panic as an exceptional boundary concern rather than everyday flow control, especially in servers and workers.",
-      "path": "04-functions-and-errors/7-panic-recover",
-      "run_command": "go run ./04-functions-and-errors/7-panic-recover",
-      "test_command": "",
-      "starter_path": "",
-      "next_items": [
-        "FE.9"
-      ],
-      "tags": [
-        "panic",
-        "recover",
-        "failure-boundaries"
-      ]
-    },
-    {
-      "id": "FE.9",
-      "section_id": "s04",
-      "slug": "error-handling-project",
-      "title": "Error Handling Project",
+      "slug": "order-summary",
+      "title": "Order Summary",
       "type": "exercise",
       "subtype": "",
       "level": "core",
       "verification_mode": "mixed",
-      "estimated_time": 60,
-      "summary": "Guide learners through combining custom errors, wrapped failures, and defer-based cleanup in one focused exercise.",
+      "estimated_time": 45,
+      "summary": "Guide learners through combining validation, calculation, orchestration, and explicit errors in one small foundations-safe milestone.",
       "objectives": [
-        "Build a small program that applies the section's explicit error-handling ideas together",
-        "Preserve useful failure context by wrapping low-level errors without hiding the underlying math failure"
+        "Build a small program that validates inputs and returns an honest summary or error",
+        "Keep validation, calculation, and formatting in separate helpers while one function coordinates the whole flow"
       ],
       "prerequisites": [
         "FE.1",
+        "FE.2",
+        "FE.3",
         "FE.4",
         "FE.5",
-        "FE.6",
-        "FE.7",
-        "FE.8"
+        "FE.6"
       ],
-      "production_relevance": "Small tools and services often need to continue handling expected failures while still surfacing enough context for debugging and review.",
-      "path": "04-functions-and-errors/8-error-handling",
-      "run_command": "go run ./04-functions-and-errors/8-error-handling",
-      "test_command": "",
-      "starter_path": "04-functions-and-errors/8-error-handling/_starter",
-      "next_items": [
-        "FE.10"
-      ],
+      "production_relevance": "Small real-world tools often need to validate input, stop honestly on failure, and keep the happy path readable.",
+      "path": "01-foundations/05-functions-and-errors/7-order-summary",
+      "run_command": "go run ./01-foundations/05-functions-and-errors/7-order-summary",
+      "test_command": "go test ./01-foundations/05-functions-and-errors/7-order-summary",
+      "starter_path": "01-foundations/05-functions-and-errors/7-order-summary/_starter",
+      "next_items": [],
       "tags": [
         "exercise",
         "errors",
-        "wrapping",
-        "defer"
-      ]
-    },
-    {
-      "id": "FE.10",
-      "section_id": "s04",
-      "slug": "functional-options-pattern",
-      "title": "Functional Options Pattern",
-      "type": "lesson",
-      "subtype": "pattern",
-      "level": "stretch",
-      "verification_mode": "run",
-      "estimated_time": 35,
-      "summary": "Introduce the functional options pattern as a scalable way to configure behavior without constructor explosion.",
-      "objectives": [
-        "Explain how option functions separate defaults from configuration overrides",
-        "Recognize when the pattern helps and when it overcomplicates a small API"
-      ],
-      "prerequisites": [
-        "FE.1",
-        "FE.2"
-      ],
-      "production_relevance": "Functional options appear in many Go libraries where configuration flexibility matters, but they should be used intentionally rather than by habit.",
-      "path": "04-functions-and-errors/9-functional-options",
-      "run_command": "go run ./04-functions-and-errors/9-functional-options",
-      "test_command": "",
-      "starter_path": "",
-      "next_items": [],
-      "tags": [
-        "patterns",
-        "configuration",
-        "api-design"
+        "validation",
+        "orchestration",
+        "functions"
       ]
     },
     {

--- a/docs/stages/01-language-fundamentals.md
+++ b/docs/stages/01-language-fundamentals.md
@@ -42,7 +42,7 @@ This stage has four connected parts:
 3. `data-structures`
    - arrays, slices, maps, pointers, and mutation-aware thinking
 4. `functions-and-errors`
-   - function boundaries, multiple returns, custom errors, defer, and recover
+   - function boundaries, parameters, multiple returns, validation, orchestration, and explicit failure handling
 
 The stage is intentionally ordered from "what is a value?" to "what is a function boundary?".
 
@@ -51,7 +51,7 @@ The stage is intentionally ordered from "what is a value?" to "what is a functio
 - [01-core-foundations/language-basics](../../01-core-foundations/language-basics/)
 - [01-foundations/03-control-flow](../../01-foundations/03-control-flow/)
 - [01-foundations/04-data-structures](../../01-foundations/04-data-structures/)
-- [04-functions-and-errors](../../04-functions-and-errors/)
+- [01-foundations/05-functions-and-errors](../../01-foundations/05-functions-and-errors/)
 
 ## Stage Support Docs
 
@@ -81,7 +81,7 @@ Use this order across the source sections:
 1. [01-core-foundations/language-basics](../../01-core-foundations/language-basics/)
 2. [01-foundations/03-control-flow](../../01-foundations/03-control-flow/)
 3. [01-foundations/04-data-structures](../../01-foundations/04-data-structures/)
-4. [04-functions-and-errors](../../04-functions-and-errors/)
+4. [01-foundations/05-functions-and-errors](../../01-foundations/05-functions-and-errors/)
 
 Do not skip ahead from `language-basics` into functions and errors too early.
 Control flow and data structures make the later function and error lessons much easier to
@@ -101,7 +101,7 @@ skip:
 - `LB.4`
 - `CF.5`
 - `DS.6`
-- `FE.9`
+- `FE.7`
 
 Those are the main proof surfaces that show you can actually use the stage, not just read it.
 
@@ -123,7 +123,7 @@ The current milestone backbone is:
 - `LB.4` application logger
 - `CF.5` pricing checkout
 - `DS.6` contact manager
-- `FE.9` error handling project
+- `FE.7` order summary
 
 If you can complete those four milestone surfaces honestly, you have the practical foundation for
 the next beta stage.

--- a/docs/stages/language-fundamentals/README.md
+++ b/docs/stages/language-fundamentals/README.md
@@ -15,7 +15,7 @@ Then work through the source sections in order:
 1. [01-core-foundations/language-basics](../../../01-core-foundations/language-basics/)
 2. [01-foundations/03-control-flow](../../../01-foundations/03-control-flow/)
 3. [01-foundations/04-data-structures](../../../01-foundations/04-data-structures/)
-4. [04-functions-and-errors](../../../04-functions-and-errors/)
+4. [01-foundations/05-functions-and-errors](../../../01-foundations/05-functions-and-errors/)
 
 ## What These Docs Are For
 

--- a/docs/stages/language-fundamentals/milestone-guidance.md
+++ b/docs/stages/language-fundamentals/milestone-guidance.md
@@ -12,7 +12,7 @@ Together, they show whether a learner can actually use the stage instead of only
 | `LB.4` | application logger | you can write a small Go program with named values, simple structure, and readable output |
 | `CF.5` | pricing checkout | you can combine branching, looping, switch-based rules, and safe skipping in one runnable flow |
 | `DS.6` | contact manager | you can use slices, maps, and pointers together without losing track of mutation |
-| `FE.9` | error handling project | you can model failures explicitly and use functions and cleanup in a disciplined way |
+| `FE.7` | order summary | you can validate input, orchestrate helper functions, and return explicit errors without hiding the flow |
 
 ## How To Use These Milestones
 
@@ -34,7 +34,7 @@ check backward honestly:
 - weak on basic Go program shape: start with `LB.4`
 - weak on decision logic and loops: start with `CF.5`
 - weak on collections and mutation: start with `DS.6`
-- weak on function contracts and failures: start with `FE.9`
+- weak on function contracts and failures: start with `FE.7`
 
 ## Honest Readiness Signals
 
@@ -54,4 +54,4 @@ Go back one layer:
 - `LB.4` too hard: revisit `language-basics`
 - `CF.5` too hard: revisit `if`, `for`, `break / continue`, and `switch`
 - `DS.6` too hard: revisit slices, maps, and pointers
-- `FE.9` too hard: revisit multiple returns, custom errors, wrapping, and `defer`
+- `FE.7` too hard: revisit multiple returns, errors as values, validation, and orchestration

--- a/docs/stages/language-fundamentals/stage-map.md
+++ b/docs/stages/language-fundamentals/stage-map.md
@@ -20,9 +20,9 @@ error handling.
    - core job: teach slices, maps, pointers, and mutation-aware thinking
    - milestone: `DS.6` contact manager
 4. `functions-and-errors`
-   - source: [04-functions-and-errors](../../../04-functions-and-errors/)
-   - core job: teach function boundaries, explicit failures, wrapping, and cleanup
-   - milestone: `FE.9` error handling project
+   - source: [01-foundations/05-functions-and-errors](../../../01-foundations/05-functions-and-errors/)
+   - core job: teach function boundaries, explicit failures, validation, and orchestration
+   - milestone: `FE.7` order summary
 
 ## What Each Part Adds
 
@@ -49,7 +49,8 @@ This is where the learner starts treating function signatures and errors as expl
 2. Move through `01-foundations/03-control-flow` and complete `CF.5`.
 3. Move through [01-foundations/04-data-structures](../../../01-foundations/04-data-structures/)
    and complete `DS.6`.
-4. Move through Section `04` and complete `FE.9`.
+4. Move through [01-foundations/05-functions-and-errors](../../../01-foundations/05-functions-and-errors/)
+   and complete `FE.7`.
 
 ## Bridge-Path Reminder
 
@@ -59,7 +60,7 @@ What you should not skip is proof:
 - `LB.4`
 - `CF.5`
 - `DS.6`
-- `FE.9`
+- `FE.7`
 
 ## Exit Condition
 

--- a/docs/templates/ADVANCED_CONTENT_ROADMAP.md
+++ b/docs/templates/ADVANCED_CONTENT_ROADMAP.md
@@ -1,0 +1,129 @@
+# Advanced Content Roadmap
+
+This document maps advanced overlays to the current top-level architecture.
+
+## Overview
+
+| Folder | Scope | Advanced Overlay |
+|--------|-------|------------------|
+| `01-foundations` | zero-magic basics | none beyond the local README-first contract |
+| `02-engineering-core` | deeper engineering choices | advanced thinking first |
+| `03-backend-systems` | service and data behavior | advanced thinking, production notes, backend failures |
+| `04-concurrency` | concurrent execution | advanced thinking, failure scenarios, production notes |
+| `05-architecture` | design boundaries | advanced thinking |
+| `06-production` | operations and reliability | production notes, failure scenarios |
+| `07-advanced` | performance and expert trade-offs | all advanced overlays as needed |
+| `08-projects` | integration and flagship pressure | all advanced overlays as needed |
+
+## Delivery Map
+
+### 01-foundations
+
+Advanced overlays: none by default.
+
+Keep:
+- mission
+- mental model
+- visual model where appropriate
+- machine view where appropriate
+- code walkthrough
+- try it
+- small production relevance
+
+Do not inject:
+- custom error taxonomy
+- security attack catalogs
+- concurrency failure drills
+- profiling and escape-analysis detail
+- large-scale pressure framing
+
+### 02-engineering-core
+
+Start using [THINKING_SECTIONS_ADVANCED.md](./THINKING_SECTIONS_ADVANCED.md) for topics like:
+
+- custom errors
+- wrapping and translation
+- interface design trade-offs
+- type and boundary decisions
+
+### 03-backend-systems
+
+Use:
+
+- [THINKING_SECTIONS_ADVANCED.md](./THINKING_SECTIONS_ADVANCED.md)
+- [PRODUCTION_NOTES_ADVANCED.md](./PRODUCTION_NOTES_ADVANCED.md)
+- [FAILURE_SCENARIOS_ADVANCED.md](./FAILURE_SCENARIOS_ADVANCED.md)
+
+Focus areas:
+
+- HTTP timeouts
+- request bounds
+- database pool behavior
+- handler and service failure paths
+
+### 04-concurrency
+
+Use all advanced overlays for:
+
+- goroutine leaks
+- races
+- worker pools
+- backpressure
+- shutdown behavior
+
+### 05-architecture
+
+Primarily use [THINKING_SECTIONS_ADVANCED.md](./THINKING_SECTIONS_ADVANCED.md) for:
+
+- boundaries
+- dependency direction
+- service versus module choices
+
+### 06-production
+
+Use:
+
+- [PRODUCTION_NOTES_ADVANCED.md](./PRODUCTION_NOTES_ADVANCED.md)
+- [FAILURE_SCENARIOS_ADVANCED.md](./FAILURE_SCENARIOS_ADVANCED.md)
+
+Focus areas:
+
+- graceful shutdown
+- observability
+- deployment behavior
+- operational failure handling
+
+### 07-advanced
+
+Use all advanced overlays for:
+
+- profiling
+- allocation trade-offs
+- memory retention
+- expert diagnostics
+
+### 08-projects
+
+Use all advanced overlays where the project needs:
+
+- production realism
+- system design pressure
+- failure diagnosis
+- integration reasoning
+
+## Quick Reference
+
+| Situation | Template |
+|-----------|----------|
+| later-stage design trade-offs | [THINKING_SECTIONS_ADVANCED.md](./THINKING_SECTIONS_ADVANCED.md) |
+| production behavior and operational notes | [PRODUCTION_NOTES_ADVANCED.md](./PRODUCTION_NOTES_ADVANCED.md) |
+| diagnosis and recovery drills | [FAILURE_SCENARIOS_ADVANCED.md](./FAILURE_SCENARIOS_ADVANCED.md) |
+| expert/flagship assessment surfaces | [rubric-checkpoint-template.md](./rubric-checkpoint-template.md) |
+
+## Rule
+
+Advanced content should appear only when:
+
+1. the learner already owns the local syntax and happy path
+2. the added complexity helps judgment rather than just sounding impressive
+3. the lesson still matches the stage boundary

--- a/docs/templates/FAILURE_SCENARIOS_ADVANCED.md
+++ b/docs/templates/FAILURE_SCENARIOS_ADVANCED.md
@@ -1,0 +1,161 @@
+# Advanced Failure Scenarios
+
+This document is a reference for later-stage lessons that intentionally teach diagnosis and recovery.
+
+It is not a foundations template.
+
+## 1. Concurrency Failures
+
+Use in `04-concurrency`.
+
+```markdown
+### Scenario: Goroutine Leak in Background Worker
+
+**Setup:**
+```go
+for {
+    task := getTask()
+    go process(task)
+}
+```
+
+**Expected:** work continues normally
+
+**Actual:** goroutine count grows until memory pressure or collapse
+
+**Root Cause:** there is no cancellation or bound on worker creation
+
+**Solution Direction:**
+- propagate context
+- stop on cancellation
+- use bounded workers
+
+**Prevention:**
+- track goroutine count
+- review all long-lived loops for exit paths
+```
+
+```markdown
+### Scenario: Data Race in Shared Counter
+
+**Setup:**
+```go
+counter++
+```
+
+**Expected:** deterministic count
+
+**Actual:** non-deterministic results under concurrent access
+
+**Solution Direction:**
+- mutex
+- atomic
+- message passing
+
+**Prevention:**
+- run with `-race`
+- review all shared mutable state
+```
+
+## 2. Backend Failures
+
+Use in `03-backend-systems` and `06-production`.
+
+```markdown
+### Scenario: Slow Request Body Exhausts Memory
+
+**Setup:** request body is read without limits
+
+**Expected:** request completes normally
+
+**Actual:** server memory spikes or process crashes
+
+**Solution Direction:**
+- bound body size
+- enforce timeouts
+- reject oversized payloads early
+```
+
+```markdown
+### Scenario: Connection Pool Exhaustion
+
+**Setup:** too many concurrent database users without tuned pool limits
+
+**Expected:** steady throughput
+
+**Actual:** blocked requests, timeouts, or dependency collapse
+
+**Solution Direction:**
+- configure connection limits
+- add timeouts
+- monitor pool metrics
+- reduce unnecessary concurrent work
+```
+
+## 3. Performance and Memory Failures
+
+Use in `07-advanced`.
+
+```markdown
+### Scenario: Retained Backing Array
+
+**Setup:** a tiny slice view keeps a large backing array alive
+
+**Expected:** memory drops after processing
+
+**Actual:** heap stays large
+
+**Solution Direction:**
+- copy required data out
+- redesign buffer lifecycle
+- measure before and after with heap profiling
+```
+
+```markdown
+### Scenario: Allocation Regression in Hot Path
+
+**Setup:** a loop allocates every iteration
+
+**Expected:** stable throughput
+
+**Actual:** latency and GC pressure climb
+
+**Solution Direction:**
+- profile first
+- identify avoidable allocations
+- compare clarity against optimization cost
+```
+
+## Reusable Shape
+
+```markdown
+### Scenario: Name
+
+**Setup:**
+code or operating context
+
+**Expected:**
+healthy behavior
+
+**Actual:**
+broken behavior
+
+**Root Cause:**
+the real mechanism
+
+**Solution Direction:**
+- fix 1
+- fix 2
+
+**Prevention:**
+- habit 1
+- signal 2
+```
+
+## Rule
+
+Only add these scenarios when the learner can already:
+
+- read the code surface confidently
+- explain the happy path
+- benefit from a diagnosis task instead of just copying the solution

--- a/docs/templates/PRODUCTION_NOTES_ADVANCED.md
+++ b/docs/templates/PRODUCTION_NOTES_ADVANCED.md
@@ -1,0 +1,144 @@
+# Advanced Production Notes
+
+This document is a reference for later-stage lessons that need production-hardening guidance.
+
+It is not a foundations template.
+
+## 1. Backend Systems
+
+Use in `03-backend-systems`.
+
+```markdown
+## Production Notes
+
+### HTTP Timeouts
+- read timeout
+- write timeout
+- idle timeout
+- header timeout
+
+### Common Issues
+1. Slow header or body attacks
+   - Fix: set header/read timeouts
+
+2. Large request bodies
+   - Fix: bound body size before reading
+
+3. Handler-spawned background work
+   - Fix: use context, cancellation, and limits
+```
+
+## 2. Database and Stateful Services
+
+Use in `03-backend-systems` and `06-production`.
+
+```markdown
+## Production Notes
+
+### Connection Pool Management
+- max open connections
+- max idle connections
+- connection lifetime
+- idle lifetime
+
+### Common Issues
+1. Pool exhaustion
+   - Symptom: requests block or time out
+   - Fix: set limits, use timeouts, monitor pool metrics
+
+2. Deadlocks
+   - Fix: consistent lock order and shorter transactions
+
+3. Slow queries
+   - Fix: inspect plans and indexes
+```
+
+## 3. Concurrency
+
+Use in `04-concurrency` and `06-production`.
+
+```markdown
+## Production Notes
+
+### Common Issues
+1. Goroutine leaks
+   - Fix: cancellation, worker limits, shutdown discipline
+
+2. Race conditions
+   - Fix: `-race`, mutex, channels, or atomics where appropriate
+
+3. Backpressure collapse
+   - Fix: bounded queues, semaphores, admission control
+```
+
+## 4. Memory and Performance
+
+Use in `07-advanced`.
+
+```markdown
+## Production Notes
+
+### Common Issues
+1. Unbounded maps and caches
+2. Retained backing arrays
+3. Allocation-heavy hot paths
+
+### Debugging Tools
+- pprof for CPU
+- pprof for heap
+- trace for scheduler and blocking behavior
+```
+
+## 5. Shutdown and Observability
+
+Use in `06-production` and `08-projects`.
+
+```markdown
+## Production Notes
+
+### Shutdown
+1. Stop taking new work
+2. Drain in-flight work
+3. Close stateful dependencies
+4. Flush logs and exit cleanly
+
+### Observability
+- structured logs
+- request or correlation IDs
+- latency percentiles
+- error rate
+- saturation metrics
+```
+
+## Reusable Shape
+
+```markdown
+## Production Notes
+
+### Critical Configuration
+- item 1
+- item 2
+
+### Common Failure Modes
+1. Issue
+   - Symptom
+   - Fix
+
+### Monitoring Checklist
+- metric 1
+- metric 2
+
+### Debugging Commands
+```bash
+# command 1
+# command 2
+```
+```
+
+## Rule
+
+Only add this layer when the lesson already has:
+
+- a clear local mental model
+- a working happy path
+- enough earned context for operational consequences to make sense

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,17 +1,64 @@
-# Beta Templates
+# Templates
 
-These templates support the public beta learning system.
+This folder contains reusable curriculum-reference templates.
 
-They are intentionally small and reusable so new pressure, review, and checkpoint surfaces can be
-added without inventing local rules each time.
+The key rule is scope:
 
-## In This Folder
+- `01-foundations` keeps the small README-first lesson contract
+- advanced thinking, failure, and production overlays are references for later stages
+- expert and flagship assessment surfaces still use the shared [rubric-checkpoint-template.md](./rubric-checkpoint-template.md)
 
-- [Rubric and checkpoint template](./rubric-checkpoint-template.md)
+## Template Overview
 
-## Current Use
+| Template | Purpose | Use It In |
+|----------|---------|-----------|
+| [rubric-checkpoint-template.md](./rubric-checkpoint-template.md) | Expert and flagship assessment surfaces | Expert layer and flagship project |
+| [THINKING_SECTIONS_ADVANCED.md](./THINKING_SECTIONS_ADVANCED.md) | Later-stage design and trade-off prompts | `02-engineering-core` and above |
+| [PRODUCTION_NOTES_ADVANCED.md](./PRODUCTION_NOTES_ADVANCED.md) | Production-hardening overlays | `03-backend-systems`, `04-concurrency`, `06-production`, `07-advanced`, `08-projects` |
+| [FAILURE_SCENARIOS_ADVANCED.md](./FAILURE_SCENARIOS_ADVANCED.md) | Diagnosis and recovery drills | `04-concurrency` and above |
+| [ADVANCED_CONTENT_ROADMAP.md](./ADVANCED_CONTENT_ROADMAP.md) | Delivery map for advanced overlays | Maintainer reference |
 
-The first users of this template set are:
+## Foundations Rule
 
-- [9 Expert Layer](../stages/09-expert-layer.md)
-- [10 Flagship Project](../stages/10-flagship-project.md)
+For `01-foundations`, use the local lesson contract only:
+
+- mission
+- mental model where appropriate
+- visual model where appropriate
+- machine view where appropriate
+- code walkthrough
+- try it
+- small production relevance
+
+Do not force in:
+
+- custom error taxonomies
+- SQL injection or XSS exercises
+- concurrency failure drills
+- profiling and escape-analysis detail
+- "10k requests per second" pressure framing
+
+## Quick Decision Guide
+
+```text
+Is this lesson in 01-foundations?
+  Yes -> keep the basic README-first lesson contract only
+  No  -> is the lesson mainly about design trade-offs?
+           Yes -> use THINKING_SECTIONS_ADVANCED
+           No  -> is it mainly about production behavior?
+                    Yes -> use PRODUCTION_NOTES_ADVANCED
+                    No  -> is it mainly about failures and diagnosis?
+                             Yes -> use FAILURE_SCENARIOS_ADVANCED
+                             No  -> stay with the local lesson contract
+```
+
+## Guidance
+
+1. Match the template to the stage.
+2. Treat advanced templates as references, not copy-paste obligations.
+3. Keep early lessons readable before trying to make them exhaustive.
+4. Use the roadmap when a topic could fit in more than one place.
+
+## Next Reference
+
+Use [ADVANCED_CONTENT_ROADMAP.md](./ADVANCED_CONTENT_ROADMAP.md) when deciding when a later-stage concept should appear.

--- a/docs/templates/THINKING_SECTIONS_ADVANCED.md
+++ b/docs/templates/THINKING_SECTIONS_ADVANCED.md
@@ -1,0 +1,129 @@
+# Advanced Thinking Sections
+
+This document is a reference for later-stage lessons that need deeper design and trade-off prompts.
+
+It is not a foundations template.
+
+## 1. Error Design
+
+Use in `02-engineering-core` and above, after learners already understand ordinary `(value, error)` flow.
+
+```markdown
+## Thinking Questions
+
+### Error Taxonomy
+1. When should you create custom error types instead of plain errors?
+2. What is the difference between wrapping with `%w` and formatting with `%v`?
+3. How do you keep error codes stable across versions?
+
+### Recovery Strategy
+1. When should a caller retry versus return immediately?
+2. When is backoff required?
+3. Where does a circuit breaker belong?
+
+### Layer Boundaries
+1. How should repository, service, and handler layers shape errors differently?
+2. When should one layer translate an error from a lower layer?
+3. What error information should stay internal?
+```
+
+## 2. Concurrent Systems
+
+Use in `04-concurrency`.
+
+```markdown
+## Thinking Questions
+
+### Goroutine Management
+1. What is the difference between bounded and unbounded goroutine creation?
+2. How do worker pools change shutdown behavior?
+3. What makes a goroutine leak easy to miss?
+
+### Channel Design
+1. When should you use buffered versus unbuffered channels?
+2. How do channels create backpressure?
+3. When is fan-out/fan-in a good fit?
+
+### Synchronization
+1. When is a mutex simpler than a channel?
+2. When is `RWMutex` worth the complexity?
+3. What state should never be shared directly?
+```
+
+## 3. Performance and Memory
+
+Use in `07-advanced`.
+
+```markdown
+## Thinking Questions
+
+### Memory Behavior
+1. What is escape analysis and when does it matter?
+2. What changes when data moves from stack to heap?
+3. What allocation patterns increase GC pressure?
+
+### Measurement
+1. When should you profile instead of guessing?
+2. How do CPU and memory profiles answer different questions?
+3. What is the hot path in this code?
+
+### Trade-offs
+1. When is micro-optimization worth the readability cost?
+2. How do you compare clarity against allocation savings?
+3. Which optimization would you reject even if it benchmarks faster?
+```
+
+## 4. System Design
+
+Use in `07-advanced` and `08-projects`.
+
+```markdown
+## Thinking Questions
+
+### Architecture
+1. What boundary is this design trying to protect?
+2. When is a monolith better than a distributed design?
+3. Which dependency direction keeps the system easiest to change?
+
+### Reliability
+1. What breaks first when a dependency slows down?
+2. Where should rate limiting or load shedding happen?
+3. How would you stop one subsystem from cascading failure into another?
+
+### Observability
+1. What signal would tell you the system is degraded before users complain?
+2. When is logging enough, and when do you need metrics or tracing?
+3. What would make a 3 AM incident easier to debug?
+```
+
+## Reusable Shape
+
+```markdown
+## Thinking Questions
+
+### Design Level
+- What decision is this lesson really about?
+- What trade-off does the learner need to justify?
+
+### Boundary Level
+- What inputs, outputs, or dependencies make this tricky?
+- What should stay simple even if other parts grow?
+
+### Failure Level
+- What breaks first?
+- What evidence would prove the diagnosis?
+
+### Evolution Level
+- How would this design change in a larger system?
+- What extension would you reject for now?
+```
+
+## Rule
+
+Use these prompts when the learner has already earned:
+
+- the core syntax
+- the local mental model
+- the basic happy path
+
+Foundations should stay with smaller, local questions.

--- a/scripts/internal/curriculumvalidator/validator.go
+++ b/scripts/internal/curriculumvalidator/validator.go
@@ -124,6 +124,7 @@ func Validate(root string, report func(string)) (Result, error) {
 	}
 
 	pressureErrors := validatePressureDocs(root, report)
+	templateErrors := validateTemplateDocs(root, report)
 
 	return Result{
 		LessonCount:    lessonCount,
@@ -131,7 +132,7 @@ func Validate(root string, report func(string)) (Result, error) {
 		V2SectionCount: v2SectionCount,
 		V2ItemCount:    v2ItemCount,
 		HasV2:          hasV2,
-		ErrorCount:     pathErrors + runErrors + v2Errors + pressureErrors,
+		ErrorCount:     pathErrors + runErrors + v2Errors + pressureErrors + templateErrors,
 	}, nil
 }
 
@@ -788,6 +789,28 @@ func validatePressureDocs(root string, report func(string)) int {
 
 	errorsFound += validateRubricSurfaceDirectory(root, "docs/stages/expert-layer/tasks", report)
 	errorsFound += validateRubricSurfaceDirectory(root, "docs/stages/flagship-project/checkpoints", report)
+
+	return errorsFound
+}
+
+func validateTemplateDocs(root string, report func(string)) int {
+	errorsFound := 0
+
+	templateDocs := []string{
+		"docs/templates/README.md",
+		"docs/templates/THINKING_SECTIONS_ADVANCED.md",
+		"docs/templates/PRODUCTION_NOTES_ADVANCED.md",
+		"docs/templates/FAILURE_SCENARIOS_ADVANCED.md",
+		"docs/templates/ADVANCED_CONTENT_ROADMAP.md",
+	}
+
+	for _, relPath := range templateDocs {
+		if !pathExists(root, relPath) {
+			continue
+		}
+
+		errorsFound += validateMarkdownLocalLinks(root, relPath, report)
+	}
 
 	return errorsFound
 }

--- a/scripts/internal/curriculumvalidator/validator.go
+++ b/scripts/internal/curriculumvalidator/validator.go
@@ -495,8 +495,107 @@ func validateV2Curriculum(root string, report func(string)) (int, int, int, bool
 	errorsFound += validateV2LessonNavigation(root, cur.Items, report)
 	errorsFound += validateV2SectionLabels(root, sectionIDs, cur.Items, report)
 	errorsFound += validateV2TextEncoding(root, sectionIDs, cur.Items, report)
+	errorsFound += validateFoundationsReadmeContracts(root, cur.Items, report)
 
 	return len(cur.Sections), len(cur.Items), errorsFound, true, nil
+}
+
+func validateFoundationsReadmeContracts(root string, items []V2Item, report func(string)) int {
+	errorsFound := 0
+
+	for _, item := range items {
+		itemPath := filepath.ToSlash(filepath.Clean(item.Path))
+		if !strings.HasPrefix(itemPath, "01-foundations/") {
+			continue
+		}
+
+		readmePath := filepath.ToSlash(filepath.Join(itemPath, "README.md"))
+		if !pathExists(root, readmePath) {
+			report(fmt.Sprintf("Missing foundations lesson README: %s -> %s", item.ID, readmePath))
+			errorsFound++
+			continue
+		}
+
+		errorsFound += validateMarkdownLocalLinks(root, readmePath, report)
+		errorsFound += validateRequiredHeadingsForItem(root, readmePath, item, report)
+	}
+
+	return errorsFound
+}
+
+func validateRequiredHeadingsForItem(root, readmePath string, item V2Item, report func(string)) int {
+	errorsFound := 0
+
+	requiredHeadings := []string{
+		"## Mission",
+		"## Run Instructions",
+		"## Try It",
+		"## Next Step",
+	}
+
+	itemPath := filepath.ToSlash(filepath.Clean(item.Path))
+	if item.Type == "lesson" {
+		requiredHeadings = append(requiredHeadings, "## Code Walkthrough")
+	} else {
+		errorsFound += validateAtLeastOneHeading(root, readmePath, item.ID, []string{"## Code Walkthrough", "## Solution Walkthrough"}, report)
+	}
+
+	if strings.HasPrefix(itemPath, "01-foundations/04-data-structures/") || strings.HasPrefix(itemPath, "01-foundations/05-functions-and-errors/") {
+		requiredHeadings = append(requiredHeadings, "## Visual Model")
+	}
+
+	if item.Type == "lesson" && (strings.HasPrefix(itemPath, "01-foundations/04-data-structures/") || strings.HasPrefix(itemPath, "01-foundations/05-functions-and-errors/")) {
+		requiredHeadings = append(requiredHeadings, "## Mental Model")
+	}
+
+	if strings.HasPrefix(itemPath, "01-foundations/05-functions-and-errors/") {
+		requiredHeadings = append(requiredHeadings, "## Machine View")
+	}
+
+	if item.StarterPath != "" || strings.TrimSpace(item.TestCommand) != "" || item.VerificationMode == "mixed" || item.VerificationMode == "test" {
+		requiredHeadings = append(requiredHeadings, "## Verification Surface")
+	}
+
+	errorsFound += validateRequiredHeadingsWithID(root, readmePath, item.ID, requiredHeadings, report)
+
+	return errorsFound
+}
+
+func validateAtLeastOneHeading(root, relPath, itemID string, headings []string, report func(string)) int {
+	data, err := os.ReadFile(filepath.Join(root, relPath))
+	if err != nil {
+		report(fmt.Sprintf("Failed to read foundations README: %s -> %v", filepath.ToSlash(relPath), err))
+		return 1
+	}
+
+	text := string(data)
+	for _, heading := range headings {
+		if strings.Contains(text, heading) {
+			return 0
+		}
+	}
+
+	report(fmt.Sprintf("Invalid foundations README contract: %s -> %s must include one of %s", itemID, filepath.ToSlash(relPath), strings.Join(headings, ", ")))
+	return 1
+}
+
+func validateRequiredHeadingsWithID(root, relPath, itemID string, headings []string, report func(string)) int {
+	data, err := os.ReadFile(filepath.Join(root, relPath))
+	if err != nil {
+		report(fmt.Sprintf("Failed to read foundations README: %s -> %v", filepath.ToSlash(relPath), err))
+		return 1
+	}
+
+	text := string(data)
+	errorsFound := 0
+	for _, heading := range headings {
+		if !strings.Contains(text, heading) {
+			report(fmt.Sprintf("Invalid foundations README contract: %s -> %s missing %s", itemID, filepath.ToSlash(relPath), heading))
+			errorsFound++
+		}
+	}
+
+	return errorsFound
 }
 
 var mojibakeMarkers = []string{

--- a/scripts/internal/curriculumvalidator/validator_test.go
+++ b/scripts/internal/curriculumvalidator/validator_test.go
@@ -458,6 +458,35 @@ Use the checkpoint set:
 	}
 }
 
+func TestValidateRejectsBrokenTemplateDocLink(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
+	writeFile(t, root, "docs/templates/README.md", `# Templates
+
+- [Roadmap](./ADVANCED_CONTENT_ROADMAP.md)
+`)
+	writeFile(t, root, "docs/templates/ADVANCED_CONTENT_ROADMAP.md", `# Roadmap
+
+- [Missing](./DOES_NOT_EXIST.md)
+`)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount != 1 {
+		t.Fatalf("expected 1 validation error, got %d with reports %v", result.ErrorCount, reports)
+	}
+	if !containsReport(reports, "Broken local doc link: docs/templates/ADVANCED_CONTENT_ROADMAP.md -> ./DOES_NOT_EXIST.md") {
+		t.Fatalf("expected broken-template-link error in reports: %v", reports)
+	}
+}
+
 func TestValidateAcceptsFoundationsReadmeContract(t *testing.T) {
 	root := t.TempDir()
 

--- a/scripts/internal/curriculumvalidator/validator_test.go
+++ b/scripts/internal/curriculumvalidator/validator_test.go
@@ -458,6 +458,274 @@ Use the checkpoint set:
 	}
 }
 
+func TestValidateAcceptsFoundationsReadmeContract(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
+	writeFile(t, root, "curriculum.v2.json", `{
+  "schema_version": 1,
+  "sections": [
+    {
+      "id": "s04",
+      "number": "04",
+      "slug": "functions-and-errors",
+      "title": "Functions and Errors",
+      "path_prefix": "01-foundations/05-functions-and-errors",
+      "entry_points": ["FE.1"],
+      "outputs": ["FE.1"],
+      "prerequisites": []
+    }
+  ],
+  "items": [
+    {
+      "id": "FE.1",
+      "section_id": "s04",
+      "slug": "functions-basics",
+      "title": "Functions Basics",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "foundation",
+      "verification_mode": "run",
+      "path": "01-foundations/05-functions-and-errors/1-functions-basics",
+      "prerequisites": [],
+      "run_command": "go run ./01-foundations/05-functions-and-errors/1-functions-basics",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": []
+    }
+  ]
+}`)
+
+	mustMkdir(t, root, "01-foundations/05-functions-and-errors/1-functions-basics")
+	writeFile(t, root, "01-foundations/05-functions-and-errors/1-functions-basics/README.md", `# FE.1
+
+## Mission
+
+mission
+
+## Prerequisites
+
+- none
+
+## Mental Model
+
+mental model
+
+## Visual Model
+
+diagram
+
+## Machine View
+
+machine view
+
+## Run Instructions
+
+go run ./01-foundations/05-functions-and-errors/1-functions-basics
+
+## Code Walkthrough
+
+walkthrough
+
+## Try It
+
+1. try
+
+## Next Step
+
+next
+`)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount != 0 {
+		t.Fatalf("expected 0 validation errors, got %d with reports %v", result.ErrorCount, reports)
+	}
+}
+
+func TestValidateRejectsFoundationsReadmeMissingMachineView(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
+	writeFile(t, root, "curriculum.v2.json", `{
+  "schema_version": 1,
+  "sections": [
+    {
+      "id": "s04",
+      "number": "04",
+      "slug": "functions-and-errors",
+      "title": "Functions and Errors",
+      "path_prefix": "01-foundations/05-functions-and-errors",
+      "entry_points": ["FE.1"],
+      "outputs": ["FE.1"],
+      "prerequisites": []
+    }
+  ],
+  "items": [
+    {
+      "id": "FE.1",
+      "section_id": "s04",
+      "slug": "functions-basics",
+      "title": "Functions Basics",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "foundation",
+      "verification_mode": "run",
+      "path": "01-foundations/05-functions-and-errors/1-functions-basics",
+      "prerequisites": [],
+      "run_command": "go run ./01-foundations/05-functions-and-errors/1-functions-basics",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": []
+    }
+  ]
+}`)
+
+	mustMkdir(t, root, "01-foundations/05-functions-and-errors/1-functions-basics")
+	writeFile(t, root, "01-foundations/05-functions-and-errors/1-functions-basics/README.md", `# FE.1
+
+## Mission
+
+mission
+
+## Prerequisites
+
+- none
+
+## Mental Model
+
+mental model
+
+## Visual Model
+
+diagram
+
+## Run Instructions
+
+go run ./01-foundations/05-functions-and-errors/1-functions-basics
+
+## Code Walkthrough
+
+walkthrough
+
+## Try It
+
+1. try
+
+## Next Step
+
+next
+`)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount != 1 {
+		t.Fatalf("expected 1 validation error, got %d with reports %v", result.ErrorCount, reports)
+	}
+	if !containsReport(reports, "Invalid foundations README contract: FE.1 -> 01-foundations/05-functions-and-errors/1-functions-basics/README.md missing ## Machine View") {
+		t.Fatalf("expected missing-machine-view error in reports: %v", reports)
+	}
+}
+
+func TestValidateRejectsFoundationsExerciseMissingVerificationSurface(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
+	writeFile(t, root, "curriculum.v2.json", `{
+  "schema_version": 1,
+  "sections": [
+    {
+      "id": "s04",
+      "number": "04",
+      "slug": "functions-and-errors",
+      "title": "Functions and Errors",
+      "path_prefix": "01-foundations/05-functions-and-errors",
+      "entry_points": ["FE.7"],
+      "outputs": ["FE.7"],
+      "prerequisites": []
+    }
+  ],
+  "items": [
+    {
+      "id": "FE.7",
+      "section_id": "s04",
+      "slug": "order-summary",
+      "title": "Order Summary",
+      "type": "exercise",
+      "subtype": "",
+      "level": "core",
+      "verification_mode": "mixed",
+      "path": "01-foundations/05-functions-and-errors/7-order-summary",
+      "prerequisites": [],
+      "run_command": "go run ./01-foundations/05-functions-and-errors/7-order-summary",
+      "test_command": "go test ./01-foundations/05-functions-and-errors/7-order-summary",
+      "starter_path": "01-foundations/05-functions-and-errors/7-order-summary/_starter",
+      "next_items": []
+    }
+  ]
+}`)
+
+	mustMkdir(t, root, "01-foundations/05-functions-and-errors/7-order-summary")
+	mustMkdir(t, root, "01-foundations/05-functions-and-errors/7-order-summary/_starter")
+	writeFile(t, root, "01-foundations/05-functions-and-errors/7-order-summary/README.md", `# FE.7
+
+## Mission
+
+mission
+
+## Visual Model
+
+diagram
+
+## Machine View
+
+machine view
+
+## Run Instructions
+
+go run ./01-foundations/05-functions-and-errors/7-order-summary
+
+## Solution Walkthrough
+
+walkthrough
+
+## Try It
+
+1. try
+
+## Next Step
+
+next
+`)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount != 1 {
+		t.Fatalf("expected 1 validation error, got %d with reports %v", result.ErrorCount, reports)
+	}
+	if !containsReport(reports, "Invalid foundations README contract: FE.7 -> 01-foundations/05-functions-and-errors/7-order-summary/README.md missing ## Verification Surface") {
+		t.Fatalf("expected missing-verification-surface error in reports: %v", reports)
+	}
+}
+
 func writeFile(t *testing.T, root, relativePath, contents string) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- add advanced reference templates for thinking, production notes, and failure scenarios
- add an advanced-content roadmap aligned to the current repo architecture
- extend the single curriculum validator to sanity-check template doc links

## Validation
- go test ./scripts/internal/curriculumvalidator
- go run ./scripts/validate_curriculum.go
