### PR TITLE
[FOUNDATIONS] Rebuild 04-data-structures canonical path

### DIFF
--- a/01-foundations/04-data-structures/1-array/README.md
+++ b/01-foundations/04-data-structures/1-array/README.md
@@ -2,8 +2,7 @@
 
 ## Mission
 
-Learn what an array is in Go and why arrays matter even though slices become the more common tool
-later.
+Learn what an array is in Go and why arrays matter even though slices become the more common tool later.
 
 This lesson exists because arrays make one important rule visible early:
 
@@ -11,9 +10,18 @@ This lesson exists because arrays make one important rule visible early:
 
 That rule helps the learner understand slices by contrast in the next lesson.
 
+## Why This Lesson Exists Now
+
+After learning control flow (if, for, switch), the next question is: "How do I work with groups of values?"
+
+The learner already knows single values. Now they need to understand what happens when there are multiple values together.
+
+Arrays are the foundation for this. They show that Go has fixed-size collections, which introduces the critical concept: what gets copied and what gets shared.
+
 ## Prerequisites
 
 - Section entry for `01-foundations/04-data-structures`
+- Comfortable with `CF.2` for basics (loops)
 
 ## Mental Model
 
@@ -38,6 +46,16 @@ change copied[0] -> 99
 original = [10 20 30]
 copied   = [99 20 30]
 ```
+
+## Machine View
+
+When you declare an array in Go, the compiler allocates enough memory for all elements.
+
+An array variable contains the actual values, not a reference to them.
+
+When you copy an array with `copied := original`, Go copies every element from the original to the new location in memory.
+
+This is different from languages that use references. Here, two variables mean two independent copies.
 
 ## Run Instructions
 

--- a/01-foundations/04-data-structures/1-array/main.go
+++ b/01-foundations/04-data-structures/1-array/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/04-data-structures/2-slices/README.md
+++ b/01-foundations/04-data-structures/2-slices/README.md
@@ -2,8 +2,15 @@
 
 ## Mission
 
-Learn how Go represents dynamic collections through slices, and why `len`, `cap`, `make`, and
-`append` are all part of one connected idea.
+Learn how Go represents dynamic collections through slices, and why `len`, `cap`, `make`, and `append` are all part of one connected idea.
+
+## Why This Lesson Exists Now
+
+Arrays taught you about fixed-size collections and value copying. But real programs need to handle data that grows and shrinks.
+
+That is what slices do. They are Go's primary way to work with dynamic collections.
+
+This lesson builds on DS.1 by showing what happens when you need flexibility.
 
 ## Prerequisites
 
@@ -43,6 +50,19 @@ after append 40
 Go may allocate a larger backing array
 so the slice can keep growing
 ```
+
+## Machine View
+
+A slice is not an array. A slice is a data structure that points to an array.
+
+When you create a slice, Go creates a small "header" with three fields:
+- **pointer**: the address of the first element in the backing array
+- **len**: how many elements are currently accessible
+- **cap**: how many elements can be added before the backing array must be reallocated
+
+When you pass a slice to a function, you are passing this small header, not copying the whole backing array.
+
+When `append` needs more capacity, it allocates a new, larger backing array and copies the old elements over.
 
 ## Run Instructions
 

--- a/01-foundations/04-data-structures/2-slices/main.go
+++ b/01-foundations/04-data-structures/2-slices/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/04-data-structures/3-maps/README.md
+++ b/01-foundations/04-data-structures/3-maps/README.md
@@ -2,8 +2,15 @@
 
 ## Mission
 
-Learn how Go performs keyed lookup with maps and why the comma-ok pattern matters whenever a missing
-key would otherwise be ambiguous.
+Learn how Go performs keyed lookup with maps and why the comma-ok pattern matters whenever a missing key would otherwise be ambiguous.
+
+## Why This Lesson Exists Now
+
+So far you have learned about sequential data (arrays, slices). But sometimes you need to find things by name or ID, not by position.
+
+Maps solve exactly that problem: fast lookup by key instead of scanning from the start.
+
+This lesson builds on DS.2 by adding the ability to organize data by keys.
 
 ## Prerequisites
 
@@ -30,6 +37,14 @@ lookup rules
 existing key -> value + exists=true
 missing key  -> zero value + exists=false
 ```
+
+## Machine View
+
+A map in Go is a hash table. When you store a key-value pair, Go computes a hash of the key and stores the data at that location.
+
+When you look up a key, Go computes the same hash and retrieves the value.
+
+If a key does not exist, looking it up returns the zero value for the value type (0 for int, "" for string, etc.). This is why the comma-ok pattern exists: to distinguish between a missing key and a key whose value happens to be zero.
 
 ## Run Instructions
 

--- a/01-foundations/04-data-structures/3-maps/main.go
+++ b/01-foundations/04-data-structures/3-maps/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/04-data-structures/4-pointers/README.md
+++ b/01-foundations/04-data-structures/4-pointers/README.md
@@ -2,8 +2,15 @@
 
 ## Mission
 
-Learn what a pointer is, how dereferencing works, and why pointers matter when an update must
-change the original stored value rather than only a copy.
+Learn what a pointer is, how dereferencing works, and why pointers matter when an update must change the original stored value rather than only a copy.
+
+## Why This Lesson Exists Now
+
+You have learned about arrays, slices, and maps. But there is still a gap: how do you share data between parts of your program so that updates are visible everywhere?
+
+That is what pointers solve. When you pass a slice to a function, you are passing a reference. But for single values or when you need explicit sharing, pointers are the tool.
+
+This lesson builds on DS.1 (arrays as value types) and DS.2 (slices as references) to complete the picture.
 
 ## Prerequisites
 
@@ -37,6 +44,18 @@ bobPhone := &phones[1]
 
 bobPhone --> phones[1]
 ```
