### PR TITLE
[DOCS] lock RC baseline docs after v2.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,37 @@ Format: **[Date] - Description**. Sections: `Added`, `Fixed`, `Changed`, `Remove
 
 ---
 
+## [2026-04-22] - v2.1.0-beta.1 Beta-Complete Snapshot
+
+### Added
+
+- Published the `v2.1.0-beta.1` prerelease and public announcement as the beta-complete checkpoint for the v2.1 curriculum.
+- Promoted `release/v2` into the active RC stabilization line for the next hardening phase.
+
+### Changed
+
+- Completed the public 12-section learner-path migration across root stage folders, learner-facing docs, and `curriculum.v2.json`.
+- Tightened the single Go validator so release-facing docs, curriculum metadata, and repo health checks reflect the same source of truth more honestly.
+- Aligned public docs and stage navigation with the current root-stage architecture, including the promoted backend, concurrency, quality, architecture, production, and flagship surfaces.
+- Cleaned release-facing documentation so the beta-complete snapshot and RC branch model are explicit.
+
+### Fixed
+
+- Rewrote stale learner-facing links that still pointed to intentionally deleted `docs/stages/...` paths.
+- Resolved Stage 06 wording drift so the README matches the promoted `HS`, `API`, and `DB` metadata path.
+- Cleaned visible mojibake and release-state drift from the public docs used for learner orientation.
+
+---
+
 ## [2026-04-18] - The v2.1 12-Section Architecture Optimization
 
 ### Changed
 
-- **Curriculum Architecture Consolidation:** Optimized the drafted 21-section blueprint into a highly focused **12-Section (s00–s11)** model to reduce cognitive overhead and improve the learning progression.
+- **Curriculum Architecture Consolidation:** Optimized the drafted 21-section blueprint into a highly focused **12-Section (s00-s11)** model to reduce cognitive overhead and improve the learning progression.
 - **Documentation Alignment:** Achieved 100% alignment across all core documentation (`ARCHITECTURE.md`, `ROADMAP.md`, `CODE-STANDARDS.md`, `COMMON-MISTAKES.md`) and satellite documentation (`README.md`, `LEARNING-PATH.md`, `CURRICULUM-BLUEPRINT.md`, `TESTING-STANDARDS.md`, `CONTRIBUTING.md`, `MAINTAINER-CHECKLIST.md`, `docs/PROGRESSION.md`).
 - **Teaching Contract:** Formalized the `README`-first, `main.go`-second pedagogical contract. Every lesson now strictly requires Mission, Prerequisites, Mental Model, Visual Model, Machine View, Try It, In Production, and Thinking Questions.
 - **AI Automation Skills:** Rewrote internal AI skills (`github-workflow` and `migration`) to strictly enforce the v2.1 12-section GitHub workflow and template requirements.
-- **Next Up Navigation:** Upgraded terminal footers to output natively clickable paths (e.g., `Run: go run ./01-getting-started/2-hello-world`) for seamless navigation in VS Code and modern terminals.
+- **Next Up Navigation:** Upgraded terminal footers to output natively clickable paths (for example, `Run: go run ./01-getting-started/2-hello-world`) for seamless navigation in VS Code and modern terminals.
 
 ### Removed
 
@@ -26,13 +48,13 @@ Format: **[Date] - Description**. Sections: `Added`, `Fixed`, `Changed`, `Remove
 
 ### Added
 
-- **Strict GitHub Workflow:** Officially documented and enforced the Antigravity `github-workflow` skill across `CONTRIBUTING.md` and `MAINTAINER-CHECKLIST.md`. All future changes now require approved Issues linked to the v2 project board before drafting PRs.
+- **Strict GitHub Workflow:** Officially documented and enforced the Antigravity `github-workflow` skill across `CONTRIBUTING.md` and `MAINTAINER-CHECKLIST.md`. All future changes now require approved issues linked to the v2 project board before drafting PRs.
 
 ### Changed
 
 - **Curriculum Architecture Shift:** Fully transitioned all repository documentation from the legacy 11-stage model to the new **5-Phase, 21-Section Blueprint**.
