### PR TITLE
[FOUNDATIONS] Rebuild 01-getting-started canonical path

### DIFF
--- a/01-core-foundations/README.md
+++ b/01-core-foundations/README.md
@@ -7,9 +7,9 @@ write small, typed Go programs without guessing."
 
 ## Beta Routing Rule
 
-Section `01` is now one source section that feeds two different public beta stages:
+Section `01` is now one legacy source section that feeds two different public beta stages:
 
-- [0 Foundation](../docs/stages/00-foundation.md) owns `getting-started`
+- [0 Foundation](../docs/stages/00-foundation.md) owns the canonical [01-foundations/01-getting-started](../01-foundations/01-getting-started/)
 - [1 Language Fundamentals](../docs/stages/01-language-fundamentals.md) begins with `language-basics`
 
 That means this section is still one physical source area in the repo, but it is no longer one
@@ -35,7 +35,7 @@ into `LB.1` to `LB.4` as the start of [1 Language Fundamentals](../docs/stages/0
 If Go is already installed and you can run both:
 
 - `go version`
-- `go run ./01-core-foundations/getting-started/2-hello-world`
+- `go run ./01-foundations/01-getting-started/2-hello-world`
 
 you can skim `GT.1` to `GT.4` and begin the main fundamentals track at `LB.1`.
 

--- a/01-core-foundations/getting-started/README.md
+++ b/01-core-foundations/getting-started/README.md
@@ -1,47 +1,23 @@
-# Getting Started Track
+# Getting Started Track (Legacy Path)
 
-## Mission
+## Status
 
-This track removes the setup friction that usually blocks beginners before they ever reach real Go
-fundamentals.
+This folder is now a legacy source surface.
 
-## Beta Stage Ownership
+The canonical learner path has moved to:
 
-This track belongs to the public beta stage [0 Foundation](../../docs/stages/00-foundation.md).
+- [01-foundations/01-getting-started](../../01-foundations/01-getting-started/)
 
-It is the setup and first-run half of Section `01`, not the beginning of `1 Language Fundamentals`.
+## Why This Folder Still Exists
 
-By the end of this track, a learner should be able to:
+The old path is kept temporarily so historical links, older references, and transition-era docs do
+not break all at once.
 
-- verify a working Go installation
-- run a simple Go program
-- explain the purpose of `package main` and `func main()`
-- use the basic command loop: `go run`, `go fmt`, `go vet`, `go build`, `go test`
+## Use The Canonical Path Instead
 
-## Track Map
+If you are actively learning, start here:
 
-| ID | Surface | Why It Matters | Requires |
-| --- | --- | --- | --- |
-| `GT.1` | [installation](./1-installation) | Confirms Go is installed and the environment is real before deeper lessons begin. | entry |
-| `GT.2` | [hello world](./2-hello-world) | Teaches the minimum runnable Go program and the shape of `main`. | `GT.1` |
-| `GT.3` | [how Go works](./3-how-go-works) | Explains packages, compilation, and exported names in plain terms. | `GT.2` |
-| `GT.4` | [development environment](./4-dev-environment) | Establishes the everyday tool loop learners will use for the rest of the repo. | `GT.3` |
-
-## Suggested Order
-
-1. Run `GT.1` and confirm the environment works.
-2. Read and run `GT.2` carefully.
-3. Use `GT.3` to understand what Go is doing under the hood.
-4. Finish `GT.4` before moving into `LB.1` if you are new to Go tooling.
-
-## Where This Leads
-
-After this track, move into [Language Basics](../language-basics/) and start with `LB.1`.
-
-In beta routing terms:
-
-- this track is the end of `0 Foundation`
-- `LB.1` is the start of [1 Language Fundamentals](../../docs/stages/01-language-fundamentals.md)
-
-If you already know how to install Go and run simple programs, you can use this track as a quick
-tooling refresher instead of a hard gate.
+1. [GT.1 installation](../../01-foundations/01-getting-started/1-installation/)
+2. [GT.2 hello world](../../01-foundations/01-getting-started/2-hello-world/)
+3. [GT.3 how Go works](../../01-foundations/01-getting-started/3-how-go-works/)
+4. [GT.4 development environment](../../01-foundations/01-getting-started/4-dev-environment/)

--- a/01-foundations/01-getting-started/1-installation/README.md
+++ b/01-foundations/01-getting-started/1-installation/README.md
@@ -1,0 +1,133 @@
+# GT.1 Installation Verification
+
+## Mission
+
+Confirm that Go is installed and that this machine can actually run a Go program.
+
+This lesson is intentionally simple.
+The point is not to impress the learner.
+The point is to prove that the environment is real.
+
+## Why This Lesson Exists Now
+
+Beginners often lose confidence before programming even starts.
+They are not stuck on logic yet.
+They are stuck on setup.
+
+So the first lesson should answer one clear question:
+
+Can this computer run Go code successfully?
+
+## Mental Model
+
+Running a Go lesson means:
+
+1. the `go` tool reads the source files
+2. Go compiles them
+3. the compiled program runs
+4. the terminal shows the output
+
+If this lesson runs, the whole learning loop becomes much more trustworthy.
+
+## Visual Model
+
+```text
+you type:
+go run ./01-foundations/01-getting-started/1-installation
+```
+
+```text
+Go tool:
+source code -> compile -> execute -> terminal output
+```
+
+```text
+successful output means:
+- Go is installed
+- the repo path is correct
+- the terminal can run the toolchain
+```
+
+## Machine View
+
+This lesson calls values from Go's `runtime` package.
+That package exposes information about the program that is currently running.
+
+When the lesson prints:
+
+- Go version
+- operating system
+- architecture
+- CPU count
+
+it is reading facts from the running binary and the current machine environment.
+
+## Run Instructions
+
+```bash
+go run ./01-foundations/01-getting-started/1-installation
+```
+
+## Code Walkthrough
+
+### `package main`
+
+This file belongs to the special `main` package.
+That tells Go this code should build into an executable program, not a reusable library.
+
+### `import ("fmt" "runtime")`
+
+The program needs two standard-library packages:
+
+- `fmt` to print output
+- `runtime` to inspect the running program and machine details
+
+### `fmt.Println("Go installation looks healthy.")`
+
+This prints the first human-facing success message.
+It gives the learner a fast confidence signal before any detail lines appear.
+
+### `runtime.Version()`
+
+This returns the Go version that built the running program.
+It answers: "Which Go toolchain is active right now?"
+
+### `runtime.GOOS` and `runtime.GOARCH`
+
+These identify the operating system and processor architecture.
+
+Examples:
+
+- `windows/amd64`
+- `linux/amd64`
+- `darwin/arm64`
+
+### `runtime.NumCPU()`
+
+This shows how many logical CPUs the program can see.
+The beginner does not need concurrency yet.
+They only need to see that a running program can inspect its environment.
+
+### `fmt.Println("NEXT UP: GT.2 hello-world")`
+
+The footer keeps the lesson path explicit.
+A beginner should never have to guess where to go next.
+
+## Try It
+
+1. Run `go version` in the terminal before or after this lesson and compare it to the program output.
+2. Change the first message text and rerun the lesson.
+3. Add one more `fmt.Println(...)` line and confirm the program still runs.
+
+## Common Questions
+
+- Why does a setup lesson need code?
+  Because the goal is not only to install Go. The goal is to prove the machine can run a real Go
+  program from this repo.
+
+- Why print system facts this early?
+  Because it helps the learner connect "program output" with "real machine state."
+
+## Next Step
+
+Continue to `GT.2` hello world.

--- a/01-foundations/01-getting-started/1-installation/main.go
+++ b/01-foundations/01-getting-started/1-installation/main.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func main() {
+	fmt.Println("Go installation looks healthy.")
+	fmt.Printf("Go version:   %s\n", runtime.Version())
+	fmt.Printf("OS/Arch:      %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Printf("Logical CPUs: %d\n", runtime.NumCPU())
+	fmt.Println()
+	fmt.Println("---------------------------------------------------")
+	fmt.Println("NEXT UP: GT.2 hello-world")
+	fmt.Println("Current: GT.1 (installation)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/01-foundations/01-getting-started/2-hello-world/README.md
+++ b/01-foundations/01-getting-started/2-hello-world/README.md
@@ -1,0 +1,132 @@
+# GT.2 Hello World
+
+## Mission
+
+Learn the smallest useful shape of an executable Go program.
+
+This lesson teaches the learner what a Go program must have in order to run at all.
+
+## Why This Lesson Exists Now
+
+After installation works, the learner needs to see a complete program that still feels small enough
+to understand line by line.
+
+That means learning:
+
+- why `package main` exists
+- why `func main()` matters
+- how `import` gives access to standard-library code
+- how printed output reaches the terminal
+
+## Mental Model
+
+A minimal Go program has a clear shape:
+
+1. declare the package
+2. import what the file needs
+3. define `main`
+4. run statements inside `main`
+
+That shape repeats through the whole curriculum.
+
+## Visual Model
+
+```text
+package main
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, World!")
+}
+```
+
+```text
+program shape:
+
+package -> imports -> main function -> output
+```
+
+## Machine View
+
+When you run this lesson, Go does not read one line and immediately print it the way a shell
+script might feel.
+
+Instead, the `go` tool:
+
+1. compiles the source file into a runnable program
+2. starts execution at `main`
+3. executes each statement inside `main`
+4. writes output to standard output, which the terminal displays
+
+That is why Go can catch many mistakes before the program ever starts.
+
+## Run Instructions
+
+```bash
+go run ./01-foundations/01-getting-started/2-hello-world
+```
+
+## Code Walkthrough
+
+### `package main`
+
+This line tells Go the file belongs to the executable package.
+Without `package main`, the `go run` flow would not know to build a runnable program from this
+file.
+
+### `import "fmt"`
+
+The file needs Go's formatting package so it can print output.
+Imports are how one package gains access to code from another package.
+
+### `func main() {`
+
+This is the program entry point.
+Execution begins here.
+If the file has helper code but no `main` function, the program cannot start as an executable.
+
+### `fmt.Println("Hello, World! Welcome to The Go Engineer.")`
+
+This prints a full line of text.
+`Println` adds a newline at the end, so the next output starts on a new line.
+
+### `fmt.Println("Go was created at", "Google", "in", 2009)`
+
+This shows that `Println` can print more than one value.
+It inserts spaces between the values automatically.
+
+### `language := "Go"` and `year := 2009`
+
+These two lines store small values in variables.
+The section is not formally teaching variables yet.
+It is only showing that printed output can come from named values as well as direct text.
+
+### `fmt.Printf("%s was created in %d\n", language, year)`
+
+`Printf` gives more control than `Println`.
+
+This line says:
+
+- `%s` should be replaced by a string
+- `%d` should be replaced by an integer
+- `\n` should end the line
+
+That helps the learner see that output can be shaped, not only dumped.
+
+## Try It
+
+1. Change the welcome message text and rerun the lesson.
+2. Change `year := 2009` to another number and inspect the final line.
+3. Add one more `fmt.Println(...)` line below the existing output.
+
+## Common Questions
+
+- Why is `main` special?
+  Because executable Go programs start there.
+
+- Why do we need `fmt` just to print?
+  Because printing functionality lives in a package, and Go makes package use explicit.
+
+## Next Step
+
+Continue to `GT.3` how Go works.

--- a/01-foundations/01-getting-started/2-hello-world/main.go
+++ b/01-foundations/01-getting-started/2-hello-world/main.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World! Welcome to The Go Engineer.")
+	fmt.Println("Go was created at", "Google", "in", 2009)
+
+	language := "Go"
+	year := 2009
+	fmt.Printf("%s was created in %d\n", language, year)
+
+	fmt.Println()
+	fmt.Println("---------------------------------------------------")
+	fmt.Println("NEXT UP: GT.3 how-go-works")
+	fmt.Println("Current: GT.2 (hello-world)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/01-foundations/01-getting-started/3-how-go-works/README.md
+++ b/01-foundations/01-getting-started/3-how-go-works/README.md
@@ -1,0 +1,130 @@
+# GT.3 How Go Works
+
+## Mission
+
+Build a beginner-safe mental model for packages, imports, compilation, and exported names.
+
+This lesson is not trying to teach every compiler detail.
+It is trying to make the basic workflow feel explainable.
+
+## Why This Lesson Exists Now
+
+After `hello world`, beginners often know that the code runs but not why it runs.
+
+This lesson answers a few important "behind the scenes" questions:
+
+- What is a package?
+- What does `import` really do?
+- Why can one file call `strings.ToUpper(...)`?
+- What happens when `go run` is executed?
+
+## Mental Model
+
+Go organizes code into packages.
+A package groups related code and gives it a name.
+
+This file uses several packages:
+
+- `fmt` for printing
+- `strings` for string operations
+- `math` for mathematical functions
+
+The program does not own those tools.
+It borrows them through imports.
+
+## Visual Model
+
+```text
+this file
+  |
+  +--> fmt.Println(...)
+  +--> strings.ToUpper(...)
+  +--> strings.Split(...)
+  +--> math.Sqrt(...)
+```
+
+```text
+go run
+  |
+  +--> read source
+  +--> compile program
+  +--> run executable
+  +--> show terminal output
+```
+
+## Machine View
+
+The Go toolchain builds this program before it runs.
+
+That means:
+
+- imported package code is resolved during the build
+- function calls are type-checked before execution
+- the final program starts only after compilation succeeds
+
+So when the learner sees printed output, they are seeing the result of a compiled executable, not a
+line-by-line interpreter loop.
+
+## Run Instructions
+
+```bash
+go run ./01-foundations/01-getting-started/3-how-go-works
+```
+
+## Code Walkthrough
+
+### `import ("fmt" "math" "strings")`
+
+This lesson imports more than one package because it wants to show that one program can use several
+different tools at once.
+
+### `greeting := "hello, go developer!"`
+
+The program begins with a plain string value.
+That gives the `strings` package something to work on.
+
+### `strings.ToUpper(greeting)`
+
+This calls a function named `ToUpper` from the `strings` package.
+
+The capital `T` matters.
+In Go, names that start with an uppercase letter are exported, which means other packages may use
+them.
+
+### `strings.Contains(greeting, "go")`
+
+This asks a yes-or-no question about the string and returns a boolean answer.
+The learner does not need full boolean theory yet.
+They only need to see that package functions can return useful results, not only print text.
+
+### `strings.Split("one,two,three", ",")`
+
+This turns one string into multiple parts.
+It is an early preview that packages can transform data, not just display it.
+
+### `math.Pi`, `math.Sqrt(144)`, and `math.Pow(2, 10)`
+
+These lines show two things:
+
+- packages can expose values like `Pi`
+- packages can expose functions like `Sqrt` and `Pow`
+
+That helps the learner see imports as access to organized capabilities.
+
+## Try It
+
+1. Change `greeting` and see how `ToUpper` and `Contains` react.
+2. Change `"one,two,three"` to another comma-separated string.
+3. Replace `math.Sqrt(144)` with `math.Sqrt(81)` and rerun.
+
+## Common Questions
+
+- Why do package functions use `packageName.FunctionName(...)`?
+  Because Go makes package ownership explicit at the call site.
+
+- Why are some names uppercase?
+  In Go, uppercase names are exported for use from other packages.
+
+## Next Step
+
+Continue to `GT.4` development environment.

--- a/01-foundations/01-getting-started/3-how-go-works/main.go
+++ b/01-foundations/01-getting-started/3-how-go-works/main.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+func main() {
+	greeting := "hello, go developer!"
+	upper := strings.ToUpper(greeting)
+	hasGo := strings.Contains(greeting, "go")
+	parts := strings.Split("one,two,three", ",")
+
+	fmt.Println("Original:   ", greeting)
+	fmt.Println("Uppercase:  ", upper)
+	fmt.Println("Contains go:", hasGo)
+	fmt.Println("Split parts:", parts)
+	fmt.Printf("Pi:         %.2f\n", math.Pi)
+	fmt.Printf("Sqrt(144):  %.0f\n", math.Sqrt(144))
+	fmt.Printf("2^10:       %.0f\n", math.Pow(2, 10))
+	fmt.Println()
+	fmt.Println("---------------------------------------------------")
+	fmt.Println("NEXT UP: GT.4 dev-environment")
+	fmt.Println("Current: GT.3 (how-go-works)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/01-foundations/01-getting-started/4-dev-environment/README.md
+++ b/01-foundations/01-getting-started/4-dev-environment/README.md
@@ -1,0 +1,116 @@
+# GT.4 Development Environment
+
+## Mission
+
+Learn the basic command loop that makes day-to-day Go work predictable.
+
+This lesson is the bridge between "I can run one program" and "I know the basic tools I will keep
+using across the repo."
+
+## Why This Lesson Exists Now
+
+A beginner who can run one lesson still needs one more confidence layer:
+
+- how to format code
+- how to compile code
+- how to run tests
+- how to recognize whether editor support is installed
+
+That is what this lesson establishes.
+
+## Mental Model
+
+The Go toolchain is a working loop, not a single command.
+
+The beginner-safe version of that loop is:
+
+1. write or change code
+2. run `go fmt`
+3. run `go build` or `go run`
+4. run `go test` when tests exist
+
+That loop repeats through the whole curriculum.
+
+## Visual Model
+
+```text
+edit code
+   |
+   +--> go fmt
+   +--> go build or go run
+   +--> go test
+```
+
+```text
+editor support:
+
+gopls -> code intelligence
+gofmt -> standard formatting
+```
+
+## Machine View
+
+These commands do different jobs:
+
+- `go fmt` rewrites source files into Go's standard style
+- `go build` compiles packages to verify they are valid
+- `go run` compiles and executes in one step
+- `go test` builds and runs tests
+
+This lesson also checks whether some tools can be found on the machine path.
+That is why it uses `exec.LookPath(...)`.
+
+## Run Instructions
+
+```bash
+go run ./01-foundations/01-getting-started/4-dev-environment
+```
+
+## Code Walkthrough
+
+### `commands := []commandInfo{ ... }`
+
+The lesson stores the important Go commands in a small slice of labeled records.
+That keeps the output readable without repeating nearly identical `fmt.Printf(...)` blocks.
+
+### `for _, command := range commands { ... }`
+
+This loop prints the command list in a consistent format.
+The learner does not need to master loops here.
+They only need to recognize that repetition can print structured output cleanly.
+
+### `tools := []toolInfo{ ... }`
+
+This second list describes the editor-support tools the lesson wants to check.
+
+### `exec.LookPath(tool.name)`
+
+This asks the operating system whether a tool is available on the command path.
+
+If the tool is found, the lesson prints where it lives.
+If it is missing, the lesson prints a helpful note instead.
+
+### `fmt.Println("NEXT UP: LB.1 variables")`
+
+The footer connects this section to the next learning surface.
+It tells the learner they are leaving setup and moving toward language fundamentals.
+
+## Try It
+
+1. Run `go fmt ./...` in the repo root after reading this lesson.
+2. Run `go build ./...` in the repo root and see whether the command finishes quietly.
+3. Temporarily add a fake tool name to the tool list and inspect the "not found" branch.
+
+## Common Questions
+
+- Why is `go fmt` such a big deal in Go?
+  Because Go intentionally uses one standard formatting style so teams do not waste energy arguing
+  about formatting rules.
+
+- Why can `go build` finish with no output?
+  In Go, a successful build often says nothing. Silence usually means success.
+
+## Next Step
+
+Continue to `LB.1` variables once `02-language-basics` is rebuilt, or move through the currently
+available canonical foundations path from `03-control-flow` onward.

--- a/01-foundations/01-getting-started/4-dev-environment/main.go
+++ b/01-foundations/01-getting-started/4-dev-environment/main.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+type commandInfo struct {
+	name        string
+	description string
+}
+
+type toolInfo struct {
+	name string
+}
+
+func main() {
+	commands := []commandInfo{
+		{name: "go fmt ./...", description: "format Go code into the standard style"},
+		{name: "go build ./...", description: "compile packages to verify they are valid"},
+		{name: "go run ./01-foundations/01-getting-started/2-hello-world", description: "compile and execute one target"},
+		{name: "go test ./...", description: "run tests across the repo"},
+	}
+
+	tools := []toolInfo{
+		{name: "gofmt"},
+		{name: "gopls"},
+	}
+
+	fmt.Printf("Go version: %s\n", runtime.Version())
+	fmt.Printf("OS/Arch:    %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Println()
+	fmt.Println("Core Go commands:")
+	for _, command := range commands {
+		fmt.Printf("- %-16s %s\n", command.name, command.description)
+	}
+
+	fmt.Println()
+	fmt.Println("Tool check:")
+	for _, tool := range tools {
+		path, err := exec.LookPath(tool.name)
+		if err != nil {
+			fmt.Printf("- %s: not found on PATH\n", tool.name)
+			continue
+		}
+		fmt.Printf("- %s: %s\n", tool.name, path)
+	}
+
+	fmt.Println()
+	fmt.Println("---------------------------------------------------")
+	fmt.Println("NEXT UP: LB.1 variables")
+	fmt.Println("Current: GT.4 (dev-environment)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/01-foundations/01-getting-started/README.md
+++ b/01-foundations/01-getting-started/README.md
@@ -1,0 +1,73 @@
+# 01 Getting Started
+
+## Mission
+
+This section helps a complete beginner cross the first real threshold:
+
+- Go is installed
+- the terminal is no longer mysterious
+- a tiny program can run successfully
+- the learner can explain the basic shape of a Go program
+
+The goal is not to race into syntax.
+The goal is to replace fear with a reliable first-run loop.
+
+## Why This Section Exists Now
+
+Before a learner can think about control flow, data structures, or functions, they need one calm,
+repeatable truth:
+
+1. open the repo
+2. run a program
+3. read the output
+4. change something small
+5. run it again
+
+That loop is the real foundation for everything that follows.
+
+## Section Map
+
+| ID | Lesson | What It Unlocks |
+| --- | --- | --- |
+| `GT.1` | [installation](./1-installation/) | confirms that Go is installed and runnable |
+| `GT.2` | [hello world](./2-hello-world/) | teaches the minimum executable Go program |
+| `GT.3` | [how Go works](./3-how-go-works/) | explains packages, imports, and compilation at a beginner-safe level |
+| `GT.4` | [development environment](./4-dev-environment/) | establishes the everyday command loop used across the repo |
+
+## Zero-Magic Boundary
+
+This section stays intentionally small.
+
+It does not try to teach:
+
+- variables in depth
+- branching and loops
+- functions as a design tool
+- data structures as a problem-solving system
+
+It only teaches enough to make the learner operational and calm.
+
+## How To Use This Section
+
+For each lesson:
+
+1. read the `README.md`
+2. open `main.go`
+3. run the lesson
+4. make one small change
+5. run it again
+
+That order matters.
+The README explains what to look for before the learner stares at code.
+
+## Finish This Section When
+
+- `go run` feels familiar instead of scary
+- the learner can explain what `package main` and `func main()` are doing
+- the learner can move between folders and run lessons without panic
+- the learner can use the basic command loop: `go run`, `go fmt`, `go build`, and `go test`
+
+## Next Step
+
+Move to [02-language-basics](../02-language-basics/) after this section is rebuilt, or continue to
+[03-control-flow](../03-control-flow/) if you are following the currently available canonical path.

--- a/01-foundations/README.md
+++ b/01-foundations/README.md
@@ -56,22 +56,23 @@ clearly and explained later in the proper section.
 
 ## Current Priority
 
-The next real rebuild under this architecture is `05-functions-and-errors`.
-
-That section is where the learner stops leaving logic inline in `main()` and starts working with:
-
-- reusable function boundaries
-- clear parameters and return values
-- explicit failure handling
-- validation before work
-- one small milestone that proves logic plus failure together
-
-## Next Step
-
-After `05-functions-and-errors`, the foundations layer is ready for the remaining early-path
-retrofits:
+The current rebuild line is moving backward to finish the front of Foundations:
 
 - `01-getting-started`
 - `02-language-basics`
 
-Those three sections together are the main bridge from syntax exposure to engineering thinking.
+That work matters because the later canonical sections are already in place:
+
+- `03-control-flow`
+- `04-data-structures`
+- `05-functions-and-errors`
+
+## Next Step
+
+Once `01-getting-started` and `02-language-basics` are rebuilt, the whole foundations layer will
+share one learner contract from the very first lesson onward:
+
+- README first
+- clean code second
+- zero-magic sequencing
+- one obvious next step at the end of every lesson

--- a/LEARNING-PATH.md
+++ b/LEARNING-PATH.md
@@ -228,7 +228,7 @@ Choose your target stage from the table above and use the Targeted Path honestly
 
 The beta stages regroup the current source sections like this:
 
-- `0 Foundation`: `01-core-foundations/getting-started`
+- `0 Foundation`: `01-foundations/01-getting-started`
 - `1 Language Fundamentals`: `01-core-foundations/language-basics`, `02`, `03`, `04`
 - `2 Types and Design`: `05`, `06`, `07`
 - `3 Modules and IO`: `08`, `09`

--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,10 @@ clean: ## Remove build artifacts
 
 ## Run Examples
 run-hello: ## Run the Hello World example
-	go run ./01-core-foundations/getting-started/2-hello-world
+	go run ./01-foundations/01-getting-started/2-hello-world
 
 run-env: ## Run the environment check
-	go run ./01-core-foundations/getting-started/4-dev-environment
+	go run ./01-foundations/01-getting-started/4-dev-environment
 
 ## Coverage
 cover: ## Run tests with coverage report

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ git clone https://github.com/rasel9t6/the-go-engineer.git
 cd the-go-engineer
 go mod download
 go version
-go run ./01-core-foundations/getting-started/2-hello-world
+go run ./01-foundations/01-getting-started/2-hello-world
 ```
 
 ## Beta Public Curriculum
@@ -47,7 +47,7 @@ Each stage now has a dedicated public entry page under [docs/stages](./docs/stag
 
 | Beta stage | Focus | Current source content |
 | --- | --- | --- |
-| [0 Foundation](./docs/stages/00-foundation.md) | tools, execution, terminal confidence, first-run mental models | [01-core-foundations/getting-started](./01-core-foundations/getting-started/) |
+| [0 Foundation](./docs/stages/00-foundation.md) | tools, execution, terminal confidence, first-run mental models | [01-foundations/01-getting-started](./01-foundations/01-getting-started/) |
 | [1 Language Fundamentals](./docs/stages/01-language-fundamentals.md) | syntax, control flow, data structures, functions, errors | [01-core-foundations/language-basics](./01-core-foundations/language-basics/), [01-foundations/03-control-flow](./01-foundations/03-control-flow/), [01-foundations/04-data-structures](./01-foundations/04-data-structures/), [01-foundations/05-functions-and-errors](./01-foundations/05-functions-and-errors/) |
 | [2 Types and Design](./docs/stages/02-types-and-design.md) | structs, interfaces, composition, text and data modeling | [05-types-and-interfaces](./05-types-and-interfaces/), [06-composition](./06-composition/), [07-strings-and-text](./07-strings-and-text/) |
 | [3 Modules and IO](./docs/stages/03-modules-and-io.md) | packages, modules, encoding, filesystems, CLI boundaries | [08-modules-and-packages](./08-modules-and-packages/), [09-io-and-cli](./09-io-and-cli/) |
@@ -132,7 +132,7 @@ For the full explanation of that relationship, see
 
 ```bash
 # run a lesson
-go run ./01-core-foundations/getting-started/2-hello-world
+go run ./01-foundations/01-getting-started/2-hello-world
 
 # run a starter exercise
 go run ./01-foundations/05-functions-and-errors/7-order-summary/_starter

--- a/curriculum.json
+++ b/curriculum.json
@@ -12,7 +12,7 @@
                     "is_entry": true,
                     "is_exercise": false,
                     "sub_graph": "Getting Started",
-                    "path": "01-core-foundations/getting-started/1-installation"
+          "path": "01-foundations/01-getting-started/1-installation"
                 },
                 {
                     "id": "GS.2",
@@ -24,7 +24,7 @@
                     "is_entry": false,
                     "is_exercise": false,
                     "sub_graph": "Getting Started",
-                    "path": "01-core-foundations/getting-started/2-hello-world"
+          "path": "01-foundations/01-getting-started/2-hello-world"
                 },
                 {
                     "id": "GS.3",
@@ -36,7 +36,7 @@
                     "is_entry": false,
                     "is_exercise": false,
                     "sub_graph": "Getting Started",
-                    "path": "01-core-foundations/getting-started/3-how-go-works"
+          "path": "01-foundations/01-getting-started/3-how-go-works"
                 },
                 {
                     "id": "GS.4",
@@ -48,7 +48,7 @@
                     "is_entry": false,
                     "is_exercise": false,
                     "sub_graph": "Getting Started",
-                    "path": "01-core-foundations/getting-started/4-dev-environment"
+          "path": "01-foundations/01-getting-started/4-dev-environment"
                 },
                 {
                     "id": "LB.1",

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -674,8 +674,8 @@
       ],
       "prerequisites": [],
       "production_relevance": "A learner cannot build reliable habits until the local Go toolchain and environment are actually working.",
-      "path": "01-core-foundations/getting-started/1-installation",
-      "run_command": "go run ./01-core-foundations/getting-started/1-installation",
+      "path": "01-foundations/01-getting-started/1-installation",
+      "run_command": "go run ./01-foundations/01-getting-started/1-installation",
       "test_command": "",
       "starter_path": "",
       "next_items": [
@@ -706,8 +706,8 @@
         "GT.1"
       ],
       "production_relevance": "Understanding the minimal shape of a Go program makes later package, tool, and build concepts much easier to absorb.",
-      "path": "01-core-foundations/getting-started/2-hello-world",
-      "run_command": "go run ./01-core-foundations/getting-started/2-hello-world",
+      "path": "01-foundations/01-getting-started/2-hello-world",
+      "run_command": "go run ./01-foundations/01-getting-started/2-hello-world",
       "test_command": "",
       "starter_path": "",
       "next_items": [
@@ -738,8 +738,8 @@
         "GT.2"
       ],
       "production_relevance": "Early package and compilation intuition reduces confusion once the curriculum reaches modules, testing, and architecture.",
-      "path": "01-core-foundations/getting-started/3-how-go-works",
-      "run_command": "go run ./01-core-foundations/getting-started/3-how-go-works",
+      "path": "01-foundations/01-getting-started/3-how-go-works",
+      "run_command": "go run ./01-foundations/01-getting-started/3-how-go-works",
       "test_command": "",
       "starter_path": "",
       "next_items": [
@@ -770,8 +770,8 @@
         "GT.3"
       ],
       "production_relevance": "Teams rely on a repeatable tool loop long before they reach advanced architecture or deployment work.",
-      "path": "01-core-foundations/getting-started/4-dev-environment",
-      "run_command": "go run ./01-core-foundations/getting-started/4-dev-environment",
+      "path": "01-foundations/01-getting-started/4-dev-environment",
+      "run_command": "go run ./01-foundations/01-getting-started/4-dev-environment",
       "test_command": "",
       "starter_path": "",
       "next_items": [

--- a/docs/stages/00-foundation.md
+++ b/docs/stages/00-foundation.md
@@ -23,7 +23,7 @@ If you are new to programming or terminals, use this order:
 
 1. read [foundation/first-run-checklist.md](./foundation/first-run-checklist.md)
 2. read [foundation/terminal-and-files.md](./foundation/terminal-and-files.md)
-3. run the source track in [01-core-foundations/getting-started](../../01-core-foundations/getting-started/)
+3. run the source track in [01-foundations/01-getting-started](../../01-foundations/01-getting-started/)
 4. use [foundation/workflow-confidence.md](./foundation/workflow-confidence.md) when something feels
    confusing or fragile
 
@@ -40,7 +40,7 @@ sanity pass instead of a long stop.
 
 ## Current Source Content
 
-- [01-core-foundations/getting-started](../../01-core-foundations/getting-started/)
+- [01-foundations/01-getting-started](../../01-foundations/01-getting-started/)
 
 Beta support docs:
 
@@ -53,10 +53,10 @@ Beta support docs:
 
 Use the current source lessons in this order:
 
-1. [GT.1 installation](../../01-core-foundations/getting-started/1-installation/)
-2. [GT.2 hello world](../../01-core-foundations/getting-started/2-hello-world/)
-3. [GT.3 how Go works](../../01-core-foundations/getting-started/3-how-go-works/)
-4. [GT.4 development environment](../../01-core-foundations/getting-started/4-dev-environment/)
+1. [GT.1 installation](../../01-foundations/01-getting-started/1-installation/)
+2. [GT.2 hello world](../../01-foundations/01-getting-started/2-hello-world/)
+3. [GT.3 how Go works](../../01-foundations/01-getting-started/3-how-go-works/)
+4. [GT.4 development environment](../../01-foundations/01-getting-started/4-dev-environment/)
 
 Practical rule:
 
@@ -90,8 +90,8 @@ Before moving on, review:
 
 Then rerun:
 
-- [GT.2 hello world](../../01-core-foundations/getting-started/2-hello-world/)
-- [GT.4 development environment](../../01-core-foundations/getting-started/4-dev-environment/)
+- [GT.2 hello world](../../01-foundations/01-getting-started/2-hello-world/)
+- [GT.4 development environment](../../01-foundations/01-getting-started/4-dev-environment/)
 
 ## Next Stage
 

--- a/docs/stages/foundation/README.md
+++ b/docs/stages/foundation/README.md
@@ -13,7 +13,7 @@ curriculum.
 
 Then move into the current source track:
 
-- [01-core-foundations/getting-started](../../../01-core-foundations/getting-started/)
+- [01-foundations/01-getting-started](../../../01-foundations/01-getting-started/)
 
 ## What These Docs Are For
 

--- a/docs/stages/foundation/first-run-checklist.md
+++ b/docs/stages/foundation/first-run-checklist.md
@@ -16,15 +16,15 @@ happened."
 
 ```bash
 go version
-go run ./01-core-foundations/getting-started/2-hello-world
+go run ./01-foundations/01-getting-started/2-hello-world
 ```
 
 5. Open and run:
 
-- [GT.1 installation](../../../01-core-foundations/getting-started/1-installation/)
-- [GT.2 hello world](../../../01-core-foundations/getting-started/2-hello-world/)
-- [GT.3 how Go works](../../../01-core-foundations/getting-started/3-how-go-works/)
-- [GT.4 development environment](../../../01-core-foundations/getting-started/4-dev-environment/)
+- [GT.1 installation](../../../01-foundations/01-getting-started/1-installation/)
+- [GT.2 hello world](../../../01-foundations/01-getting-started/2-hello-world/)
+- [GT.3 how Go works](../../../01-foundations/01-getting-started/3-how-go-works/)
+- [GT.4 development environment](../../../01-foundations/01-getting-started/4-dev-environment/)
 
 ## What Success Looks Like
 

--- a/docs/stages/foundation/terminal-and-files.md
+++ b/docs/stages/foundation/terminal-and-files.md
@@ -9,7 +9,7 @@ If the terminal still feels mysterious, use this page before you assume you are 
 You type a command like:
 
 ```bash
-go run ./01-core-foundations/getting-started/2-hello-world
+go run ./01-foundations/01-getting-started/2-hello-world
 ```
 
 That tells the system to run the code inside that lesson folder.
@@ -26,7 +26,7 @@ In this repo, lessons live inside folders.
 When you see a path like:
 
 ```text
-01-core-foundations/getting-started/2-hello-world
+01-foundations/01-getting-started/2-hello-world
 ```
 
 that path is pointing you to one lesson surface.

--- a/scripts/internal/curriculumvalidator/validator.go
+++ b/scripts/internal/curriculumvalidator/validator.go
@@ -391,9 +391,9 @@ func validateV2Curriculum(root string, report func(string)) (int, int, int, bool
 
 		if section, exists := sectionIDs[item.SectionID]; exists && section.PathPrefix != "" {
 			itemPath := filepath.ToSlash(filepath.Clean(item.Path))
-			sectionPrefix := filepath.ToSlash(filepath.Clean(section.PathPrefix))
-			if itemPath != sectionPrefix && !strings.HasPrefix(itemPath, sectionPrefix+"/") {
-				report(fmt.Sprintf("Invalid v2 section path alignment: %s -> %s (expected prefix %s)", item.ID, item.Path, section.PathPrefix))
+			allowedPrefixes := allowedPathPrefixesForSection(section)
+			if !matchesAnyPrefix(itemPath, allowedPrefixes) {
+				report(fmt.Sprintf("Invalid v2 section path alignment: %s -> %s (expected prefix %s)", item.ID, item.Path, strings.Join(allowedPrefixes, " or ")))
 				errorsFound++
 			}
 		}
@@ -501,6 +501,26 @@ func validateV2Curriculum(root string, report func(string)) (int, int, int, bool
 	return len(cur.Sections), len(cur.Items), errorsFound, true, nil
 }
 
+func allowedPathPrefixesForSection(section V2Section) []string {
+	prefixes := []string{filepath.ToSlash(filepath.Clean(section.PathPrefix))}
+
+	if section.ID == "s01" {
+		prefixes = append(prefixes, "01-foundations/01-getting-started")
+	}
+
+	return prefixes
+}
+
+func matchesAnyPrefix(itemPath string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if itemPath == prefix || strings.HasPrefix(itemPath, prefix+"/") {
+			return true
+		}
+	}
+
+	return false
+}
+
 func validateFoundationsReadmeContracts(root string, items []V2Item, report func(string)) int {
 	errorsFound := 0
 
@@ -539,6 +559,10 @@ func validateRequiredHeadingsForItem(root, readmePath string, item V2Item, repor
 		requiredHeadings = append(requiredHeadings, "## Code Walkthrough")
 	} else {
 		errorsFound += validateAtLeastOneHeading(root, readmePath, item.ID, []string{"## Code Walkthrough", "## Solution Walkthrough"}, report)
+	}
+
+	if strings.HasPrefix(itemPath, "01-foundations/01-getting-started/") && item.Type == "lesson" {
+		requiredHeadings = append(requiredHeadings, "## Mental Model", "## Visual Model", "## Machine View")
 	}
 
 	if strings.HasPrefix(itemPath, "01-foundations/04-data-structures/") || strings.HasPrefix(itemPath, "01-foundations/05-functions-and-errors/") {

--- a/scripts/internal/curriculumvalidator/validator_test.go
+++ b/scripts/internal/curriculumvalidator/validator_test.go
@@ -755,6 +755,94 @@ next
 	}
 }
 
+func TestValidateAcceptsGettingStartedReadmeContractAndSplitSectionPrefix(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, "curriculum.json", `{"sections":[]}`)
+	writeValidPressureDocs(t, root)
+	writeFile(t, root, "curriculum.v2.json", `{
+  "schema_version": 1,
+  "sections": [
+    {
+      "id": "s01",
+      "number": "01",
+      "slug": "core-foundations",
+      "title": "Core Foundations",
+      "path_prefix": "01-core-foundations",
+      "entry_points": ["GT.1"],
+      "outputs": ["GT.1"],
+      "prerequisites": []
+    }
+  ],
+  "items": [
+    {
+      "id": "GT.1",
+      "section_id": "s01",
+      "slug": "installation",
+      "title": "Installation Verification",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "foundation",
+      "verification_mode": "run",
+      "path": "01-foundations/01-getting-started/1-installation",
+      "prerequisites": [],
+      "run_command": "go run ./01-foundations/01-getting-started/1-installation",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": []
+    }
+  ]
+}`)
+
+	mustMkdir(t, root, "01-foundations/01-getting-started/1-installation")
+	mustMkdir(t, root, "01-core-foundations")
+	writeFile(t, root, "01-foundations/01-getting-started/1-installation/README.md", `# GT.1
+
+## Mission
+
+mission
+
+## Mental Model
+
+mental model
+
+## Visual Model
+
+diagram
+
+## Machine View
+
+machine view
+
+## Run Instructions
+
+go run ./01-foundations/01-getting-started/1-installation
+
+## Code Walkthrough
+
+walkthrough
+
+## Try It
+
+1. try
+
+## Next Step
+
+next
+`)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount != 0 {
+		t.Fatalf("expected 0 validation errors, got %d with reports %v", result.ErrorCount, reports)
+	}
+}
+
 func writeFile(t *testing.T, root, relativePath, contents string) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- build the canonical README-first getting-started section under 01-foundations/01-getting-started
- retarget GT.1 through GT.4 routing, quickstart docs, and stage-0 support docs to the new path
- update the single curriculum validator to accept the split s01 migration and require the richer getting-started lesson contract

## Validation
- go run ./01-foundations/01-getting-started/1-installation
- go run ./01-foundations/01-getting-started/2-hello-world
- go run ./01-foundations/01-getting-started/3-how-go-works
- go run ./01-foundations/01-getting-started/4-dev-environment
- go test ./scripts/internal/curriculumvalidator
- go run ./scripts/validate_curriculum.go
- git diff --check

Closes #302
Closes #303
Closes #304