### PR TITLE
[FOUNDATIONS] Rebuild 03-control-flow canonical path

### DIFF
--- a/01-foundations/01-getting-started/1-installation/main.go
+++ b/01-foundations/01-getting-started/1-installation/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/01-getting-started/2-hello-world/main.go
+++ b/01-foundations/01-getting-started/2-hello-world/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/01-getting-started/3-how-go-works/main.go
+++ b/01-foundations/01-getting-started/3-how-go-works/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/01-getting-started/4-dev-environment/main.go
+++ b/01-foundations/01-getting-started/4-dev-environment/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/02-language-basics/1-variables/main.go
+++ b/01-foundations/02-language-basics/1-variables/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Rasel Hossen
+// Licensed under The Go Engineer License v1.0
+
 package main
 
 import "fmt"

--- a/01-foundations/02-language-basics/2-constants/main.go
+++ b/01-foundations/02-language-basics/2-constants/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Rasel Hossen
+// Licensed under The Go Engineer License v1.0
+
 package main
 
 import "fmt"

--- a/01-foundations/02-language-basics/3-enums/main.go
+++ b/01-foundations/02-language-basics/3-enums/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Rasel Hossen
+// Licensed under The Go Engineer License v1.0
+
 package main
 
 import "fmt"

--- a/01-foundations/02-language-basics/4-application-logger/_starter/main.go
+++ b/01-foundations/02-language-basics/4-application-logger/_starter/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Rasel Hossen
+// Licensed under The Go Engineer License v1.0
+
 package main
 
 import "fmt"

--- a/01-foundations/02-language-basics/4-application-logger/main.go
+++ b/01-foundations/02-language-basics/4-application-logger/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Rasel Hossen
+// Licensed under The Go Engineer License v1.0
+
 package main
 
 import "fmt"

--- a/01-foundations/03-control-flow/1-if-else/README.md
+++ b/01-foundations/03-control-flow/1-if-else/README.md
@@ -14,6 +14,62 @@ Now you need to decide what happens when those values mean different things.
 
 That is what `if`, `else if`, and `else` do.
 
+## Production Relevance
+
+In production Go code, branching matters because:
+
+- **Validation**: Check if input is valid before processing
+- **Authorization**: Verify permissions before allowing actions
+- **Error handling**: Decide what to do when something fails
+- **State machines**: Transition between different program states
+
+Real services use branching for every request validation, error response, and business rule.
+
+## Mental Model
+
+Branching is about questions that have limited answers.
+
+A program asks a yes/no question (or a which-one question) and picks exactly one path to follow.
+
+The key insight is: only ONE branch runs. The others are skipped.
+
+## Visual Model
+
+```text
+condition: temperature > 30?
+    |
+    +--> true  --> print "hot"
+    |
+    +--> false --> print "okay"
+```
+
+```text
+condition: score >= 90?
+    |
+    +--> true  --> "A"
+    +--> false --> check score >= 80
+                       |
+                       +--> true --> "B"
+                       +--> false --> check score >= 70
+                                          |
+                                          +--> true --> "C"
+                                          +--> false --> "F"
+```
+
+## Machine View
+
+When an `if` statement runs, the Go runtime evaluates the condition expression.
+
+If the result is true, it executes the first block and skips all `else if` and `else` blocks.
+If false, it checks each `else if` in order.
+If none match, it runs the `else` block (if it exists).
+
+Only the selected block's code runs. The other code never executes.
+
+## Prerequisites
+
+- `LB.4` application logger (or equivalent: variables, constants, iota)
+
 ## Run Instructions
 
 ```bash

--- a/01-foundations/03-control-flow/1-if-else/main.go
+++ b/01-foundations/03-control-flow/1-if-else/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/03-control-flow/2-for-basics/README.md
+++ b/01-foundations/03-control-flow/2-for-basics/README.md
@@ -15,6 +15,60 @@ After branching, the next question is:
 
 That is the loop question.
 
+## Production Relevance
+
+In production Go code, loops matter because:
+
+- **Data processing**: Iterate over database rows, API responses, or file contents
+- **Batch operations**: Process items in chunks or queues
+- **Initialization**: Set up structures or configurations
+- **Monitoring**: Repeatedly check status or health
+
+Every real service uses loops for processing requests, logging, and background jobs.
+
+## Mental Model
+
+A loop is a way to say "do this same work for each item" or "keep doing this until something changes."
+
+The key insight: the loop body can run zero times, once, or many times depending on the condition.
+
+## Visual Model
+
+```text
+for i := 1; i <= 5; i++ {
+    print i
+}
+```
+```
+i=1 --> print 1
+i=2 --> print 2
+i=3 --> print 3
+i=4 --> print 4
+i=5 --> print 5
+i=6 (stops, condition false)
+```
+
+```text
+for countdown > 0 {
+    print countdown
+    countdown--
+}
+```
+
+## Machine View
+
+A `for` loop has three optional parts:
+
+1. **Init**: Run once before the first iteration (`i := 1`)
+2. **Condition**: Check before each iteration (`i <= 5`)
+3. **Post**: Run after each iteration (`i++`)
+
+When the condition becomes false, the loop stops and the program continues after the loop block.
+
+## Prerequisites
+
+- `CF.1` if/else
+
 ## Run Instructions
 
 ```bash

--- a/01-foundations/03-control-flow/2-for-basics/main.go
+++ b/01-foundations/03-control-flow/2-for-basics/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/03-control-flow/3-break-continue/README.md
+++ b/01-foundations/03-control-flow/3-break-continue/README.md
@@ -17,6 +17,45 @@ Once a learner can write a loop, the next question is:
 
 That is the purpose of loop control.
 