-- **Code Standards:** Added formal guidelines for the v2 three-tier Error Framework (`UserError`, `SystemError`, `FatalError`), Context propagation, Generics, and Security practices.
-- **Testing Standards:** Updated the coverage matrix to map against the 21 sections and explicitly added required Fuzz Testing and API/gRPC testing standards.
+- **Code Standards:** Added formal guidelines for the v2 three-tier Error Framework (`UserError`, `SystemError`, `FatalError`), context propagation, generics, and security practices.
+- **Testing Standards:** Updated the coverage matrix to map against the 21 sections and explicitly added required fuzz testing and API/gRPC testing standards.
 - **Reference Remapping:** Remapped all "Common Mistakes" cross-references to point to the correct sections in the new 21-section blueprint.
 
 ### Removed
@@ -75,14 +97,14 @@ Format: **[Date] - Description**. Sections: `Added`, `Fixed`, `Changed`, `Remove
 - **Curriculum Dependency Graph:** Automated granular mapping of 15 sections across 28 sub-graphs using `curriculum.json`.
 - **Premium Console Footers:** Integrated "Next Up" context-aware navigation footers into all 115 `main.go` files.
 - **Visual Breadcrumbs:** Added previous/next/exercise navigation links to all section READMEs.
-- **Root Metadata:** Updated root `README.md` and `ROADMAP.md` with the new ID-based learning path (GS, LB, CF, etc.).
+- **Root Metadata:** Updated root `README.md` and `ROADMAP.md` with the new ID-based learning path (`GS`, `LB`, `CF`, and related section IDs).
 - **Validation Script:** Created `scripts/validate_curriculum.go` to ensure filesystem integrity for all future additions.
 
 ### Fixed
 
 - **ID Collision:** Resolved ID collisions for "Graceful Shutdown" vs "Getting Started" by implementing section-specific context namespaces.
 - **Bulk Refactor Cleanup:** Fixed widespread Go syntax errors and markdown lint issues introduced during the integration phase.
-- **[BUG] Chapter 1 Lesson 1:** Added missing instructions to `1-installation` (GS.1) boilerplate (#4).
+- **[BUG] Chapter 1 Lesson 1:** Added missing instructions to `1-installation` (`GS.1`) boilerplate (#4).
 
 ---
 
@@ -92,25 +114,25 @@ Format: **[Date] - Description**. Sections: `Added`, `Fixed`, `Changed`, `Remove
 
 - **Curriculum Architecture:** Completely refactored the legacy 28 flat-folder structure into an elite, chronologically ordered 15-chapter book format.
 - **Cross-Domain Separation:** Decoupled concepts by their primary domain, cleanly separating runtime operations (`11-concurrency/time-and-scheduling`) and external operations (`09-io-and-cli/encoding`).
-- **HTTP Domain Split:** Amputated the HTTP Clients/Mocking directory exactly down the middle, separating true HTTP networking (`10-web-and-database/http-client`) from test abstraction limits (`13-quality-and-performance/http-client-testing`).
+- **HTTP Domain Split:** Amputated the HTTP clients/mocking directory exactly down the middle, separating true HTTP networking (`10-web-and-database/http-client`) from test abstraction limits (`13-quality-and-performance/http-client-testing`).
 - **Internal Imports:** Ran a mass-migration script converting all legacy `internal/` pointers uniformly.
-- **Docs Update:** Rewrote README tables, ROADMAP tracking lists, and CONTRIBUTING guides natively reflecting the elite `v1` path routing.
+- **Docs Update:** Rewrote README tables, ROADMAP tracking lists, and CONTRIBUTING guides to reflect the elite `v1` path routing.
 
 ### Removed
 
-- DELETED the legacy compatibility `symlinks` from the repository root entirely!
+- Deleted the legacy compatibility symlinks from the repository root entirely.
 
 ---
 
-## [2026-04-04] - Phase 7 additions + bug fixes
+## [2026-04-04] - Phase 7 additions and bug fixes
 
 ### Added
 
 - **Section 23: Structured Logging** - slog basics, context-keyed logger, custom Handler, zerolog comparison
 - **Section 24: errgroup & sync.Pool** - errgroup, errgroup+context pipeline, sync.Pool, bounded pipeline resizer exercise, URL checker exercise
-- **Section 25: Profiling** - CPU profile, live `net/http/pprof` endpoint, go tool pprof workflow
+- **Section 25: Profiling** - CPU profile, live `net/http/pprof` endpoint, `go tool pprof` workflow
 - **Section 26: gRPC** - proto3 definition, unary server with interceptors, typed client stub
