### PR TITLE
[FIX] align RC metadata and maintainer run targets

### DIFF
--- a/03-functions-errors/3-multiple-return-values/README.md
+++ b/03-functions-errors/3-multiple-return-values/README.md
@@ -8,7 +8,7 @@ Learn how one function can return more than one value and why that matters befor
 
 You now know how to pass data into functions and get a result back. But sometimes you need more than one piece of information.
 
-For example, a function that searches a list might need to return both the result AND whether it was found. Go handles this naturally by allowing multiple return values.
+For example, a function that searches a list might need to return both the result and whether it was found. Go handles this naturally by allowing multiple return values.
 
 This lesson builds on FE.2 by showing how to return more than one piece of data.
 
@@ -32,6 +32,7 @@ graph LR
     A["input"] --> B["function boundary"]
     B --> C["value or error"]
 ```
+
 ```text
 findItem(items, "tea")
         |
@@ -52,7 +53,7 @@ caller chooses what each returned value means
 
 Go lets a function hand multiple values back to the caller directly.
 
-The important machine truth here is not “where each byte goes.”
+The important machine truth here is not "where each byte goes."
 It is that the caller receives more than one result and must decide what to do with each one.
 
 That prepares the learner for the next lesson, where the second value becomes an `error`.
@@ -102,7 +103,7 @@ The function still returns two values, but they now mean:
 
 This second function returns two related values without using a boolean.
 
-That proves multiple return values are broader than only â€œsuccess or failure.â€
+That proves multiple return values are broader than only "success or failure."
 
 ### `parts := strings.SplitN(fullName, " ", 2)`
 
@@ -147,15 +148,17 @@ This line shows the same pattern again with a different meaning.
 - Is this already the same as `(value, error)`?
   Not yet, but it prepares you for that pattern.
 
-## ⚠️ In Production
+## In Production
+
 Multiple return values let Go functions communicate more honestly.
 They make success, failure, and extra context visible to the caller.
 
-## 🤔 Thinking Questions
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
 Continue to `FE.4` errors as values.

--- a/03-functions-errors/5-validation/README.md
+++ b/03-functions-errors/5-validation/README.md
@@ -30,6 +30,7 @@ graph LR
     A["input"] --> B["function boundary"]
     B --> C["value or error"]
 ```
+
 ```text
 cart name -----------+
 prices --------------+--> validation gate --> ok --> continue
@@ -51,7 +52,7 @@ The important machine truth is:
 - if the rule fails, the function returns immediately with an error value
 - later lines in that function do not run on the failure path
 
-That â€œreturn earlyâ€ behavior is the real engineering habit this lesson is building.
+That "return early" behavior is the real engineering habit this lesson is building.
 
 ## Run Instructions
 
@@ -68,7 +69,7 @@ This function takes one input and returns one `error`.
 That alone teaches a useful shape:
 
 - some functions do not return business data
-- some functions return only â€œdid this pass or fail?â€
+- some functions return only "did this pass or fail?"
 
 ### `strings.TrimSpace(name) == ""`
 
@@ -83,7 +84,7 @@ The function does not continue because the input is not valid enough.
 ### `return nil`
 
 This is the success path.
-`nil` means â€œno validation error.â€
+`nil` means "no validation error."
 
 ### `func validatePrices(prices []int) error {`
 
@@ -99,7 +100,7 @@ This line checks each input value one by one.
 
 ### `if price < 0 {`
 
-This is the specific rule for â€œbad price data.â€
+This is the specific rule for "bad price data."
 
 ### `return fmt.Errorf("price at index %d cannot be negative", i)`
 
@@ -127,15 +128,17 @@ This shows the caller-side pattern again:
 - Why return `error` instead of `bool`?
   Because the caller needs a reason, not only a yes/no signal.
 
-## ⚠️ In Production
+## In Production
+
 Validation is one of the earliest places where engineering discipline shows up.
 It protects the rest of the program from clearly broken input.
 
-## 🤔 Thinking Questions
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
 Continue to `FE.6` orchestration.

--- a/04-types-design/12-functional-options/README.md
+++ b/04-types-design/12-functional-options/README.md
@@ -2,7 +2,7 @@
 
 ## Mission
 
-Learn the functional options patternâ€”a common Go pattern for building configurable APIs without requiring many constructor parameters.
+Learn the functional options pattern - a common Go pattern for building configurable APIs without requiring many constructor parameters.
 
 ## Why This Lesson Exists Now
 
@@ -14,7 +14,7 @@ When a type has many optional fields, passing all of them to a constructor becom
 
 ## Mental Model
 
-Think of ordering a pizza. You could have a constructor with 20 parameters (crust, sauce, cheese, toppings, size, etc.). Or you could have `WithExtraCheese()`, `WithPepperoni()`, `LargeSize()` functions that you chain together. Much cleaner!
+Think of ordering a pizza. You could have a constructor with 20 parameters (crust, sauce, cheese, toppings, size, and so on). Or you could have `WithExtraCheese()`, `WithPepperoni()`, and `LargeSize()` functions that you combine. Much cleaner.
 
 ## Visual Model
 
@@ -23,6 +23,7 @@ graph TD
     A["data"] --> B["type definition"]
     B --> C["methods or interface behavior"]
 ```
+
 ```go
 // Without options: too many parameters
 NewServer("web", "us-east", 4, 16, true, false, "linux", "10.0.0.1", ...)
@@ -53,7 +54,7 @@ Define a function type that modifies a config struct.
 
 ### Option function
 
-Each option function returns an Option that gets applied.
+Each option function returns an `Option` that gets applied.
 
 ### WithDefault pattern
 
@@ -65,14 +66,16 @@ Use functional composition to build up configuration.
 2. Create a server with multiple options chained together.
 3. Make some options have default values.
 
-## ⚠️ In Production
-Functional options are used throughout Go APIsâ€”gRPC, Terraform provider, Cobra CLI, etc. Essential for building clean, extensible libraries.
+## In Production
 