+## Production Relevance
+
+In production Go code, break and continue matter because:
+
+- **Search**: Stop processing once the target is found
+- **Validation**: Skip invalid records while processing a batch
+- **Optimization**: Exit early when further work is pointless
+- **Filtering**: Selectively process only relevant items
+
+Real services use these for search results, data validation, and early termination.
+
+## Mental Model
+
+- `break` means "stop the loop NOW and move on"
+- `continue` means "skip THIS iteration but keep looping"
+
+## Visual Model
+
+```text
+for i := 1; i <= 10; i++ {
+    if i == 7 { break }      --> stop here, exit loop
+    if i is even { continue } --> skip print, next i
+    print i
+}
+```
+
+Output: 1, 3, 5 (stops at 7)
+
+## Machine View
+
+When `break` executes, the Go runtime jumps to the first statement after the loop.
+When `continue` executes, the runtime jumps to the loop's post statement (like `i++`).
+
+Both are control-flow changes that alter the normal sequential execution.
+
+## Prerequisites
+
+- `CF.2` for basics
+
 ## Run Instructions
 
 ```bash

--- a/01-foundations/03-control-flow/3-break-continue/main.go
+++ b/01-foundations/03-control-flow/3-break-continue/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/03-control-flow/4-switch/README.md
+++ b/01-foundations/03-control-flow/4-switch/README.md
@@ -2,13 +2,67 @@
 
 ## Mission
 
-Learn how to choose between several possible paths without writing long, hard-to-read branch
-chains.
+Learn how to choose between several possible paths without writing long, hard-to-read branch chains.
 
 ## Why This Lesson Exists Now
 
 `if / else if / else` works well for a small number of branches.
 When the number of cases grows, `switch` often reads more clearly.
+
+## Production Relevance
+
+In production Go code, switch matters because:
+
+- **State handling**: Map request states or HTTP status codes
+- **Command processing**: Handle different user commands or operations
+- **Mode selection**: Choose behavior based on configuration or environment
+- **Type handling**: Differentiate between categories or kinds
+
+Real services use switch for routing, status codes, and business rule engines.
+
+## Mental Model
+
+Switch is like a multi-way if-else but organized as a table of cases.
+
+Instead of checking each condition one by one, you check one value against many possibilities.
+
+The key: only ONE case runs, and you can group multiple values in one case.
+
+## Visual Model
+
+```text
+switch day {
+case "Monday", "Tuesday", "Wednesday", "Thursday", "Friday":
+    print "weekday"
+case "Saturday", "Sunday":
+    print "weekend"
+}
+```
+
+```text
+switch {
+case score >= 90:
+    print "A"
+case score >= 80:
+    print "B"
+default:
+    print "other"
+}
+```
+
+## Machine View
+
+A switch evaluates one expression and compares it against each case in order.
+
+Unlike some languages, Go does not fall through by default.
+Once a case matches and runs, the switch ends.
+
+The `default` case runs when no other case matches.
+
+## Prerequisites
+
+- `CF.1` if/else
+- `CF.2` for basics
 
 ## Run Instructions
 

--- a/01-foundations/03-control-flow/4-switch/main.go
+++ b/01-foundations/03-control-flow/4-switch/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/03-control-flow/5-pricing-checkout/README.md
+++ b/01-foundations/03-control-flow/5-pricing-checkout/README.md
@@ -2,8 +2,7 @@
 
 ## Mission
 
-Build one small checkout flow that turns the earlier control-flow lessons into a single readable,
-runnable program.
+Build one small checkout flow that turns the earlier control-flow lessons into a single readable, runnable program.
 
 This is the section milestone.
 
@@ -14,9 +13,19 @@ The earlier lessons each taught one control-flow idea in isolation.
 This milestone asks the learner to combine them:
 
 - `if` for ordinary decisions
-- `for` for repeated work
+- `for` repeated work
 - `switch` for readable multi-branch rules
 - `continue` for skipping invalid items
+
+## Production Relevance
+
+In production Go code, combining control flow matters because:
+
+- **Order processing**: Apply pricing rules, discounts, and validation
+- **Batch jobs**: Process multiple items with different handling rules
+- **Rule engines**: Execute different logic based on conditions
+
+Real services build pricing engines, shopping carts, and checkout flows using exactly these patterns.
 
 ## Zero-Magic Boundary
 

--- a/01-foundations/03-control-flow/5-pricing-checkout/_starter/main.go
+++ b/01-foundations/03-control-flow/5-pricing-checkout/_starter/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/03-control-flow/5-pricing-checkout/main.go
+++ b/01-foundations/03-control-flow/5-pricing-checkout/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 
@@ -43,4 +43,7 @@ func main() {
 	}
 
 	fmt.Printf("subtotal: %.2f\n", subtotal)
+
+	fmt.Println()
+	fmt.Println("Section 03 complete! Ready for Data Structures.")
 }


### PR DESCRIPTION
## Summary
- Upgrade 03-control-flow section to match 02-language-basics standard
- Add Production Relevance, Mental Model, Visual Model, Machine View sections to all lessons
- Add Prerequisites sections
- Update copyright headers across all 01-foundations lessons (GT, LB, CF)

## Validation
- go run ./01-foundations/03-control-flow/1-if-else
- go run ./01-foundations/03-control-flow/2-for-basics
- go run ./01-foundations/03-control-flow/3-break-continue
- go run ./01-foundations/03-control-flow/4-switch
- go run ./01-foundations/03-control-flow/5-pricing-checkout
- go run ./scripts/validate_curriculum.go

## Issues
- Closes #310
- Closes #311
- Closes #312