-- **Section 27: Graceful Shutdown** - signal.NotifyContext, http.Server.Shutdown, complete production capstone
+- **Section 27: Graceful Shutdown** - `signal.NotifyContext`, `http.Server.Shutdown`, complete production capstone
 - **Section 10 supplement** - `io/fs` as a testing seam with `fstest.MapFS`
 - **`COMMON-MISTAKES.md`** - 15 most common Go bugs with fixes and section cross-references
 - **`ROADMAP.md`** - tracks current progress and planned future sections
@@ -121,14 +143,14 @@ Format: **[Date] - Description**. Sections: `Added`, `Fixed`, `Changed`, `Remove
 - **Bug:** `23-structured-logging/3-custom-handler` - `slog.DiscardHandler` instantiation type error fixed by removing struct brackets.
 - **Bug:** `12-concurrency-patterns/3-sync-pool` - duplicate `BenchmarkWithPool` declaration causing compilation failure removed from `main.go`.
 - **Bug:** `25-profiling/1-cpu-profile` and `10-filesystem/8-fs-testing-seam` - redundant newline formatting in `fmt.Println` fixed to standard `fmt.Print`.
-- **Bug:** `26-grpc` - missing generated Protocol Buffer Go files added using `protoc` and properly imported into `gen` package.
-- **Bug:** Global repository string literals - fixed widespread compilation errors caused by improper line breaks across several past modules.
+- **Bug:** `26-grpc` - missing generated Protocol Buffer Go files added using `protoc` and properly imported into the `gen` package.
+- **Bug:** global repository string literals - fixed widespread compilation errors caused by improper line breaks across several past modules.
 
 ### Changed
 
-- `go.mod` and Dockerfiles now correctly declare `go 1.26` (was previously correct - this entry confirms it intentionally targets Go 1.26 stable)
-- README exercise table updated to include all new sections 23-27
-- README Windows CGO note added for `go-sqlite3` dependency
+- `go.mod` and Dockerfiles now correctly declare `go 1.26`.
+- README exercise table updated to include all new sections 23-27.
+- README Windows CGO note added for the `go-sqlite3` dependency.
 
 ---
 
@@ -158,4 +180,4 @@ Format: **[Date] - Description**. Sections: `Added`, `Fixed`, `Changed`, `Remove
 - Sections 00-19: complete Beginner -> Expert learning path
 - 17 exercises with `_starter/` stubs and full solutions
 - GitHub Actions CI pipeline
-- CONTRIBUTING.md with file templates and quality checklist
+- `CONTRIBUTING.md` with file templates and quality checklist

--- a/MAINTAINER-CHECKLIST.md
+++ b/MAINTAINER-CHECKLIST.md
@@ -5,7 +5,7 @@
 
 ## Daily Triage
 
-- Enforce the **GitHub Workflow**: No PRs should be reviewed unless they link to an approved Issue.
+- Enforce the **GitHub Workflow**: no PRs should be reviewed unless they link to an approved issue.
 - Confirm new contributor PRs target `main` unless the work is explicitly `v1-only`.
 - Add labels for `v1-only`, `v2`, `backport`, `release-blocker`, and `breaking-change` as early as possible.
 - Move issues into the correct milestone and add them to the **"The Go Engineer v2"** project board.
@@ -14,7 +14,7 @@
 ## PR Review & Merge Rules
 
 - **Reject** PRs that try to bypass the `README`-first teaching contract or introduce "magic" early in the curriculum (see `CURRICULUM-BLUEPRINT.md`).
-- Use **Squash and Merge** for PRs into `main`, `release/v1`, and later `release/v2`.
+- Use **Squash and Merge** for PRs into `main`, `release/v1`, and `release/v2`.
 - Never develop directly on long-lived branches.
 - If a fix belongs in both supported lines, merge it once into the correct source branch and then `git cherry-pick -x` it to the other branch.
 - Add the `backport` label before merge when that follow-up is required.
@@ -38,16 +38,16 @@ git push origin <target-branch>
 
 ## Release Flow
 