-## 🤔 Thinking Questions
+Functional options are used throughout Go APIs - gRPC, Terraform providers, Cobra CLI tools, and many internal service libraries. They help keep constructors clean and extensible.
+
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
 Continue to `TI.13` method values.

--- a/04-types-design/13-method-values/README.md
+++ b/04-types-design/13-method-values/README.md
@@ -2,7 +2,7 @@
 
 ## Mission
 
-Learn how to treat methods as first-class valuesâ€”assigning methods to variables and passing them as function arguments.
+Learn how to treat methods as first-class values - assigning methods to variables and passing them as function arguments.
 
 ## Why This Lesson Exists Now
 
@@ -14,7 +14,7 @@ In Go, methods can be extracted from their receiver and used as values. This is 
 
 ## Mental Model
 
-Think of a button on a remote. You can press the button (call the method), or you can program the button to trigger something else (use the method as a value). Method values let you treat the button itself as a thing you can store and use later.
+Think of a button on a remote. You can press the button (call the method), or you can program the button to trigger something else later (use the method as a value). Method values let you treat the button itself as a thing you can store and use later.
 
 ## Visual Model
 
@@ -23,6 +23,7 @@ graph TD
     A["data"] --> B["type definition"]
     B --> C["methods or interface behavior"]
 ```
+
 ```go
 type Counter struct{ Value int }
 
@@ -31,7 +32,6 @@ func (c *Counter) Increment() { c.Value++ }
 // Method as value - the receiver is bound
 counter := &Counter{}
 incFunc := counter.Increment // This is a func()
-// Calling it later
 incFunc()
 incFunc()
 fmt.Println(counter.Value) // 2
@@ -55,7 +55,7 @@ go run ./04-types-design/13-method-values
 
 ### Using method values
 
-Pass method values to functions that expect func().
+Pass method values to functions that expect `func()`.
 
 ### Method values vs closures
 
@@ -64,17 +64,19 @@ Method values capture the receiver; closures capture variables.
 ## Try It
 
 1. Store a method in a map of event handlers.
-2. Pass a method value to a defer statement.
+2. Pass a method value to a `defer` statement.
 3. Compare method values with closures capturing the same receiver.
 
-## ⚠️ In Production
+## In Production
+
 Method values are used in HTTP handlers, event systems, and anywhere you need to pass a method as a callback.
 
-## 🤔 Thinking Questions
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
 Continue to `TI.14` complex generic constraints if you want to finish the optional stretch path.

--- a/04-types-design/14-complex-generic-constraints/README.md
+++ b/04-types-design/14-complex-generic-constraints/README.md
@@ -2,11 +2,11 @@
 
 ## Mission
 
-Learn advanced constraint patterns including parameterized constraints, using interfaces as constraints, and creating reusable generic utilities.
+Learn advanced constraint patterns including parameterized constraints, interfaces as constraints, and reusable generic utilities.
 
 ## Why This Lesson Exists Now
 
-You know basic generics with simple constraints like `int | float64`. But real-world code often needs more sophisticated constraintsâ€”constraints that require methods, parameterized types, or multiple interface requirements.
+You know basic generics with simple constraints like `int | float64`. But real-world code often needs more sophisticated constraints - constraints that require methods, parameterized types, or multiple interface requirements.
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ You know basic generics with simple constraints like `int | float64`. But real-w
 
 ## Mental Model
 
-Think of a vending machine that accepts only certain payment methods. The constraint is not just "some type"â€”it's "anything with Pay() method that returns error." Similarly, generic constraints can require methods, not just type identity.
+Think of a vending machine that accepts only certain payment methods. The constraint is not just "some type" - it is "anything with a `Pay()` method that returns an error." Similarly, generic constraints can require methods, not just type identity.
 
 ## Visual Model
 
@@ -23,13 +23,14 @@ graph TD
     A["data"] --> B["type definition"]
     B --> C["methods or interface behavior"]
 ```
+
 ```go
 // Constraint requiring methods
 type Adder interface {
     Add(other int) int
 }
 