+
+## Machine View
+
+A pointer is a variable that stores a memory address. In Go, the zero value for a pointer is `nil`, meaning it points to nothing.
+
+When you use `&` (address-of operator), you get a pointer to the variable. When you use `*` (dereference operator), you access the value stored at that address.
+
+Unlike some languages, Go does not allow pointer arithmetic. This keeps Go safe and simple. You can only:
+- Take the address of a variable
+- Follow that address to read or write the value
+
+Slices already contain a pointer (to their backing array), which is why they can be passed to functions and have changes visible. This lesson shows you the same pattern for single values.
 
 ## Run Instructions
 

--- a/01-foundations/04-data-structures/4-pointers/main.go
+++ b/01-foundations/04-data-structures/4-pointers/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/04-data-structures/5-slices-2/README.md
+++ b/01-foundations/04-data-structures/5-slices-2/README.md
@@ -2,8 +2,15 @@
 
 ## Mission
 
-Learn why sub-slices can still affect the original data and why `append` can reuse spare capacity in
-ways that surprise beginners.
+Learn why sub-slices can still affect the original data and why `append` can reuse spare capacity in ways that surprise beginners.
+
+## Why This Lesson Exists Now
+
+You now know how to create slices and how they work. But there is a subtle trap: when you create a sub-slice, it might still share the same backing array as the original.
+
+This matters because changing data through one slice can unexpectedly change another. This is the "gotcha" that catches many Go learners.
+
+This lesson builds on DS.2 (slices) and DS.4 (pointers) by showing the connection between slice headers and shared backing arrays.
 
 ## Prerequisites
 
@@ -37,6 +44,16 @@ growth := original[2:4]
 append may still write into the original backing array
 if spare capacity exists
 ```
+
+## Machine View
+
+When you create a slice with `original[1:4]`, you are not copying the data. You are creating a new slice header that points to the same backing array.
+
+Both slices share the same underlying array. Modifying one affects the other.
+
+However, when `append` exceeds the original slice's capacity, Go allocates a new backing array and copies the data. After that point, the connection is broken.
+
+This is why understanding capacity matters: if you are working with slices derived from the same source, you might be sharing memory unintentionally.
 
 ## Run Instructions
 

--- a/01-foundations/04-data-structures/5-slices-2/main.go
+++ b/01-foundations/04-data-structures/5-slices-2/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/04-data-structures/6-contact-manager/README.md
+++ b/01-foundations/04-data-structures/6-contact-manager/README.md
@@ -2,12 +2,21 @@
 
 ## Mission
 
-Build a small in-memory contact directory that turns the `04-data-structures` lessons into one
-coherent runnable exercise.
+Build a small in-memory contact directory that turns the `04-data-structures` lessons into one coherent runnable exercise.
 
 This is the `04-data-structures` milestone.
-It is where slices, maps, and pointers come together without depending on later-section abstractions
-like helper-function design or struct-heavy modeling.
+It is where slices, maps, and pointers come together without depending on later-section abstractions like helper-function design or struct-heavy modeling.
+
+## Why This Milestone Exists
+
+The earlier lessons each taught one data structure in isolation:
+- Arrays for fixed-size collections
+- Slices for dynamic collections
+- Maps for keyed lookup
+- Pointers for direct mutation
+- Slice sharing for understanding capacity
+
+Now you combine them. This mirrors real development: you rarely use just one data structure.
 
 ## Prerequisites
 

--- a/01-foundations/04-data-structures/6-contact-manager/_starter/main.go
+++ b/01-foundations/04-data-structures/6-contact-manager/_starter/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 

--- a/01-foundations/04-data-structures/6-contact-manager/main.go
+++ b/01-foundations/04-data-structures/6-contact-manager/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Rasel Hossen
-// See LICENSE for usage terms.
+// Licensed under The Go Engineer License v1.0
 
 package main
 


### PR DESCRIPTION
## Summary
- Upgrade 04-data-structures section to match README-first standard
- Add Why This Lesson Exists Now section to all lessons
- Add Machine View section to all lessons
- Update Prerequisites sections
- Update copyright headers to Licensed under The Go Engineer License v1.0

## Validation
- go run ./01-foundations/04-data-structures/1-array
- go run ./01-foundations/04-data-structures/2-slices
- go run ./01-foundations/04-data-structures/3-maps
- go run ./01-foundations/04-data-structures/4-pointers
- go run ./01-foundations/04-data-structures/5-slices-2
- go run ./scripts/validate_curriculum.go

## Issues
- Closes #314
- Closes #315