### PR TITLE
Release: v2.1.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format: **[Date] - Description**. Sections: `Added`, `Fixed`, `Changed`, `Remove
 
 ---
 
+## [2026-04-23] - v2.1.0-rc.1 Release Gate
+
+### Changed
+
+- Defined the explicit `v2.1.0-rc.1` smoke matrix for `release/v2`, including build, tests, race detection, benchmarks, example run targets, and curriculum validation.
+- Tightened maintainer release guidance so the RC tag is only cut after the release-prep PR is merged, GitHub checks are green, and `release-blocker` issues are closed.
+
+---
+
 ## [2026-04-22] - v2.1.0-beta.1 Beta-Complete Snapshot
 
 ### Added

--- a/MAINTAINER-CHECKLIST.md
+++ b/MAINTAINER-CHECKLIST.md
@@ -44,6 +44,25 @@ git push origin <target-branch>
 - Tag final `v2.1.0` from `release/v2`.
 - Keep `release/v1` for v1 patch support until you formally end support.
 
+### RC.1 Gate
+
+Before tagging `v2.1.0-rc.1`, verify all of the following on `release/v2`:
+
+- `make build`
+- `make test`
+- `make test-race`
+- `make bench`
+- `make run-hello`
+- `make run-env`
+- `go run ./scripts/validate_curriculum.go`
+- the release-prep PR is green and approved
+- all `release-blocker` issues in the `v2 rc` milestone are closed or explicitly accepted for deferment
+- the release branch is clean immediately before tagging
+
+If GNU Make is not available in the maintainer environment, run the documented direct Go-command equivalents from `RELEASE.md` instead of skipping the gate.
+
+If `go test -race ./...` cannot run locally because the environment lacks a supported CGO toolchain or C compiler, do not silently waive it. Use the CI race check on the release-prep PR as the release gate for that item.
+
 ## Branch Hygiene
 
 - Keep `main` as the default branch.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,6 +58,13 @@ make test
 # Run with race detection
 make test-race
 
+# Run the maintained benchmark target
+make bench
+
+# Verify the maintained example run targets
+make run-hello
+make run-env
+
 # Generate coverage
 make cover
 
@@ -70,6 +77,46 @@ git status
 # Check for dependencies that need updating
 make deps-check
 ```
+
+### Step 2A: RC.1 Release Gate
+
+For `v2.1.0-rc.1`, treat the following as the minimum release gate on `release/v2`:
+
+```bash
+make build
+make test
+make test-race
+make bench
+make run-hello
+make run-env
+go run ./scripts/validate_curriculum.go
+git status
+```
+
+If GNU Make is not installed in the current maintainer environment, run the direct equivalents instead:
+
+```bash
+go build ./...
+go test ./...
+go test -race ./...
+go test ./08-quality-test/01-quality-and-performance/testing/benchmarks -bench="." -benchmem -count=1
+go run ./01-getting-started/2-hello-world
+go run ./01-getting-started/4-dev-environment
+go run ./scripts/validate_curriculum.go
+git status
+```
+
+The RC tag should only be cut after:
+
+- the `release-prep/v2.1.0-rc.1` PR into `release/v2` is merged
+- required GitHub Actions checks are green on that PR
+- all `release-blocker` issues in the `v2 rc` milestone are closed or explicitly deferred
+- the working tree on the release line is clean before tagging
+
+For the `test-race` part of the gate:
+
+- prefer a local `go test -race ./...` pass when the maintainer environment has CGO plus a working C toolchain
+- if the local environment does not provide that toolchain (for example, Windows without `gcc`), require the CI race job on the release-prep PR to pass before tagging
 
 ### Step 3: Choose the Correct Release Line
 
@@ -181,9 +228,13 @@ Before releasing, verify:
 
 - [ ] All issues in the milestone are closed
 - [ ] All PRs in the release are merged
+- [ ] The explicit RC smoke matrix has passed on `release/v2`
 - [ ] CHANGELOG.md is updated with all changes
 - [ ] ROADMAP.md status indicators are accurate
 - [ ] All CI checks pass (`build`, `test`, `vet`, `fmt`)
+- [ ] Maintained convenience targets still work (`make bench`, `make run-hello`, `make run-env`)
+- [ ] If GNU Make is unavailable, the documented direct-command fallback has also been verified
+- [ ] Race detection is green either locally with a supported CGO toolchain or in CI on the release-prep PR
 - [ ] Test coverage is maintained (> 75%)
 - [ ] No security vulnerabilities in dependencies
 - [ ] Documentation is up to date

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -228,13 +228,9 @@ Before releasing, verify:
 
 - [ ] All issues in the milestone are closed
 - [ ] All PRs in the release are merged
-- [ ] The explicit RC smoke matrix has passed on `release/v2`
 - [ ] CHANGELOG.md is updated with all changes
 - [ ] ROADMAP.md status indicators are accurate
 - [ ] All CI checks pass (`build`, `test`, `vet`, `fmt`)
-- [ ] Maintained convenience targets still work (`make bench`, `make run-hello`, `make run-env`)
-- [ ] If GNU Make is unavailable, the documented direct-command fallback has also been verified
-- [ ] Race detection is green either locally with a supported CGO toolchain or in CI on the release-prep PR
 - [ ] Test coverage is maintained (> 75%)
 - [ ] No security vulnerabilities in dependencies
 - [ ] Documentation is up to date
@@ -242,6 +238,13 @@ Before releasing, verify:
 - [ ] Version numbers updated in appropriate files
 - [ ] PR target matches the release line (`release/v1` or `release/v2`)
 - [ ] Any cross-line fix has a planned `cherry-pick -x` follow-up
+
+For `v2.1.0-rc.1` and later v2 RC/final releases, also verify:
+
+- [ ] The explicit RC smoke matrix has passed on `release/v2`
+- [ ] Maintained convenience targets still work (`make bench`, `make run-hello`, `make run-env`)
+- [ ] If GNU Make is unavailable, the documented direct-command fallback has also been verified
+- [ ] Race detection is green either locally with a supported CGO toolchain or in CI on the release-prep PR
 
 ## Rollback Procedure
 


### PR DESCRIPTION
## Release v2.1.0-rc.1

**Date**: 2026-04-23

### Summary
- define the explicit `v2.1.0-rc.1` release gate on `release/v2`
- document the exact smoke matrix required before cutting the RC tag
- record the RC gate prep in `CHANGELOG.md`

### Verification
- `go build ./...`
- `go test ./...`
- `go test ./08-quality-test/01-quality-and-performance/testing/benchmarks -bench="." -benchmem -count=1`
- `go run ./01-getting-started/2-hello-world`
- `go run ./01-getting-started/4-dev-environment`
- `go run ./scripts/validate_curriculum.go`

### Race Detection Note
- `go test -race ./...` is documented as part of the RC gate
- local Windows execution in this environment is blocked by missing `gcc`/CGO toolchain support
- the release gate now explicitly requires the CI race check on this PR when local toolchain support is unavailable

Closes #368