-// Constraint requiring multiple interfaces  
+// Constraint requiring multiple interfaces
 type Serializer interface {
     fmt.Stringer
     json.Marshaler
@@ -50,7 +51,7 @@ go run ./04-types-design/14-complex-generic-constraints
 
 ### Interface as constraint
 
-Interfaces can be constraintsâ€”anything implementing the interface works.
+Interfaces can be constraints - anything implementing the interface works.
 
 ### Multiple interface constraints
 
@@ -62,18 +63,20 @@ The built-in `comparable` constraint allows equality operators.
 
 ## Try It
 
-1. Create a constraint that requires both String() and a custom method.
-2. Use the comparable constraint to create a generic key-value pair.
+1. Create a constraint that requires both `String()` and a custom method.
+2. Use the `comparable` constraint to create a generic key-value pair.
 3. Build a constraint for numeric types with multiple operations.
 
-## ⚠️ In Production
+## In Production
+
 Complex constraints are used in real Go code for data structures, serialization, and anywhere you need type-safe generic utilities.
 
-## 🤔 Thinking Questions
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
 Continue to `TI.15` generic data structures.

--- a/04-types-design/15-generic-data-structures/README.md
+++ b/04-types-design/15-generic-data-structures/README.md
@@ -2,20 +2,20 @@
 
 ## Mission
 
-Learn to build type-safe generic data structures like Stack, Queue, and Set using Go's generics.
+Learn to build type-safe generic data structures like `Stack`, `Queue`, and `Set` using Go's generics.
 
 ## Why This Lesson Exists Now
 
-You've learned generic functions. Now learn to build generic data structures that are type-safe at compile timeâ€”no runtime type assertions needed.
+You've learned generic functions. Now learn to build generic data structures that are type-safe at compile time - no runtime type assertions needed.
 
 ## Prerequisites
 
 - `TI.9` generics
-- `TI.16` complex constraints
+- `TI.14` complex constraints
 
 ## Mental Model
 
-Think of a reusable storage box. Without generics, you'd need separate boxes for books, clothes, and electronics. With generics, one "Box<T>" works for allâ€”type-safe and efficient.
+Think of a reusable storage box. Without generics, you'd need separate boxes for books, clothes, and electronics. With generics, one `Box[T]` works for all - type-safe and efficient.
 
 ## Visual Model
 
@@ -24,6 +24,7 @@ graph TD
     A["data"] --> B["type definition"]
     B --> C["methods or interface behavior"]
 ```
+
 ```go
 type Stack[T any] struct {
     items []T
@@ -47,7 +48,7 @@ go run ./04-types-design/15-generic-data-structures
 
 ### Stack implementation
 
-LIFO data structure with type-safe push/pop.
+LIFO data structure with type-safe push and pop behavior.
 
 ### Queue implementation
 
@@ -55,22 +56,24 @@ FIFO data structure.
 
 ### Set implementation
 
-Unique element collection using map.
+Unique element collection using a map.
 
 ## Try It
 
-1. Add a Peek method to Stack that returns top element without removing.
-2. Implement a generic LinkedList.
-3. Add Remove method to Set.
+1. Add a `Peek` method to `Stack` that returns the top element without removing it.
+2. Implement a generic linked list.
+3. Add a `Remove` method to `Set`.
 
-## ⚠️ In Production
+## In Production
+
 Generic data structures are used throughout Go codebases for type-safe collections without runtime overhead.
 
-## 🤔 Thinking Questions
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
-The optional stretch path is complete. Move to **Composition** next, or return to the Section 06 map whenever you want to review the core path again.
+The optional stretch path is complete. Move to **Composition** next, or return to the Section 04 map whenever you want to review the core path again.

--- a/04-types-design/2-methods/README.md
+++ b/04-types-design/2-methods/README.md
@@ -8,7 +8,7 @@ Learn how to attach functions to types using methods, and understand the critica
 
 Now that you can group data with structs, the next question is: "How do I add behavior to that data?"
 
-In other languages, you might use classes. In Go, you use methodsâ€”functions that are attached to a specific type. The key decision is whether to use a value receiver (works on a copy) or a pointer receiver (works on the original).
+In other languages, you might use classes. In Go, you use methods - functions that are attached to a specific type. The key decision is whether to use a value receiver (works on a copy) or a pointer receiver (works on the original).
 
 ## Prerequisites
 
@@ -25,16 +25,15 @@ graph TD
     A["data"] --> B["type definition"]
     B --> C["methods or interface behavior"]
 ```
+
 ```text
-â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
-â”‚ Circle struct                           â”‚
-â”‚   Radius float64                        â”‚
-â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
-â”‚ Methods:                                â”‚
-â”‚   Area()      â†’ value receiver (read)   â”‚
-â”‚   Perimeter() â†’ value receiver (read)  â”‚
-â”‚   Scale()     â†’ pointer receiver (write)â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+Circle
+  Radius float64
+
+Methods
+  Area()      -> value receiver (read)
+  Perimeter() -> value receiver (read)
+  Scale()     -> pointer receiver (write)
 ```
 
 ## Machine View
@@ -83,14 +82,16 @@ If any method on a type needs a pointer receiver, make all methods on that type 
 - Why does Go allow calling pointer methods on values?
   Go automatically takes the address when needed. It is syntactic sugar.
 
-## ⚠️ In Production
+## In Production
+
 Methods are how Go achieves encapsulation. The receiver type determines whether callers get a copy or share the original. This affects performance and mutation behavior.
 
-## 🤔 Thinking Questions
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
 Continue to `TI.3` interfaces.

--- a/04-types-design/3-interfaces/README.md
+++ b/04-types-design/3-interfaces/README.md
@@ -8,7 +8,7 @@ Learn how to define behavior contracts using interfaces and achieve polymorphism
 
 You have structs (data) and methods (behavior). The next question is: "How do I write code that works with multiple types that share the same behavior?"
 
-In other languages, you might use inheritance. In Go, you use interfacesâ€”a type that defines what a type can do, not what it is.
+In other languages, you might use inheritance. In Go, you use interfaces - a type that defines what a type can do, not what it is.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ In other languages, you might use inheritance. In Go, you use interfacesâ€”
 
 ## Mental Model
 
-Think of a power outlet. The outlet defines a contract: "I accept anything with two prongs and a ground pin." A lamp, a phone charger, and a refrigerator all satisfy this contract differently, but the outlet does not care how they work internallyâ€”only that they have the right shape (methods).
+Think of a power outlet. The outlet defines a contract: "I accept anything with two prongs and a ground pin." A lamp, a phone charger, and a refrigerator all satisfy this contract differently, but the outlet does not care how they work internally - only that they have the right shape (methods).
 
 ## Visual Model
 
@@ -26,20 +26,15 @@ graph TD
     A["data"] --> B["type definition"]
     B --> C["methods or interface behavior"]
 ```
+
 ```text
-â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
-â”‚ Shape interface     â”‚
-â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
-â”‚ Area() float64      â”‚
-â”‚ Perimeter() float64 â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
-         â–²
-         â”‚ implements
-    â”Œâ”€â”€â”€â”€â”´â”€â”€â”€â”€â”
-    â”‚         â”‚
-â”Œâ”€â”€â”€â”´â”€â”€â”€â” â”Œâ”€â”€â”´â”€â”€â”€â”€â”
-â”‚ Rect  â”‚ â”‚ Circle â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”˜ â””â”€â”€â”€â”€â”€â”€â”€â”˜
+Shape interface
+  - Area() float64
+  - Perimeter() float64
+
+Types that implement Shape
+  - Rectangle
+  - Circle
 ```
 
 ## Machine View
@@ -48,7 +43,7 @@ An interface value is internally a 2-word struct:
 - Word 1: pointer to the type descriptor (what concrete type is stored)
 - Word 2: pointer to the data (the actual struct value)
 
-This is why interface calls are slightly slower than direct callsâ€”the runtime must look up the method through the type descriptor. This is called "dynamic dispatch."
+This is why interface calls are slightly slower than direct calls - the runtime must look up the method through the type descriptor. This is called "dynamic dispatch."
 
 ## Run Instructions
 
@@ -78,7 +73,7 @@ Sometimes you need to extract the concrete type from an interface. Use the comma
 
 1. Add a new shape type (e.g., Square) and see if it works with `printShapeInfo` without any changes.
 2. Try a type assertion that fails and observe the ok value.
-3. Add a method to one shape type that others do not haveâ€”does it still satisfy Shape?
+3. Add a method to one shape type that others do not have - does it still satisfy Shape?
 
 ## Common Questions
 
@@ -88,14 +83,16 @@ Sometimes you need to extract the concrete type from an interface. Use the comma
 - When to use interfaces vs concrete types?
   Use interfaces when you need polymorphism. Use concrete types when you need specificity.
 
-## ⚠️ In Production
+## In Production
+
 Interfaces are Go's primary tool for abstraction and testing. They let you write code that depends on behavior, not concrete types. This is essential for dependency injection, mocking, and flexible API design.
 
-## 🤔 Thinking Questions
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
 Continue to `TI.4` interface embedding.

--- a/04-types-design/4-interface-embedding/README.md
+++ b/04-types-design/4-interface-embedding/README.md
@@ -14,7 +14,7 @@ You have learned that interfaces define contracts. Sometimes you want to combine
 
 ## Mental Model
 
-Think of a universal remote. It does not have buttons for every function directlyâ€”it embeds the capabilities of a TV remote, a DVD remote, and a sound system remote into one. The universal remote "has-a" TV control, "has-a" DVD control, etc.
+Think of a universal remote. It does not have buttons for every function directly - it embeds the capabilities of a TV remote, a DVD remote, and a sound system remote into one. The universal remote "has-a" TV control, "has-a" DVD control, and so on.
 
 ## Visual Model
 
@@ -23,6 +23,7 @@ graph TD
     A["data"] --> B["type definition"]
     B --> C["methods or interface behavior"]
 ```
+
 ```text
 // Embedded interfaces combine contracts
 type Reader interface {
@@ -35,14 +36,14 @@ type Writer interface {
 
 // ReadWriter embeds both Reader and Writer
 type ReadWriter interface {
-    Reader  // embedded
-    Writer  // embedded
+    Reader
+    Writer
 }
 ```
 
 ## Machine View
 
-When interface A embeds interface B, the resulting interface has all methods from both. The embedding is staticâ€”the compiler checks at compile time that the embedded contracts are satisfied.
+When interface A embeds interface B, the resulting interface has all methods from both. The embedding is static - the compiler checks at compile time that the embedded contracts are satisfied.
 
 ## Run Instructions
 
@@ -54,7 +55,7 @@ go run ./04-types-design/4-interface-embedding
 
 ### Embedding individual interfaces
 
-When you embed interfaces, you get all their methods. No need to list them explicitly.
+When you embed interfaces, you get all their methods. There is no need to list them explicitly.
 
 ### Embedding multiple interfaces
 
@@ -62,7 +63,7 @@ One interface can embed multiple interfaces, combining their contracts.
 
 ### Use case: io.ReadWriter
 
-The standard library's io.ReadWriter is a classic exampleâ€”embedding io.Reader and io.Writer.
+The standard library's io.ReadWriter is a classic example - embedding io.Reader and io.Writer.
 
 ## Try It
 
@@ -70,14 +71,16 @@ The standard library's io.ReadWriter is a classic exampleâ€”embedding io.Re
 2. Implement your combined interface with a struct.
 3. Verify that satisfying the embedded interfaces automatically satisfies the combined one.
 
-## ⚠️ In Production
-Interface embedding is used throughout the standard library (io.ReadWriter, io.ReadCloser, etc.) and in real APIs to compose behavior contracts.
+## In Production
 
-## 🤔 Thinking Questions
+Interface embedding is used throughout the standard library (`io.ReadWriter`, `io.ReadCloser`, and more) and in real APIs to compose behavior contracts.
+
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
 Continue to `TI.5` Stringer.

--- a/04-types-design/5-stringer/README.md
+++ b/04-types-design/5-stringer/README.md
@@ -2,13 +2,13 @@
 
 ## Mission
 
-Learn how to control how your types are displayed by implementing the fmt.Stringer interface.
+Learn how to control how your types are displayed by implementing the `fmt.Stringer` interface.
 
 ## Why This Lesson Exists Now
 
 You have learned how to define structs and methods. The next practical question is: "How do I control what shows when I print my type?"
 
-When you pass a struct to fmt.Println, Go prints the raw fields by default. To control the output, implement the fmt.Stringer interface.
+When you pass a struct to `fmt.Println`, Go prints the raw fields by default. To control the output, implement the `fmt.Stringer` interface.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ When you pass a struct to fmt.Println, Go prints the raw fields by default. To c
 
 ## Mental Model
 
-When you hand someone a business card, the card shows a carefully formatted summaryâ€”not raw data. The String() method is your type's business card. Without it, Go prints the raw struct fields. With it, you control exactly how your type is presented.
+Think of a business card. The card shows a carefully formatted summary - not raw data. The `String()` method is your type's business card. Without it, Go prints the raw struct fields. With it, you control exactly how your type is presented.
 
 ## Visual Model
 
@@ -26,25 +26,19 @@ graph TD
     A["data"] --> B["type definition"]
     B --> C["methods or interface behavior"]
 ```
-```text
-fmt.Stringer interface:
-â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
-â”‚ type Stringer interface â”‚
-â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
-â”‚ String() string         â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
 
-Implementations:
-â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”  â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
-â”‚ HTTPStatus  â”‚  â”‚   Weekday  â”‚
-â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤  â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
-â”‚ String()    â”‚  â”‚  String()  â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜  â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```text
+fmt.Stringer interface
+  - String() string
+
+Examples
+  - HTTPStatus -> String()
+  - Weekday -> String()
 ```
 
 ## Machine View
 
-The fmt package automatically checks for the Stringer interface when printing. If your type implements String() string, fmt.Println, fmt.Printf with %s or %v, log.Println, and error messages will all call your method.
+The `fmt` package automatically checks for the `Stringer` interface when printing. If your type implements `String() string`, `fmt.Println`, `fmt.Printf` with `%s` or `%v`, `log.Println`, and error messages will all call your method.
 
 ## Run Instructions
 
@@ -56,38 +50,40 @@ go run ./04-types-design/5-stringer
 
 ### `func (s HTTPStatus) String() string {`
 
-This implements fmt.Stringer for HTTPStatus. Now when you print an HTTPStatus, it shows "HTTP 200: OK" instead of the raw struct.
+This implements `fmt.Stringer` for `HTTPStatus`. Now when you print an `HTTPStatus`, it shows `HTTP 200: OK` instead of the raw struct.
 
 ### Custom types
 
-You can create new types from existing ones: `type Weekday int`. This creates a completely new typeâ€”Weekday and int are not interchangeable.
+You can create new types from existing ones: `type Weekday int`. This creates a completely new type - `Weekday` and `int` are not interchangeable.
 
 ### Stringer with iota
 
-Combine custom types with iota (from Section 02) to create enum-like constants.
+Combine custom types with `iota` (from Section 02) to create enum-like constants.
 
 ## Try It
 
-1. Add a String() method to the Server struct from TI.1 and test it with fmt.Println.
-2. Create a custom type based on float64 and implement Stringer.
-3. Try printing a value before and after adding the Stringer implementation.
+1. Add a `String()` method to the `Server` struct from TI.1 and test it with `fmt.Println`.
+2. Create a custom type based on `float64` and implement `Stringer`.
+3. Try printing a value before and after adding the `Stringer` implementation.
 
 ## Common Questions
 
 - Why is Stringer the most commonly implemented interface?
-  Because every type needs to be displayed somewhereâ€”logs, errors, user output.
+  Because every type needs to be displayed somewhere - logs, errors, and user output.
 
-- What is the difference between %v and %s?
-  %v uses String() if available, %s specifically calls String().
+- What is the difference between `%v` and `%s`?
+  `%v` uses `String()` if available, while `%s` specifically expects string output.
 
-## ⚠️ In Production
+## In Production
+
 Stringer is essential for logging, debugging, and user-facing output. It makes your types readable in any context where they are printed or logged.
 
-## 🤔 Thinking Questions
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
 Continue to `TI.6` type switch.

--- a/04-types-design/6-type-switch/README.md
+++ b/04-types-design/6-type-switch/README.md
@@ -14,7 +14,7 @@ You have learned about type assertions (checking one type). Sometimes you need t
 
 ## Mental Model
 
-Think of a sorting machine. Items come down the belt, and different items need different handlingâ€”fragile items go to one bin, heavy items to another, documents to a third. The machine "switches" on the type of item to decide where it goes.
+Think of a sorting machine. Items come down the belt, and different items need different handling - fragile items go to one bin, heavy items to another, documents to a third. The machine "switches" on the type of item to decide where it goes.
 
 ## Visual Model
 
@@ -23,6 +23,7 @@ graph TD
     A["data"] --> B["type definition"]
     B --> C["methods or interface behavior"]
 ```
+
 ```text
 switch v := value.(type) {
 case string:
@@ -63,8 +64,8 @@ The default case handles types you have not explicitly handled.
 ## Try It
 
 1. Add a new type to the shape example and handle it in the type switch.
-2. Use a type switch inside a function that accepts interface{}.
-3. Try calling a method that only exists on one specific type using type switch.
+2. Use a type switch inside a function that accepts `interface{}`.
+3. Try calling a method that only exists on one specific type using a type switch.
 
 ## Common Questions
 
@@ -74,14 +75,16 @@ The default case handles types you have not explicitly handled.
 - When should I use type switches?
   When you have an interface that can hold multiple concrete types and you need different logic for each.
 
-## ⚠️ In Production
-Type switches are used in serialization (json.Unmarshal), reflection, and handling API responses that return different types.
+## In Production
 
-## 🤔 Thinking Questions
+Type switches are used in serialization (`json.Unmarshal`), reflection, and handling API responses that return different types.
+
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
 Continue to `TI.7` custom errors.

--- a/04-types-design/8-custom-errors/README.md
+++ b/04-types-design/8-custom-errors/README.md
@@ -6,7 +6,7 @@ Learn how to define custom error types that carry structured information for bet
 
 ## Why This Lesson Exists Now
 
-Go's built-in error interface is simple: just `Error() string`. But sometimes you need more informationâ€”what went wrong, where, and additional context. Custom error types let you do this.
+Go's built-in `error` interface is simple: just `Error() string`. But sometimes you need more information - what went wrong, where, and additional context. Custom error types let you do this.
 
 ## Prerequisites
 
@@ -15,7 +15,7 @@ Go's built-in error interface is simple: just `Error() string`. But sometimes yo
 
 ## Mental Model
 
-Think of a boarding pass. A simple "flight delayed" message is not enough. A good error includes: flight number, original time, new time, reason, and gate. Custom errors are like detailed boarding passes for your program.
+Think of a boarding pass. A simple "flight delayed" message is not enough. A good error includes flight number, original time, new time, reason, and gate. Custom errors are like detailed boarding passes for your program.
 
 ## Visual Model
 
@@ -24,6 +24,7 @@ graph TD
     A["data"] --> B["type definition"]
     B --> C["methods or interface behavior"]
 ```
+
 ```text
 type ValidationError struct {
     Field   string
@@ -38,7 +39,7 @@ func (e ValidationError) Error() string {
 
 ## Machine View
 
-Custom errors implement the error interface by providing an Error() method. You can add any fields and use errors.As() to check specific error types.
+Custom errors implement the `error` interface by providing an `Error()` method. You can add any fields you want, and callers can use `errors.As()` to check for a specific error type.
 
 ## Run Instructions
 
@@ -50,7 +51,7 @@ go run ./04-types-design/8-custom-errors
 
 ### Basic custom error
 
-Define a struct and implement the Error() method.
+Define a struct and implement the `Error()` method.
 
 ### Error with fields
 
@@ -58,22 +59,24 @@ Add fields to carry structured information.
 
 ### Type assertions for errors
 
-Use errors.As() to check specific error types and handle them differently.
+Use `errors.As()` to check specific error types and handle them differently.
 
 ## Try It
 
 1. Create a custom error type with multiple fields.
-2. Use errors.As() to check for your custom error and access its fields.
+2. Use `errors.As()` to check for your custom error and access its fields.
 3. Wrap multiple error types and handle each differently.
 
-## ⚠️ In Production
+## In Production
+
 Custom errors are used in real applications for validation errors, API errors with codes, and database errors with retry information.
 
-## 🤔 Thinking Questions
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
 Continue to `TI.9` generics, then tackle the payroll milestone at `TI.10`.

--- a/04-types-design/9-generics/README.md
+++ b/04-types-design/9-generics/README.md
@@ -6,7 +6,7 @@ Learn how to write functions and types that work with multiple types using type 
 
 ## Why This Lesson Exists Now
 
-You have interfaces for behavior abstraction. But sometimes you need to write utility functions that work with any type while maintaining type safety. Before generics, you had to write duplicate code or use interface{} and lose type safety.
+You have interfaces for behavior abstraction. But sometimes you need to write utility functions that work with any type while maintaining type safety. Before generics, you had to write duplicate code or use `interface{}` and lose type safety.
 
 ## Prerequisites
 
@@ -15,7 +15,7 @@ You have interfaces for behavior abstraction. But sometimes you need to write ut
 
 ## Mental Model
 
-Think of a vending machine. It does not care if it dispenses sodas, snacks, or toysâ€”the mechanism is the same. The "type parameter" is what is in each slot. The "constraint" says "must fit in the slot."
+Think of a vending machine. It does not care if it dispenses sodas, snacks, or toys - the mechanism is the same. The type parameter is what is in each slot. The constraint says what is allowed to fit in the slot.
 
 ## Visual Model
 
@@ -24,16 +24,17 @@ graph TD
     A["data"] --> B["type definition"]
     B --> C["methods or interface behavior"]
 ```
+
 This diagram shows the generic function signature:
 
 - `Sum` is the function name
-- `[T Numeric]` declares a type parameter T constrained to numeric types
-- `numbers []T` is the parameter (a slice of type T)
+- `[T Numeric]` declares a type parameter `T` constrained to numeric types
+- `numbers []T` is the parameter (a slice of type `T`)
 - `T` is the return type
 
 ## Machine View
 
-When you call `Sum([]int{1, 2, 3})`, the compiler replaces T with int everywhere in the function. This is called monomorphizationâ€”the generic code is compiled into specific versions for each type used.
+When you call `Sum([]int{1, 2, 3})`, the compiler replaces `T` with `int` everywhere in the function. This is called monomorphization - the generic code is compiled into specific versions for each type used.
 
 ## Run Instructions
 
@@ -45,19 +46,19 @@ go run ./04-types-design/9-generics
 
 ### Type constraints
 
-- `any`: accepts all types (equivalent to interface{})
-- `comparable`: supports == and != operators
-- Custom constraints: `type Numeric interface { int | float64 | ... }`
+- `any`: accepts all types (equivalent to `interface{}`)
+- `comparable`: supports `==` and `!=` operators
+- custom constraints: `type Numeric interface { int | float64 | ... }`
 
 ### Type parameters
 
-The syntax `[T Numeric]` declares a type parameter T with constraint Numeric.
+The syntax `[T Numeric]` declares a type parameter `T` with constraint `Numeric`.
 
 ### Generic functions
 
-- Sum: works with any numeric type
-- Filter: works with any type
-- Map: transforms from type T to type U
+- `Sum`: works with any numeric type
+- `Filter`: works with any type
+- `Map`: transforms from type `T` to type `U`
 
 ## Try It
 
@@ -67,20 +68,22 @@ The syntax `[T Numeric]` declares a type parameter T with constraint Numeric.
 
 ## Common Questions
 
-- When to use generics vs interfaces?
+- When should I use generics vs interfaces?
   Use generics for data structures and algorithms that work with multiple types. Use interfaces for behavior abstraction and polymorphism.
 
 - What is the performance impact?
-  Generics are monomorphized at compile timeâ€”no runtime overhead.
+  Generics are monomorphized at compile time - there is no runtime type-checking overhead from the abstraction itself.
 
-## ⚠️ In Production
-Generics are essential for building reusable data structures (maps, slices, trees) and utility functions without code duplication.
+## In Production
 
-## 🤔 Thinking Questions
+Generics are essential for building reusable data structures and utility functions without code duplication.
+
+## Thinking Questions
 
 1. What problem is this lesson trying to solve?
 2. What would change if you removed this idea from the program?
 3. Where do you expect to see this pattern again in real Go code?
+
 ## Next Step
 
 Continue to `TI.10` payroll processor project to use one small generic helper inside a larger interface-based exercise.

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
-.PHONY: build test vet fmt lint run clean help
+.PHONY: build test test-race test-verbose bench vet fmt fmt-check lint tidy deps-check deps-update clean run-hello run-env cover help
 
 # ============================================================================
-# The Go Engineer â€” Makefile
+# The Go Engineer - Makefile
 # ============================================================================
 # Usage:
-#   make help     â€” Show all available commands
-#   make build    â€” Compile all packages
-#   make test     â€” Run all tests
-#   make lint     â€” Run linter and vet
-#   make fmt      â€” Format all Go files
-#   make clean    â€” Remove build artifacts
+#   make help     - Show all available commands
+#   make build    - Compile all packages
+#   make test     - Run all tests
+#   make lint     - Run linter and vet
+#   make fmt      - Format all Go files
+#   make clean    - Remove build artifacts
 # ============================================================================
 
 # Default target
@@ -17,87 +17,87 @@
 
 ## Build & Compile
 build: ## Compile all packages (verifies everything compiles)
-	@echo "ðŸ”¨ Building all packages..."
+	@echo "Building all packages..."
 	go build ./...
-	@echo "âœ… Build successful"
+	@echo "Build successful"
 
 ## Testing
 test: ## Run all tests
-	@echo "ðŸ§ª Running tests..."
+	@echo "Running tests..."
 	go test ./...
 
 test-race: ## Run all tests with race detector
-	@echo "ðŸ§ª Running tests with race detection..."
+	@echo "Running tests with race detection..."
 	go test -race ./...
 
 test-verbose: ## Run all tests with verbose output
-	@echo "ðŸ§ª Running tests (verbose)..."
+	@echo "Running tests (verbose)..."
 	go test -v ./...
 
 bench: ## Run benchmarks
-	@echo "ðŸ“Š Running benchmarks..."
-	go test -bench=. -benchmem -count=1 ./12-quality-and-performance/testing/benchmarks/
+	@echo "Running benchmarks..."
+	go test ./08-quality-test/01-quality-and-performance/testing/benchmarks -bench="." -benchmem -count=1
 
 ## Code Quality
 vet: ## Run go vet (find suspicious code)
-	@echo "ðŸ” Running go vet..."
+	@echo "Running go vet..."
 	go vet ./...
-	@echo "âœ… Vet passed"
+	@echo "Vet passed"
 
 fmt: ## Format all Go files
-	@echo "âœ¨ Formatting code..."
+	@echo "Formatting code..."
 	gofmt -w .
-	@echo "âœ… Formatted"
+	@echo "Formatted"
 
 fmt-check: ## Check if code is formatted (CI use)
-	@echo "ðŸ” Checking formatting..."
-	@test -z "$$(gofmt -l .)" || (echo "âŒ Unformatted files:" && gofmt -l . && exit 1)
-	@echo "âœ… All files formatted"
+	@echo "Checking formatting..."
+	@test -z "$$(gofmt -l .)" || (echo "Unformatted files:" && gofmt -l . && exit 1)
+	@echo "All files formatted"
 
 lint: vet fmt-check ## Run all linters (vet + format check)
-	@echo "âœ… All lint checks passed"
+	@echo "All lint checks passed"
 
 ## Utility
 tidy: ## Sync go.mod with imports
-	@echo "ðŸ“¦ Tidying modules..."
+	@echo "Tidying modules..."
 	go mod tidy
-	@echo "âœ… Modules tidied"
+	@echo "Modules tidied"
 
 deps-check: ## Check module dependencies
-	@echo "ðŸ“‹ Checking dependencies..."
+	@echo "Checking dependencies..."
 	@echo "All dependencies:"
 	go list -u -m all
-	@echo "âœ… Dependency check complete"
+	@echo "Dependency check complete"
 
 deps-update: ## Update all dependencies to latest patch version
-	@echo "ðŸ”„ Updating dependencies..."
+	@echo "Updating dependencies..."
 	go get -u ./...
 	go mod tidy
-	@echo "âœ… Dependencies updated"
+	@echo "Dependencies updated"
 
 clean: ## Remove build artifacts
-	@echo "ðŸ§¹ Cleaning..."
+	@echo "Cleaning..."
 	rm -f coverage.out
 	go clean -cache -testcache
-	@echo "âœ… Clean"
+	@echo "Clean"
 
 ## Run Examples
 run-hello: ## Run the Hello World example
-	go run ./01-foundations/01-getting-started/2-hello-world
+	go run ./01-getting-started/2-hello-world
 
 run-env: ## Run the environment check
-	go run ./01-foundations/01-getting-started/4-dev-environment
+	go run ./01-getting-started/4-dev-environment
 
 ## Coverage
 cover: ## Run tests with coverage report
-	@echo "ðŸ“Š Generating coverage report..."
+	@echo "Generating coverage report..."
 	go test -coverprofile=coverage.out ./...
 	go tool cover -func=coverage.out
-	@echo "ðŸ“„ HTML report: go tool cover -html=coverage.out"
+	@echo "HTML report: go tool cover -html=coverage.out"
 
 ## Help
 help: ## Show this help message
-	@echo "The Go Engineer â€” Available Commands:"
+	@echo "The Go Engineer - Available Commands:"
 	@echo ""
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -9,7 +9,7 @@
       "path_prefix": "00-how-computers-work",
       "phase": "foundations",
       "summary": "Understand the machine before you write the code.",
-      "status": "pilot",
+      "status": "implemented",
       "entry_points": [
         "HC.1"
       ],
@@ -25,7 +25,7 @@
       "path_prefix": "01-getting-started",
       "phase": "foundations",
       "summary": "Build environment confidence, run the first programs, and make the terminal and editor feel safe.",
-      "status": "pilot",
+      "status": "implemented",
       "entry_points": [
         "GT.1"
       ],
@@ -44,7 +44,7 @@
       "path_prefix": "02-language-basics",
       "phase": "foundations",
       "summary": "Teach values, control flow, and data structures as one zero-magic builder path.",
-      "status": "pilot",
+      "status": "implemented",
       "entry_points": [
         "LB.1"
       ],
@@ -65,7 +65,7 @@
       "path_prefix": "03-functions-errors",
       "phase": "foundations",
       "summary": "Turn inline logic into reusable function boundaries and make failure explicit.",
-      "status": "pilot",
+      "status": "implemented",
       "entry_points": [
         "FE.1"
       ],
@@ -84,7 +84,7 @@
       "path_prefix": "04-types-design",
       "phase": "foundations",
       "summary": "Shape programs with types, interfaces, composition, and text-heavy workflows.",
-      "status": "pilot",
+      "status": "implemented",
       "entry_points": [
         "TI.1",
         "CO.1",
@@ -107,7 +107,7 @@
       "path_prefix": "05-packages-io",
       "phase": "engineering-core",
       "summary": "Teach module boundaries, package identity, CLI workflows, encoding, and filesystem work.",
-      "status": "pilot",
+      "status": "implemented",
       "entry_points": [
         "MP.1",
         "CL.1",
@@ -132,7 +132,7 @@
       "path_prefix": "06-backend-db",
       "phase": "engineering-core",
       "summary": "Teach HTTP services, API design, and database workflows as one application-shaped backend path.",
-      "status": "pilot",
+      "status": "implemented",
       "entry_points": [
         "HS.1",
         "API.1",
@@ -155,7 +155,7 @@
       "path_prefix": "07-concurrency",
       "phase": "engineering-core",
       "summary": "Teach goroutines, channels, context, scheduling, and bounded concurrency patterns.",
-      "status": "pilot",
+      "status": "implemented",
       "entry_points": [
         "GC.0",
         "SY.1",
@@ -182,7 +182,7 @@
       "path_prefix": "08-quality-test",
       "phase": "engineering-core",
       "summary": "Teach testing, benchmarks, and profiling so learners can prove behavior and inspect cost.",
-      "status": "pilot",
+      "status": "implemented",
       "entry_points": [
         "TE.1",
         "PR.1"
@@ -203,7 +203,7 @@
       "path_prefix": "09-architecture",
       "phase": "systems",
       "summary": "Teach package design, architecture patterns, and security engineering as one systems-thinking stage.",
-      "status": "pilot",
+      "status": "implemented",
       "entry_points": [
         "PD.1",
         "ARCH.1",
@@ -226,7 +226,7 @@
       "path_prefix": "10-production",
       "phase": "systems",
       "summary": "Teach runtime behavior, configuration, observability, deployment-aware thinking, and build-time automation.",
-      "status": "pilot",
+      "status": "implemented",
       "entry_points": [
         "SL.1",
         "GS.1",
@@ -254,7 +254,7 @@
       "path_prefix": "11-flagship",
       "phase": "systems",
       "summary": "Integrate larger project work into one final proof stage after the production tooling path is already established.",
-      "status": "pilot",
+      "status": "implemented",
       "entry_points": [
         "FG.1"
       ],

--- a/scripts/internal/curriculumvalidator/validator.go
+++ b/scripts/internal/curriculumvalidator/validator.go
@@ -36,6 +36,7 @@ type V2Section struct {
 	EntryPoints   []string `json:"entry_points"`
 	Outputs       []string `json:"outputs"`
 	Prerequisites []string `json:"prerequisites"`
+	Status        string   `json:"status"`
 }
 
 type V2Item struct {
@@ -102,6 +103,11 @@ var (
 		"test":   true,
 		"rubric": true,
 		"mixed":  true,
+	}
+	allowedSectionStatuses = map[string]bool{
+		"":            true,
+		"implemented": true,
+		"placeholder": true,
 	}
 )
 
@@ -343,6 +349,11 @@ func validateV2Curriculum(root string, report func(string)) (int, int, int, int,
 
 		if s.Number == "" || s.Slug == "" || s.Title == "" || s.PathPrefix == "" {
 			report(fmt.Sprintf("Invalid v2 section metadata: %s requires number, slug, title, and path_prefix", s.ID))
+			errorsFound++
+		}
+
+		if !allowedSectionStatuses[strings.TrimSpace(s.Status)] {
+			report(fmt.Sprintf("Invalid v2 section status: %s -> %s", s.ID, s.Status))
 			errorsFound++
 		}
 
@@ -729,6 +740,12 @@ var mojibakeMarkers = []string{
 	"\u00c3\u00a2\u20ac\u00a0",
 	"\u00c3\u00a2\u00c5\u201c",
 	"\u00c3\u00a2\u00c2\u009d",
+	"\u00e2\u20ac\u0153",
+	"\u00e2\u20ac\u009d",
+	"\u00e2\u20ac\u201d",
+	"\u00e2\u0080\u0094",
+	"\u00e2\u2020\u2019",
+	"\u00e2\u20ac\u00a2",
 }
 
 func validateV2TextEncoding(root string, sections map[string]V2Section, items []V2Item, report func(string)) int {
@@ -915,14 +932,14 @@ func validateMarkdownSurfaces(root string, report func(string)) int {
 
 		if d.IsDir() {
 			switch d.Name() {
-			case ".git", "vendor", ".agents", ".cache", ".github", ".opencode", "temp":
+			case ".git", "vendor", ".agents", ".cache", ".gocache", ".github", ".opencode", "temp":
 				return filepath.SkipDir
 			default:
 				return nil
 			}
 		}
 
-		if filepath.Ext(path) != ".md" {
+		if filepath.Ext(path) != ".md" && filepath.Base(path) != "Makefile" {
 			return nil
 		}
 

--- a/scripts/internal/curriculumvalidator/validator_test.go
+++ b/scripts/internal/curriculumvalidator/validator_test.go
@@ -168,6 +168,44 @@ func TestValidateRejectsUnknownSectionPrerequisite(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsInvalidSectionStatus(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, "curriculum.v2.json", `{
+  "schema_version": 1,
+  "sections": [
+    {
+      "id": "s00",
+      "number": "00",
+      "slug": "how-computers-work",
+      "title": "How Computers Work",
+      "path_prefix": "00-how-computers-work",
+      "status": "pilot",
+      "entry_points": [],
+      "outputs": [],
+      "prerequisites": []
+    }
+  ],
+  "items": []
+}`)
+	writeValidPressureDocs(t, root)
+	mustMkdir(t, root, "00-how-computers-work")
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount != 1 {
+		t.Fatalf("expected 1 validation error, got %d with reports %v", result.ErrorCount, reports)
+	}
+	if !containsReport(reports, "Invalid v2 section status: s00 -> pilot") {
+		t.Fatalf("expected section-status error in reports: %v", reports)
+	}
+}
+
 func TestValidateRejectsMixedContractWithoutCommands(t *testing.T) {
 	root := t.TempDir()
 


### PR DESCRIPTION
## Summary
- fix the maintainer `make` convenience targets so benchmarks and example runs point at real lesson paths
- promote v2 section metadata from `pilot` to `implemented` and validate section status explicitly
- clean remaining mojibake in RC-facing lesson READMEs so the validator and public text stay coherent

## Verification
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go run ./scripts/validate_curriculum.go`
- `go test ./08-quality-test/01-quality-and-performance/testing/benchmarks -bench="." -benchmem -count=1`
- `go run ./01-getting-started/2-hello-world`
- `go run ./01-getting-started/4-dev-environment`

Closes #366