-- Tag v2 prereleases from `main` as `v2.0.0-alpha.N`.
-- Cut `release/v2` from `main` once v2 is feature complete.
+- Tag v2 prereleases from `main` as `v2.1.0-alpha.N` while the stabilization line is still open.
+- Keep `release/v2` as the active RC stabilization branch once beta-complete work is cut there.
 - Tag beta and RC builds from `release/v2`.
-- Tag final `v2.0.0` from `release/v2`.
+- Tag final `v2.1.0` from `release/v2`.
 - Keep `release/v1` for v1 patch support until you formally end support.
 
 ## Branch Hygiene
 
 - Keep `main` as the default branch.
-- Keep branch protections on `main` and `release/v1`.
+- Keep branch protections on `main`, `release/v1`, and `release/v2`.
 - Retire `release/v1.0.0` only after all external references and protections are moved to `release/v1`.
 - Auto-delete short-lived branches after merge.
 
@@ -55,11 +55,11 @@ git push origin <target-branch>
 
 Before any release, verify these documents are aligned with `ARCHITECTURE.md`:
 
-- `ROADMAP.md` — section statuses match reality
-- `LEARNING-PATH.md` — phases and section boundaries correct
-- `CURRICULUM-BLUEPRINT.md` — teaching contract matches README contract
-- `CODE-STANDARDS.md` — NEXT UP regex and templates current
-- `TESTING-STANDARDS.md` — coverage targets match section IDs
-- `COMMON-MISTAKES.md` — all "Taught in" references use correct lesson IDs
-- `docs/PROGRESSION.md` — milestone table matches `ARCHITECTURE.md` milestones
-- `CONTRIBUTING.md` — section numbering and workflow current
+- `ROADMAP.md` - section statuses match reality
+- `LEARNING-PATH.md` - phases and section boundaries correct
+- `CURRICULUM-BLUEPRINT.md` - teaching contract matches README contract
+- `CODE-STANDARDS.md` - NEXT UP regex and templates current
+- `TESTING-STANDARDS.md` - coverage targets match section IDs
+- `COMMON-MISTAKES.md` - all "Taught in" references use correct lesson IDs
+- `docs/PROGRESSION.md` - milestone table matches `ARCHITECTURE.md` milestones
+- `CONTRIBUTING.md` - section numbering and workflow current

