### PR TITLE
[DOCS] open v2.1 stable validation window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Format: **[Date] - Description**. Sections: `Added`, `Fixed`, `Changed`, `Remove
 
 ---
 
+## [2026-04-23] - v2.1.0-rc.1 Published
+
+### Added
+
+- Published the `v2.1.0-rc.1` prerelease from `release/v2`.
+- Opened the public RC validation window with a release page and maintainer announcement.
+
+### Changed
+
+- Updated the public release-facing docs so the repo advertises the live release candidate instead of the beta snapshot.
+- Shifted roadmap and release wording from "RC is next" to "stable validation is active."
+
+---
+
 ## [2026-04-23] - v2.1.0-rc.1 Release Gate
 
 ### Changed

--- a/MAINTAINER-CHECKLIST.md
+++ b/MAINTAINER-CHECKLIST.md
@@ -63,6 +63,13 @@ If GNU Make is not available in the maintainer environment, run the documented d
 
 If `go test -race ./...` cannot run locally because the environment lacks a supported CGO toolchain or C compiler, do not silently waive it. Use the CI race check on the release-prep PR as the release gate for that item.
 
+### After `v2.1.0-rc.1` Is Published
+
+- Keep `release/v2` focused on release blockers, validation findings, and release-facing polish only.
+- Open all RC findings in the `v2 rc` milestone and keep them on the **The Go Engineer v2** project board.
+- Do not resume beta migration or broad architecture work on `release/v2`.
+- Tag final `v2.1.0` only after RC blockers are closed or explicitly deferred.
+
 ## Branch Hygiene
 
 - Keep `main` as the default branch.

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ For the full curriculum source of truth, read [ARCHITECTURE.md](./ARCHITECTURE.m
 
 ## Current Status
 
-The v2.1 beta migration is complete, and RC hardening is now active on `release/v2`.
+The v2.1 beta migration is complete, and **`v2.1.0-rc.1` is now live** on `release/v2`.
 
 - `release/v1`: stable v1 line for current learners
 - `main`: active v2 development and integration line
-- `release/v2`: active v2.1 stabilization and RC line
+- `release/v2`: active v2.1 RC validation and stabilization line
 
 Latest prerelease:
 
-- `v2.1.0-beta.1`: beta-complete snapshot published before RC hardening
+- `v2.1.0-rc.1`: first release candidate published from `release/v2`
 
 ## Quick Start
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,9 +13,9 @@ The Go Engineer follows **semantic versioning** for stable releases:
 
 Current v2.1 state:
 
-- published prerelease: `v2.1.0-beta.1`
+- published prerelease: `v2.1.0-rc.1`
 - active stabilization branch: `release/v2`
-- next planned milestone: `v2.1.0-rc.1`
+- next planned milestone: `v2.1.0`
 
 ## Branch Roles
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,15 +5,15 @@
 
 ## Current Status
 
-The v2.1 beta migration is complete, and RC hardening is active on `release/v2`.
+The v2.1 beta migration is complete, and the **v2.1.0-rc.1 validation window is active** on `release/v2`.
 
 - the 12-section architecture is live
 - root-stage source folders are aligned to the public section map
 - `curriculum.v2.json` is the active curriculum source
 - the single validator is the required repo health check
-- `v2.1.0-beta.1` is the published beta-complete prerelease snapshot
+- `v2.1.0-rc.1` is the published release candidate snapshot
 
-The next release step is **RC hardening**, not more beta migration.
+The next release step is **stable release validation**, not more migration or architecture work.
 
 ## Branch Model
 
@@ -31,9 +31,9 @@ The next release step is **RC hardening**, not more beta migration.
 | Validator | Complete | single Go validator is the required repo health check |
 | Beta migration work | Complete | no remaining beta-architecture migration blocker |
 
-## RC Focus
+## Stable Release Focus
 
-RC work should now concentrate on:
+RC validation should now concentrate on:
 
 1. learner-path polish and consistency
 2. validator strictness and repo hygiene
@@ -58,9 +58,9 @@ RC work should now concentrate on:
 | s10 Production Operations | Beta-ready | keep config, observability, deployment, and code generation coherent |
 | s11 GoScale Flagship | Beta-ready | deepen integrated proof and release-readiness |
 
-## RC Exit Criteria
+## v2.1 Stable Exit Criteria
 
-Before cutting `v2.1.0-rc.1` from `release/v2`, we should be able to say:
+Before cutting `v2.1.0` from `release/v2`, we should be able to say:
 
 - the public docs, metadata, and validator agree
 - section navigation has no dead internal links
@@ -73,5 +73,5 @@ Before cutting `v2.1.0-rc.1` from `release/v2`, we should be able to say:
 | Version | Target | Criteria |
 | --- | --- | --- |
 | v2.1.0-beta.1 | published | beta migration complete and validator green |
-| v2.1.0-rc.1 | next | stabilization, polish, and release prep on `release/v2` |
-| v2.1 | release | RC passes and release docs are complete |
+| v2.1.0-rc.1 | published | RC gate passed and validation window is open on `release/v2` |
+| v2.1.0 | next | RC validation passes and release blockers are closed |


### PR DESCRIPTION
## Summary
- update the public release-facing docs to advertise `v2.1.0-rc.1` as the live prerelease
- shift roadmap/release wording from "RC is next" to "stable validation is active"
- add maintainer guidance for the post-rc.1 validation window and record the published RC in the changelog

Closes #371

## Validation
- go run ./scripts/validate_curriculum.go
- go test ./scripts/internal/curriculumvalidator
- git diff --check
