### PR TITLE
[FEAT] strengthen FE.7 after the function-ordering rewrite

### DIFF
--- a/03-functions-errors/7-order-summary/README.md
+++ b/03-functions-errors/7-order-summary/README.md
@@ -2,7 +2,7 @@
 
 ## Mission
 
-Build a small order-summary program that combines validation, helper functions, multiple return values, and explicit errors into one readable flow.
+Build a small order-summary program that combines validation, helper functions, first-class functions, closures, multiple return values, and explicit errors into one readable flow.
 
 ## Prerequisites
 
@@ -12,6 +12,8 @@ Build a small order-summary program that combines validation, helper functions, 
 - `FE.4` errors as values
 - `FE.5` validation
 - `FE.6` orchestration
+- `FE.8` first-class functions
+- `FE.9` closures - mechanics
 
 ## Mental Model
 
@@ -20,6 +22,7 @@ This milestone is a pipeline of small functions:
 - validate inputs
 - stop early on error
 - calculate totals
+- apply pricing rules passed in as callbacks
 - build the final summary
 
 The goal is not cleverness. It is honest flow control with clear responsibilities.
@@ -32,15 +35,16 @@ graph TD
     B --> C["validate prices"]
     C --> D["validate shipping"]
     D --> E["sum prices"]
-    E --> F["build summary"]
-    B --> G["return error early"]
-    C --> G
-    D --> G
+    E --> F["apply pricing rules"]
+    F --> G["build summary"]
+    B --> H["return error early"]
+    C --> H
+    D --> H
 ```
 
 ## Machine View
 
-Each helper returns control to `processOrder`. If a helper returns an error, `processOrder` immediately returns that error to its caller. Only the success path reaches the calculation and summary steps.
+Each helper returns control to `processOrder`. Pricing rules are passed in as function values, and the closure-built discount rule keeps its own threshold and amount alive after the factory function returns. If any validator fails, `processOrder` returns early before the pricing pipeline runs.
 
 ## Run Instructions
 
@@ -60,13 +64,21 @@ go test ./03-functions-errors/7-order-summary
 
 This helper performs one job only: calculate the subtotal.
 
+### `applyPricingRules(subtotal int, rules ...pricingRule) int`
+
+This helper shows FE.8 directly: callers pass behavior in as function values, and the order flow applies them without knowing their internals.
+
+### `makeMinimumSubtotalDiscount(...)`
+
+This helper shows FE.9 directly: it returns a closure that captures the discount threshold and amount so the rule can be reused later.
+
 ### `buildSummary(...)`
 
-Formatting lives in its own helper so it does not get mixed into validation logic.
+Formatting lives in its own helper so it does not get mixed into validation logic, and it makes the rule-adjusted subtotal visible.
 
 ### `processOrder(...) (string, error)`
 
-This function orchestrates the whole flow and makes the contract explicit: summary on success, error on failure.
+This function orchestrates the whole flow and makes the contract explicit: summary on success, error on failure. It also shows that orchestration can accept behavior from FE.8 without losing readability.
 
 ### `return "", err`
 
@@ -75,8 +87,8 @@ Early returns keep failure handling honest and stop the flow before invalid data
 ## Try It
 
 1. Add another item price to the success case.
-2. Make shipping negative and trace the failure path.
-3. Replace the order name with only spaces and verify validation stops the flow.
+2. Change the discount threshold so the closure no longer applies to the starter order.
+3. Add a second pricing rule and trace how the adjusted subtotal changes step by step.
 
 ## Verification Surface
 
@@ -88,14 +100,14 @@ go test ./03-functions-errors/7-order-summary
 
 ## ⚠️ In Production
 
-This is the everyday shape of backend Go code: validate, return errors explicitly, keep helpers small, and make orchestration readable. Systems become fragile when these concerns collapse into one giant function.
+This is the everyday shape of backend Go code: validate, return errors explicitly, keep helpers small, and pass policy in as narrow callbacks. Closure-based configuration is common in pricing, retries, middleware, and feature-flag evaluation.
 
 ## 🤔 Thinking Questions
 
 1. Why is returning an explicit error better than hiding failure inside printed output?
-2. What gets clearer when validation, calculation, and formatting are separate helpers?
-3. Why is `processOrder` a better owner of sequence than `main()`?
+2. What gets clearer when pricing policy is passed in as a function instead of hard-coded into `processOrder`?
+3. Why is a closure a better fit for discount configuration than global variables?
 
 ## Next Step
 
-Continue to `TI.1` structs.
+Continue to `FE.10`.

--- a/03-functions-errors/7-order-summary/_starter/main.go
+++ b/03-functions-errors/7-order-summary/_starter/main.go
@@ -9,21 +9,27 @@ import "fmt"
 //
 // Mental model:
 // Build small helpers first, then let one function coordinate the whole flow.
+// Pricing rules are function values, and the discount helper is a closure that
+// captures threshold and amount.
 //
 // Run: go run ./03-functions-errors/7-order-summary/_starter
+
+type pricingRule func(int) int
 
 // TODO: Implement validateOrderName(name string) error
 // TODO: Implement validatePrices(prices []int) error
 // TODO: Implement validateShipping(shipping int) error
 // TODO: Implement sumPrices(prices []int) int
-// TODO: Implement buildSummary(name string, subtotal int, shipping int) string
-// TODO: Implement processOrder(name string, prices []int, shipping int) (string, error)
+// TODO: Implement applyPricingRules(subtotal int, rules ...pricingRule) int
+// TODO: Implement makeMinimumSubtotalDiscount(threshold int, amount int) pricingRule
+// TODO: Implement buildSummary(name string, subtotal int, adjustedSubtotal int, shipping int) string
+// TODO: Implement processOrder(name string, prices []int, shipping int, rules ...pricingRule) (string, error)
 
 func main() {
 	fmt.Println("=== Order Summary Exercise ===")
 	fmt.Println()
-	fmt.Println("TODO: Build the order summary using foundations-level functions and errors.")
-	fmt.Println("Start with the validators, then add sumPrices, buildSummary, and processOrder.")
+	fmt.Println("TODO: Build the order summary using validation helpers, pricing-rule callbacks, and a closure-based discount rule.")
+	fmt.Println("Start with the validators, then add sumPrices, applyPricingRules, makeMinimumSubtotalDiscount, and processOrder.")
 	fmt.Println()
 	fmt.Println("When finished, compare your solution with ../main.go")
 }

--- a/03-functions-errors/7-order-summary/main.go
+++ b/03-functions-errors/7-order-summary/main.go
@@ -12,10 +12,12 @@ import (
 // 05 Functions and Errors - Order Summary (Exercise)
 //
 // Mental model:
-// Smaller helpers validate and calculate, and one orchestration function keeps
-// the whole flow readable.
+// Smaller helpers validate and calculate, one orchestration function owns the
+// sequence, and pricing rules are passed in as function values.
 //
 // Run: go run ./03-functions-errors/7-order-summary
+
+type pricingRule func(int) int
 
 func validateOrderName(name string) error {
 	if strings.TrimSpace(name) == "" {
@@ -57,12 +59,47 @@ func sumPrices(prices []int) int {
 	return total
 }
 
-func buildSummary(name string, subtotal int, shipping int) string {
-	total := subtotal + shipping
-	return fmt.Sprintf("%s -> subtotal: %d, shipping: %d, total: %d", name, subtotal, shipping, total)
+func applyPricingRules(subtotal int, rules ...pricingRule) int {
+	adjusted := subtotal
+
+	for _, rule := range rules {
+		adjusted = rule(adjusted)
+		if adjusted < 0 {
+			adjusted = 0
+		}
+	}
+
+	return adjusted
 }
 
-func processOrder(name string, prices []int, shipping int) (string, error) {
+func makeMinimumSubtotalDiscount(threshold int, amount int) pricingRule {
+	return func(subtotal int) int {
+		if subtotal < threshold {
+			return subtotal
+		}
+
+		adjusted := subtotal - amount
+		if adjusted < 0 {
+			return 0
+		}
+
+		return adjusted
+	}
+}
+
+func buildSummary(name string, subtotal int, adjustedSubtotal int, shipping int) string {
+	total := adjustedSubtotal + shipping
+	return fmt.Sprintf(
+		"%s -> subtotal: %d, adjusted subtotal: %d, shipping: %d, total: %d",
+		name,
+		subtotal,
+		adjustedSubtotal,
+		shipping,
+		total,
+	)
+}
+
+func processOrder(name string, prices []int, shipping int, rules ...pricingRule) (string, error) {
 	if err := validateOrderName(name); err != nil {
 		return "", err
 	}
@@ -76,27 +113,31 @@ func processOrder(name string, prices []int, shipping int) (string, error) {
 	}
 
 	subtotal := sumPrices(prices)
-	return buildSummary(name, subtotal, shipping), nil
+	adjustedSubtotal := applyPricingRules(subtotal, rules...)
+
+	return buildSummary(name, subtotal, adjustedSubtotal, shipping), nil
 }
 
 func main() {
 	fmt.Println("=== Order Summary ===")
 
-	summary, err := processOrder("starter cart", []int{12, 18, 25}, 10)
+	vipDiscount := makeMinimumSubtotalDiscount(50, 5)
+
+	summary, err := processOrder("starter cart", []int{12, 18, 25}, 10, vipDiscount)
 	if err != nil {
 		fmt.Println("error:", err)
 	} else {
 		fmt.Println(summary)
 	}
 
-	summary, err = processOrder(" ", []int{12, 18, 25}, 10)
+	summary, err = processOrder("small cart", []int{12, 8}, 5, vipDiscount)
 	if err != nil {
 		fmt.Println("error:", err)
 	} else {
 		fmt.Println(summary)
 	}
 
-	summary, err = processOrder("starter cart", []int{12, -3, 25}, 10)
+	summary, err = processOrder(" ", []int{12, 18, 25}, 10, vipDiscount)
 	if err != nil {
 		fmt.Println("error:", err)
 	} else {
@@ -104,7 +145,7 @@ func main() {
 	}
 
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("SECTION COMPLETE: FE.7 order-summary")
-	fmt.Println("NEXT UP: 02-engineering-core")
+	fmt.Println("NEXT UP: FE.10")
+	fmt.Println("Current: FE.7 (order summary)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/03-functions-errors/7-order-summary/main_test.go
+++ b/03-functions-errors/7-order-summary/main_test.go
@@ -25,8 +25,29 @@ func TestProcessOrderSuccess(t *testing.T) {
 		t.Fatalf("expected success, got error: %v", err)
 	}
 
+	if !strings.Contains(summary, "adjusted subtotal: 55") {
+		t.Fatalf("expected adjusted subtotal 55 in summary, got %q", summary)
+	}
+
 	if !strings.Contains(summary, "total: 65") {
 		t.Fatalf("expected total 65 in summary, got %q", summary)
+	}
+}
+
+func TestProcessOrderAppliesPricingRule(t *testing.T) {
+	discount := makeMinimumSubtotalDiscount(50, 5)
+
+	summary, err := processOrder("starter cart", []int{12, 18, 25}, 10, discount)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	if !strings.Contains(summary, "adjusted subtotal: 50") {
+		t.Fatalf("expected adjusted subtotal 50 in summary, got %q", summary)
+	}
+
+	if !strings.Contains(summary, "total: 60") {
+		t.Fatalf("expected discounted total 60 in summary, got %q", summary)
 	}
 }
 


### PR DESCRIPTION
## Summary
- update FE.7 so the exercise uses first-class functions and closure-based pricing rules
- refresh the starter, lesson README, and tests to match the reordered FE.7 -> FE.8 -> FE.9 teaching flow

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go run ./scripts/validate_curriculum.go`

Closes #356