--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ For the full curriculum source of truth, read [ARCHITECTURE.md](./ARCHITECTURE.m
 
 ## Current Status
 
-The v2 beta migration is complete on `main`.
+The v2.1 beta migration is complete, and RC hardening is now active on `release/v2`.
 
 - `release/v1`: stable v1 line for current learners
-- `main`: completed v2 beta implementation line
-- `release/v2`: reserved for v2 RC and stabilization once feature freeze begins
+- `main`: active v2 development and integration line
+- `release/v2`: active v2.1 stabilization and RC line
+
+Latest prerelease:
+
+- `v2.1.0-beta.1`: beta-complete snapshot published before RC hardening
 
 ## Quick Start
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,17 +11,24 @@ The Go Engineer follows **semantic versioning** for stable releases:
 
 **Release Format**: `v1.0.0`, `v1.1.0`, `v1.0.1`
 
+Current v2.1 state:
+
+- published prerelease: `v2.1.0-beta.1`
+- active stabilization branch: `release/v2`
+- next planned milestone: `v2.1.0-rc.1`
+
 ## Branch Roles
 
 The project uses long-lived branches for supported major versions:
 
 - `main`: active v2 development and prerelease integration branch
 - `release/v1`: stable v1 maintenance branch for current users
-- `release/v2`: created from `main` when v2 reaches feature freeze
+- `release/v2`: active v2.1 stabilization and RC branch
 
 Topic branches stay short-lived and always branch from the line they should ship to.
 
 - `feat/...` and `fix/...` branch from `main` for v2 work
+- `docs/...`, `chore/...`, and `release-prep/...` branch from `release/v2` for RC hardening work
 - `fix/v1-...` or `hotfix/v1-...` branch from `release/v1` for stable v1 fixes
 
 `v1.0.0` remains an immutable release tag. It is not the permanent maintenance branch name.
@@ -68,28 +75,22 @@ make deps-check
 
 - For v1 patch or minor releases, work from `release/v1`
 - For ongoing v2 development and alpha prereleases, work from `main`
-- For v2 beta, release candidate, and final stabilization, cut `release/v2` from `main`
+- For v2 beta snapshots already cut for stabilization, release candidates, and final release, work from `release/v2`
 
 Do not open sync PRs from `main` into `release/v1` just to keep the branches identical. Once v2 begins, those branches are expected to diverge.
 
 ### Step 4: Create the Release Branch or Topic Branch
 
 ```bash
-# One-time step: cut the long-lived v2 stabilization branch
-git switch main
-git pull origin main
-git switch -c release/v2
-git push -u origin release/v2
-
 # Example: prepare a v1 patch release from the stable line
 git switch release/v1
 git pull origin release/v1
 git switch -c release-prep/v1.X.Y
 
-# Example: prepare a v2 stabilization update after release/v2 exists
+# Example: prepare a v2 stabilization update from the active RC line
 git switch release/v2
 git pull origin release/v2
-git switch -c release-prep/v2.0.0-rc.N
+git switch -c release-prep/v2.1.0-rc.N
 
 # Commit version/changelog updates
 git add CHANGELOG.md README.md ROADMAP.md
@@ -103,8 +104,8 @@ git push origin HEAD
 
 1. Open PR into the long-lived target branch:
    - `release-prep/v1.X.Y` -> `release/v1`
-   - `release-prep/v2.0.0-rc.N` -> `release/v2`
-2. Title: `Release: v1.X.Y` or `Release: v2.0.0-rc.N`
+   - `release-prep/v2.1.0-rc.N` -> `release/v2`
+2. Title: `Release: v1.X.Y` or `Release: v2.1.0-rc.N`
 3. Description:
    ```markdown
    ## Release v1.X.Y
@@ -156,9 +157,9 @@ Maintainers should use **Squash and Merge** for release pull requests. If the sa
 
 Use prerelease tags during the v2 rollout:
 
-- `v2.0.0-alpha.N` from `main`
-- `v2.0.0-beta.N` from `release/v2`
-- `v2.0.0-rc.N` from `release/v2`
+- `v2.1.0-alpha.N` from `main`
+- `v2.1.0-beta.N` from `release/v2` once the stabilization line exists
+- `v2.1.0-rc.N` from `release/v2`
 
 Mark alpha, beta, and RC builds as prereleases on GitHub so stable v1 users are not silently moved early.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,12 +5,13 @@
 
 ## Current Status
 
-The v2 beta migration is complete on `main`.
+The v2.1 beta migration is complete, and RC hardening is active on `release/v2`.
 
 - the 12-section architecture is live
 - root-stage source folders are aligned to the public section map
 - `curriculum.v2.json` is the active curriculum source
 - the single validator is the required repo health check
+- `v2.1.0-beta.1` is the published beta-complete prerelease snapshot
 
 The next release step is **RC hardening**, not more beta migration.
 
@@ -18,7 +19,7 @@ The next release step is **RC hardening**, not more beta migration.
 
 - `main`: active v2 development and prerelease integration
 - `release/v1`: stable v1 maintenance line
-- `release/v2`: created when v2 RC stabilization begins
+- `release/v2`: active v2.1 stabilization and RC line
 
 ## Beta Completion Snapshot
 
@@ -59,7 +60,7 @@ RC work should now concentrate on:
 
 ## RC Exit Criteria
 
-Before cutting `release/v2`, we should be able to say:
+Before cutting `v2.1.0-rc.1` from `release/v2`, we should be able to say:
 
 - the public docs, metadata, and validator agree
 - section navigation has no dead internal links
@@ -71,6 +72,6 @@ Before cutting `release/v2`, we should be able to say:
 
 | Version | Target | Criteria |
 | --- | --- | --- |
-| v2.1-beta | current on `main` | beta migration complete and validator green |
-| v2.1-rc | next | stabilization, polish, and release prep on `release/v2` |
+| v2.1.0-beta.1 | published | beta migration complete and validator green |
+| v2.1.0-rc.1 | next | stabilization, polish, and release prep on `release/v2` |
 | v2.1 | release | RC passes and release docs are complete |


### PR DESCRIPTION
## Summary
- update release-facing docs to reflect the published `v2.1.0-beta.1` snapshot
- mark `release/v2` as the active RC stabilization branch across public and maintainer docs
- add the beta-complete changelog entry and clean stale wording/mojibake in the touched files

## Verification
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go run ./scripts/validate_curriculum.go`
- `git diff --check`

Closes #364