### PR TITLE
[FEAT] add Opslane module 4 HTTP API layer

### DIFF
--- a/11-flagship/01-opslane/README.md
+++ b/11-flagship/01-opslane/README.md
@@ -34,19 +34,19 @@ This project exists so the curriculum has one integrated system where earlier st
 | `docker-compose.yml` | runs the application with PostgreSQL and the flagship API |
 | `internal/` | holds the application boundaries that later modules will deepen |
 
-## Module 3 Focus
+## Module 4 Focus
 
-Module 3 establishes:
+Module 4 establishes:
 
-- password policy and bcrypt hashing
-- signed token issuance and verification
-- tenant-aware authenticated request identity
-- middleware that rejects anonymous requests before protected handlers run
+- public JSON API routes for tenant setup, user setup, and login
+- protected order and payment routes that use authenticated tenant identity
+- consistent JSON error responses
+- CORS and simple in-process rate limiting middleware
 
-This slice turns the persistence foundation into a request-level security boundary.
-The important rule is simple: protected application code should not guess tenant identity from
-untrusted request data. Auth middleware verifies the token once, then stores the tenant-scoped
-identity in the request context for downstream handlers and services.
+This slice turns the auth and persistence foundation into a runnable HTTP contract.
+The important rule is still zero magic: protected handlers do not accept tenant IDs from request
+bodies. They read tenant and user identity from verified auth context, then pass that trusted
+identity into repository calls.
 
 ## Run the Project
 
@@ -89,13 +89,50 @@ reusing incompatible data.
 curl http://localhost:8080/
 curl http://localhost:8080/health
 curl http://localhost:8080/me
+curl http://localhost:8080/api/v1/me
 ```
 
 The health endpoint now checks the live PostgreSQL connection before reporting the service as ready.
-The `/me` endpoint is intentionally protected. It returns `401 Unauthorized` without a bearer token
-and returns the tenant-scoped identity when a valid Opslane token is supplied.
+The `/me` and `/api/v1/me` endpoints are intentionally protected. They return `401 Unauthorized`
+without a bearer token and return the tenant-scoped identity when a valid Opslane token is supplied.
+
+### Setup and Login
+
+```bash
+curl -X POST http://localhost:8080/api/v1/tenants \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Acme Inc","slug":"acme"}'
+
+curl -X POST http://localhost:8080/api/v1/users \
+  -H "Content-Type: application/json" \
+  -d '{"tenant_id":1,"email":"admin@example.com","display_name":"Admin","password":"CorrectHorse7Battery","role":"admin"}'
+
+curl -X POST http://localhost:8080/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"tenant_id":1,"email":"admin@example.com","password":"CorrectHorse7Battery"}'
+```
+
+### Protected API
+
+```bash
+curl http://localhost:8080/api/v1/orders \
+  -H "Authorization: Bearer <token>"
+
+curl -X POST http://localhost:8080/api/v1/orders \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"total_cents":2500,"currency":"USD","idempotency_key":"checkout-123"}'
+
+curl -X POST http://localhost:8080/api/v1/payments \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"order_id":1,"provider_reference":"pay_123","amount_cents":2500}'
+
+curl http://localhost:8080/api/v1/orders/1/payments \
+  -H "Authorization: Bearer <token>"
+```
 
 ## Next Step
 
-After Module 3 is in place, the next build slice is the HTTP API layer so Opslane can expose user,
-order, and payment operations through stable request and error contracts.
+After Module 4 is in place, the next build slice is order processing so Opslane can move from CRUD
+surfaces into explicit business state transitions and failure-aware workflows.

--- a/11-flagship/01-opslane/cmd/server/main.go
+++ b/11-flagship/01-opslane/cmd/server/main.go
@@ -53,11 +53,12 @@ func main() {
 
 	store := db.NewStore(database)
 	app := &handlers.Application{
-		Logger:      logger,
-		Store:       store,
-		Tokens:      tokens,
-		ServiceName: cfg.App.Name,
-		Environment: cfg.App.Env,
+		Logger:            logger,
+		Store:             store,
+		Tokens:            tokens,
+		ServiceName:       cfg.App.Name,
+		Environment:       cfg.App.Env,
+		TrustedProxyCIDRs: cfg.HTTP.TrustedProxyCIDRs,
 	}
 
 	server := &http.Server{

--- a/11-flagship/01-opslane/internal/config/config.go
+++ b/11-flagship/01-opslane/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"net/netip"
 	"os"
 	"strings"
 	"time"
@@ -31,6 +32,7 @@ type HTTPConfig struct {
 	WriteTimeout      time.Duration
 	IdleTimeout       time.Duration
 	ShutdownTimeout   time.Duration
+	TrustedProxyCIDRs []netip.Prefix
 }
 
 type DatabaseConfig struct {
@@ -79,6 +81,11 @@ func LoadFromLookup(lookup LookupFunc) (Config, error) {
 		return Config{}, fmt.Errorf("parse OPSLANE_HTTP_SHUTDOWN_TIMEOUT: %w", err)
 	}
 
+	trustedProxyCIDRs, err := cidrPrefixesFromEnv(lookup, "OPSLANE_HTTP_TRUSTED_PROXY_CIDRS")
+	if err != nil {
+		return Config{}, fmt.Errorf("parse OPSLANE_HTTP_TRUSTED_PROXY_CIDRS: %w", err)
+	}
+
 	maxOpenConns, err := intFromEnv(lookup, "OPSLANE_DB_MAX_OPEN_CONNS", 4)
 	if err != nil {
 		return Config{}, fmt.Errorf("parse OPSLANE_DB_MAX_OPEN_CONNS: %w", err)
@@ -122,6 +129,7 @@ func LoadFromLookup(lookup LookupFunc) (Config, error) {
 			WriteTimeout:      writeTimeout,
 			IdleTimeout:       idleTimeout,
 			ShutdownTimeout:   shutdownTimeout,
+			TrustedProxyCIDRs: trustedProxyCIDRs,
 		},
 		Database: DatabaseConfig{
 			DSN:             stringFromEnv(lookup, "OPSLANE_DB_DSN", "postgres://opslane:secretpassword@localhost:5432/opslane?sslmode=disable"),
@@ -173,6 +181,12 @@ func (c Config) Validate() error {
 
 	if c.HTTP.ShutdownTimeout <= 0 {
 		return fmt.Errorf("OPSLANE_HTTP_SHUTDOWN_TIMEOUT must be positive")
+	}
+
+	for _, prefix := range c.HTTP.TrustedProxyCIDRs {
+		if !prefix.IsValid() {
+			return fmt.Errorf("OPSLANE_HTTP_TRUSTED_PROXY_CIDRS contains an invalid prefix")
+		}
 	}
 
 	if strings.TrimSpace(c.Database.DSN) == "" {

--- a/11-flagship/01-opslane/internal/config/config_test.go
+++ b/11-flagship/01-opslane/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"log/slog"
+	"net/netip"
 	"testing"
 	"time"
 )
@@ -51,6 +52,10 @@ func TestLoadFromLookupDefaults(t *testing.T) {
 	if cfg.Auth.TokenTTL != time.Hour {
 		t.Fatalf("token ttl = %v, want %v", cfg.Auth.TokenTTL, time.Hour)
 	}
+
+	if len(cfg.HTTP.TrustedProxyCIDRs) != 0 {
+		t.Fatalf("trusted proxy cidrs = %v, want none by default", cfg.HTTP.TrustedProxyCIDRs)
+	}
 }
 
 func TestLoadFromLookupOverrides(t *testing.T) {
@@ -65,6 +70,7 @@ func TestLoadFromLookupOverrides(t *testing.T) {
 		"OPSLANE_HTTP_WRITE_TIMEOUT":       "18s",
 		"OPSLANE_HTTP_IDLE_TIMEOUT":        "90s",
 		"OPSLANE_HTTP_SHUTDOWN_TIMEOUT":    "25s",
+		"OPSLANE_HTTP_TRUSTED_PROXY_CIDRS": "127.0.0.1/32,10.0.0.0/8",
 		"OPSLANE_DB_DSN":                   "postgres://opslane:secretpassword@db:5432/opslane?sslmode=disable",
 		"OPSLANE_DB_MAX_OPEN_CONNS":        "4",
 		"OPSLANE_DB_MAX_IDLE_CONNS":        "2",
@@ -97,6 +103,20 @@ func TestLoadFromLookupOverrides(t *testing.T) {
 
 	if cfg.HTTP.ReadHeaderTimeout != 7*time.Second {
 		t.Fatalf("read header timeout = %v, want %v", cfg.HTTP.ReadHeaderTimeout, 7*time.Second)
+	}
+
+	wantPrefixes := []netip.Prefix{
+		netip.MustParsePrefix("127.0.0.1/32"),
+		netip.MustParsePrefix("10.0.0.0/8"),
+	}
+	if len(cfg.HTTP.TrustedProxyCIDRs) != len(wantPrefixes) {
+		t.Fatalf("trusted proxy cidrs length = %d, want %d", len(cfg.HTTP.TrustedProxyCIDRs), len(wantPrefixes))
+	}
+
+	for i, want := range wantPrefixes {
+		if cfg.HTTP.TrustedProxyCIDRs[i] != want {
+			t.Fatalf("trusted proxy cidr[%d] = %v, want %v", i, cfg.HTTP.TrustedProxyCIDRs[i], want)
+		}
 	}
 
 	if cfg.Database.DSN != "postgres://opslane:secretpassword@db:5432/opslane?sslmode=disable" {
@@ -159,6 +179,20 @@ func TestLoadFromLookupRejectsInvalidDuration(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for invalid duration")
+	}
+}
+
+func TestLoadFromLookupRejectsInvalidTrustedProxyCIDR(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadFromLookup(func(key string) (string, bool) {
+		if key == "OPSLANE_HTTP_TRUSTED_PROXY_CIDRS" {
+			return "not-a-cidr", true
+		}
+		return "", false
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid trusted proxy cidr")
 	}
 }
 

--- a/11-flagship/01-opslane/internal/config/environment.go
+++ b/11-flagship/01-opslane/internal/config/environment.go
@@ -4,7 +4,9 @@
 package config
 
 import (
+	"net/netip"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -44,4 +46,29 @@ func intFromEnv(lookup LookupFunc, key string, fallback int) (int, error) {
 	}
 
 	return value, nil
+}
+
+func cidrPrefixesFromEnv(lookup LookupFunc, key string) ([]netip.Prefix, error) {
+	raw, ok := lookup(key)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(raw, ",")
+	prefixes := make([]netip.Prefix, 0, len(parts))
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+
+		prefix, err := netip.ParsePrefix(value)
+		if err != nil {
+			return nil, err
+		}
+
+		prefixes = append(prefixes, prefix)
+	}
+
+	return prefixes, nil
 }

--- a/11-flagship/01-opslane/internal/db/repository.go
+++ b/11-flagship/01-opslane/internal/db/repository.go
@@ -171,6 +171,12 @@ func (s *Store) CreateUser(ctx context.Context, user *models.User) error {
 		user.CreatedAt,
 	).Scan(&user.ID)
 	if err != nil {
+		if isForeignKeyViolation(err) {
+			return fmt.Errorf("insert user: %w", ErrInvalidReference)
+		}
+		if isUniqueViolation(err) {
+			return fmt.Errorf("insert user: %w", ErrDuplicateValue)
+		}
 		return fmt.Errorf("insert user: %w", err)
 	}
 

--- a/11-flagship/01-opslane/internal/db/repository.go
+++ b/11-flagship/01-opslane/internal/db/repository.go
@@ -6,13 +6,19 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/config"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
+
+// ErrInvalidReference means a tenant-scoped row points at a parent row that does not exist.
+var ErrInvalidReference = errors.New("invalid tenant-scoped reference")
+
+const postgresForeignKeyViolation = "23503"
 
 type TenantRepository interface {
 	CreateTenant(ctx context.Context, tenant *models.Tenant) error
@@ -289,6 +295,9 @@ func (s *Store) CreatePayment(ctx context.Context, payment *models.Payment) erro
 		payment.UpdatedAt,
 	).Scan(&payment.ID)
 	if err != nil {
+		if isForeignKeyViolation(err) {
+			return fmt.Errorf("insert payment: %w", ErrInvalidReference)
+		}
 		return fmt.Errorf("insert payment: %w", err)
 	}
 
@@ -334,4 +343,9 @@ func (s *Store) ListPaymentsByOrder(ctx context.Context, tenantID, orderID int64
 	}
 
 	return payments, nil
+}
+
+func isForeignKeyViolation(err error) bool {
+	var pqErr *pq.Error
+	return errors.As(err, &pqErr) && string(pqErr.Code) == postgresForeignKeyViolation
 }

--- a/11-flagship/01-opslane/internal/db/repository.go
+++ b/11-flagship/01-opslane/internal/db/repository.go
@@ -132,6 +132,9 @@ func (s *Store) CreateTenant(ctx context.Context, tenant *models.Tenant) error {
 		tenant.CreatedAt,
 	).Scan(&tenant.ID)
 	if err != nil {
+		if isUniqueViolation(err) {
+			return fmt.Errorf("insert tenant: %w", ErrDuplicateValue)
+		}
 		return fmt.Errorf("insert tenant: %w", err)
 	}
 
@@ -308,6 +311,9 @@ func (s *Store) CreatePayment(ctx context.Context, payment *models.Payment) erro
 	if err != nil {
 		if isForeignKeyViolation(err) {
 			return fmt.Errorf("insert payment: %w", ErrInvalidReference)
+		}
+		if isUniqueViolation(err) {
+			return fmt.Errorf("insert payment: %w", ErrDuplicateValue)
 		}
 		return fmt.Errorf("insert payment: %w", err)
 	}

--- a/11-flagship/01-opslane/internal/db/repository.go
+++ b/11-flagship/01-opslane/internal/db/repository.go
@@ -17,8 +17,10 @@ import (
 
 // ErrInvalidReference means a tenant-scoped row points at a parent row that does not exist.
 var ErrInvalidReference = errors.New("invalid tenant-scoped reference")
+var ErrDuplicateValue = errors.New("duplicate value")
 
 const postgresForeignKeyViolation = "23503"
+const postgresUniqueViolation = "23505"
 
 type TenantRepository interface {
 	CreateTenant(ctx context.Context, tenant *models.Tenant) error
@@ -225,6 +227,9 @@ func (s *Store) CreateOrder(ctx context.Context, order *models.Order) error {
 		order.UpdatedAt,
 	).Scan(&order.ID)
 	if err != nil {
+		if isUniqueViolation(err) {
+			return fmt.Errorf("insert order: %w", ErrDuplicateValue)
+		}
 		return fmt.Errorf("insert order: %w", err)
 	}
 
@@ -348,4 +353,9 @@ func (s *Store) ListPaymentsByOrder(ctx context.Context, tenantID, orderID int64
 func isForeignKeyViolation(err error) bool {
 	var pqErr *pq.Error
 	return errors.As(err, &pqErr) && string(pqErr.Code) == postgresForeignKeyViolation
+}
+
+func isUniqueViolation(err error) bool {
+	var pqErr *pq.Error
+	return errors.As(err, &pqErr) && string(pqErr.Code) == postgresUniqueViolation
 }

--- a/11-flagship/01-opslane/internal/db/repository_test.go
+++ b/11-flagship/01-opslane/internal/db/repository_test.go
@@ -16,3 +16,13 @@ func TestIsForeignKeyViolation(t *testing.T) {
 		t.Fatal("expected wrapped PostgreSQL foreign key violation to be detected")
 	}
 }
+
+func TestIsUniqueViolation(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("wrapped: %w", &pq.Error{Code: postgresUniqueViolation})
+
+	if !isUniqueViolation(err) {
+		t.Fatal("expected wrapped PostgreSQL unique violation to be detected")
+	}
+}

--- a/11-flagship/01-opslane/internal/db/repository_test.go
+++ b/11-flagship/01-opslane/internal/db/repository_test.go
@@ -1,0 +1,18 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lib/pq"
+)
+
+func TestIsForeignKeyViolation(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("wrapped: %w", &pq.Error{Code: postgresForeignKeyViolation})
+
+	if !isForeignKeyViolation(err) {
+		t.Fatal("expected wrapped PostgreSQL foreign key violation to be detected")
+	}
+}

--- a/11-flagship/01-opslane/internal/handlers/api.go
+++ b/11-flagship/01-opslane/internal/handlers/api.go
@@ -71,6 +71,10 @@ func (app *Application) handleCreateTenant(w http.ResponseWriter, r *http.Reques
 		Slug: req.Slug,
 	}
 	if err := app.Store.CreateTenant(r.Context(), &tenant); err != nil {
+		if errors.Is(err, db.ErrDuplicateValue) {
+			app.writeError(w, r, http.StatusConflict, "duplicate_slug", "tenant slug already exists")
+			return
+		}
 		app.writeError(w, r, http.StatusInternalServerError, "tenant_create_failed", "failed to create tenant")
 		return
 	}
@@ -254,6 +258,10 @@ func (app *Application) handleCreatePayment(w http.ResponseWriter, r *http.Reque
 	if err := app.Store.CreatePayment(r.Context(), &payment); err != nil {
 		if errors.Is(err, db.ErrInvalidReference) {
 			app.writeError(w, r, http.StatusNotFound, "order_not_found", "order does not exist for this tenant")
+			return
+		}
+		if errors.Is(err, db.ErrDuplicateValue) {
+			app.writeError(w, r, http.StatusConflict, "duplicate_provider_reference", "provider_reference already exists for this tenant")
 			return
 		}
 		app.writeError(w, r, http.StatusInternalServerError, "payment_create_failed", "failed to create payment")

--- a/11-flagship/01-opslane/internal/handlers/api.go
+++ b/11-flagship/01-opslane/internal/handlers/api.go
@@ -202,6 +202,10 @@ func (app *Application) handleCreateOrder(w http.ResponseWriter, r *http.Request
 		IdempotencyKey: strings.TrimSpace(req.IdempotencyKey),
 	}
 	if err := app.Store.CreateOrder(r.Context(), &order); err != nil {
+		if errors.Is(err, db.ErrDuplicateValue) {
+			app.writeError(w, r, http.StatusConflict, "duplicate_idempotency_key", "an order with this idempotency_key already exists for this tenant")
+			return
+		}
 		app.writeError(w, r, http.StatusInternalServerError, "order_create_failed", "failed to create order")
 		return
 	}

--- a/11-flagship/01-opslane/internal/handlers/api.go
+++ b/11-flagship/01-opslane/internal/handlers/api.go
@@ -1,0 +1,300 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+)
+
+const maxJSONBodySize = 1 << 20
+
+type createTenantRequest struct {
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+type createUserRequest struct {
+	TenantID    int64           `json:"tenant_id"`
+	Email       string          `json:"email"`
+	DisplayName string          `json:"display_name"`
+	Password    string          `json:"password"`
+	Role        models.UserRole `json:"role"`
+}
+
+type loginRequest struct {
+	TenantID int64  `json:"tenant_id"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type createOrderRequest struct {
+	TotalCents     int64  `json:"total_cents"`
+	Currency       string `json:"currency"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+type createPaymentRequest struct {
+	OrderID           int64                `json:"order_id"`
+	Status            models.PaymentStatus `json:"status"`
+	ProviderReference string               `json:"provider_reference"`
+	AmountCents       int64                `json:"amount_cents"`
+	FailureReason     string               `json:"failure_reason"`
+}
+
+func (app *Application) handleCreateTenant(w http.ResponseWriter, r *http.Request) {
+	var req createTenantRequest
+	if err := readJSON(w, r, &req); err != nil {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_json", err.Error())
+		return
+	}
+
+	req.Name = strings.TrimSpace(req.Name)
+	req.Slug = strings.ToLower(strings.TrimSpace(req.Slug))
+	if req.Name == "" || req.Slug == "" {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_tenant", "name and slug are required")
+		return
+	}
+
+	tenant := models.Tenant{
+		Name: req.Name,
+		Slug: req.Slug,
+	}
+	if err := app.Store.CreateTenant(r.Context(), &tenant); err != nil {
+		app.writeError(w, r, http.StatusInternalServerError, "tenant_create_failed", "failed to create tenant")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, tenant)
+}
+
+func (app *Application) handleCreateUser(w http.ResponseWriter, r *http.Request) {
+	var req createUserRequest
+	if err := readJSON(w, r, &req); err != nil {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_json", err.Error())
+		return
+	}
+
+	role := req.Role
+	if role == "" {
+		role = models.UserRoleMember
+	}
+	if !isAllowedUserRole(role) {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_role", "role must be admin, member, or billing")
+		return
+	}
+
+	passwordHash, err := auth.HashPassword(req.Password)
+	if err != nil {
+		app.writeError(w, r, http.StatusBadRequest, "weak_password", "password does not meet policy")
+		return
+	}
+
+	user := models.User{
+		TenantID:     req.TenantID,
+		Email:        strings.ToLower(strings.TrimSpace(req.Email)),
+		DisplayName:  strings.TrimSpace(req.DisplayName),
+		PasswordHash: passwordHash,
+		Role:         role,
+	}
+	if user.TenantID <= 0 || user.Email == "" || user.DisplayName == "" {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_user", "tenant_id, email, and display_name are required")
+		return
+	}
+
+	if err := app.Store.CreateUser(r.Context(), &user); err != nil {
+		app.writeError(w, r, http.StatusInternalServerError, "user_create_failed", "failed to create user")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, user)
+}
+
+func (app *Application) handleLogin(w http.ResponseWriter, r *http.Request) {
+	var req loginRequest
+	if err := readJSON(w, r, &req); err != nil {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_json", err.Error())
+		return
+	}
+
+	service := auth.NewService(app.Store, app.Tokens)
+	result, err := service.Login(r.Context(), auth.LoginRequest{
+		TenantID: req.TenantID,
+		Email:    strings.ToLower(strings.TrimSpace(req.Email)),
+		Password: req.Password,
+	})
+	if err != nil {
+		app.writeError(w, r, http.StatusUnauthorized, "invalid_credentials", "invalid credentials")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"access_token": result.Token,
+		"token_type":   "Bearer",
+		"expires_at":   result.Identity.ExpiresAt,
+		"identity":     result.Identity,
+	})
+}
+
+func (app *Application) handleListOrders(w http.ResponseWriter, r *http.Request) {
+	identity, err := auth.RequireIdentity(r.Context())
+	if err != nil {
+		app.writeError(w, r, http.StatusInternalServerError, "missing_identity", "missing authenticated identity")
+		return
+	}
+
+	orders, err := app.Store.ListOrdersByTenant(r.Context(), identity.TenantID)
+	if err != nil {
+		app.writeError(w, r, http.StatusInternalServerError, "orders_list_failed", "failed to list orders")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": orders})
+}
+
+func (app *Application) handleCreateOrder(w http.ResponseWriter, r *http.Request) {
+	identity, err := auth.RequireIdentity(r.Context())
+	if err != nil {
+		app.writeError(w, r, http.StatusInternalServerError, "missing_identity", "missing authenticated identity")
+		return
+	}
+
+	var req createOrderRequest
+	if err := readJSON(w, r, &req); err != nil {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_json", err.Error())
+		return
+	}
+
+	currency := strings.ToUpper(strings.TrimSpace(req.Currency))
+	if req.TotalCents <= 0 || currency == "" || strings.TrimSpace(req.IdempotencyKey) == "" {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_order", "total_cents, currency, and idempotency_key are required")
+		return
+	}
+
+	order := models.Order{
+		TenantID:       identity.TenantID,
+		UserID:         identity.UserID,
+		Status:         models.OrderStatusPending,
+		TotalCents:     req.TotalCents,
+		Currency:       currency,
+		IdempotencyKey: strings.TrimSpace(req.IdempotencyKey),
+	}
+	if err := app.Store.CreateOrder(r.Context(), &order); err != nil {
+		app.writeError(w, r, http.StatusInternalServerError, "order_create_failed", "failed to create order")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, order)
+}
+
+func (app *Application) handleCreatePayment(w http.ResponseWriter, r *http.Request) {
+	identity, err := auth.RequireIdentity(r.Context())
+	if err != nil {
+		app.writeError(w, r, http.StatusInternalServerError, "missing_identity", "missing authenticated identity")
+		return
+	}
+
+	var req createPaymentRequest
+	if err := readJSON(w, r, &req); err != nil {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_json", err.Error())
+		return
+	}
+
+	status := req.Status
+	if status == "" {
+		status = models.PaymentStatusPending
+	}
+	if !isAllowedPaymentStatus(status) || req.OrderID <= 0 || req.AmountCents <= 0 || strings.TrimSpace(req.ProviderReference) == "" {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_payment", "order_id, amount_cents, provider_reference, and valid status are required")
+		return
+	}
+
+	payment := models.Payment{
+		TenantID:          identity.TenantID,
+		OrderID:           req.OrderID,
+		Status:            status,
+		ProviderReference: strings.TrimSpace(req.ProviderReference),
+		AmountCents:       req.AmountCents,
+		FailureReason:     strings.TrimSpace(req.FailureReason),
+	}
+	if err := app.Store.CreatePayment(r.Context(), &payment); err != nil {
+		app.writeError(w, r, http.StatusInternalServerError, "payment_create_failed", "failed to create payment")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, payment)
+}
+
+func (app *Application) handleListPaymentsByOrder(w http.ResponseWriter, r *http.Request) {
+	identity, err := auth.RequireIdentity(r.Context())
+	if err != nil {
+		app.writeError(w, r, http.StatusInternalServerError, "missing_identity", "missing authenticated identity")
+		return
+	}
+
+	orderID, err := strconv.ParseInt(r.PathValue("orderID"), 10, 64)
+	if err != nil || orderID <= 0 {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_order_id", "order id must be a positive integer")
+		return
+	}
+
+	payments, err := app.Store.ListPaymentsByOrder(r.Context(), identity.TenantID, orderID)
+	if err != nil {
+		app.writeError(w, r, http.StatusInternalServerError, "payments_list_failed", "failed to list payments")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": payments})
+}
+
+func readJSON(w http.ResponseWriter, r *http.Request, dst any) error {
+	r.Body = http.MaxBytesReader(w, r.Body, maxJSONBodySize)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(dst); err != nil {
+		return fmt.Errorf("decode json body: %w", err)
+	}
+
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("body must contain a single json object")
+	}
+
+	return nil
+}
+
+func isAllowedUserRole(role models.UserRole) bool {
+	switch role {
+	case models.UserRoleAdmin, models.UserRoleMember, models.UserRoleBilling:
+		return true
+	default:
+		return false
+	}
+}
+
+func isAllowedPaymentStatus(status models.PaymentStatus) bool {
+	switch status {
+	case models.PaymentStatusPending, models.PaymentStatusAuthorized, models.PaymentStatusSettled, models.PaymentStatusFailed, models.PaymentStatusRefunded:
+		return true
+	default:
+		return false
+	}
+}
+
+func (app *Application) writeError(w http.ResponseWriter, _ *http.Request, status int, code, message string) {
+	writeJSON(w, status, map[string]any{
+		"error": map[string]string{
+			"code":    code,
+			"message": message,
+		},
+	})
+}

--- a/11-flagship/01-opslane/internal/handlers/api.go
+++ b/11-flagship/01-opslane/internal/handlers/api.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
@@ -239,6 +240,10 @@ func (app *Application) handleCreatePayment(w http.ResponseWriter, r *http.Reque
 		FailureReason:     strings.TrimSpace(req.FailureReason),
 	}
 	if err := app.Store.CreatePayment(r.Context(), &payment); err != nil {
+		if errors.Is(err, db.ErrInvalidReference) {
+			app.writeError(w, r, http.StatusNotFound, "order_not_found", "order does not exist for this tenant")
+			return
+		}
 		app.writeError(w, r, http.StatusInternalServerError, "payment_create_failed", "failed to create payment")
 		return
 	}

--- a/11-flagship/01-opslane/internal/handlers/api.go
+++ b/11-flagship/01-opslane/internal/handlers/api.go
@@ -145,6 +145,18 @@ func (app *Application) handleLogin(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (app *Application) requireAPIAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity, err := auth.IdentityFromRequest(app.Tokens, r)
+		if err != nil {
+			app.writeError(w, r, http.StatusUnauthorized, "unauthorized", "missing or invalid bearer token")
+			return
+		}
+
+		next.ServeHTTP(w, r.WithContext(auth.WithIdentity(r.Context(), identity)))
+	})
+}
+
 func (app *Application) handleListOrders(w http.ResponseWriter, r *http.Request) {
 	identity, err := auth.RequireIdentity(r.Context())
 	if err != nil {

--- a/11-flagship/01-opslane/internal/handlers/api.go
+++ b/11-flagship/01-opslane/internal/handlers/api.go
@@ -113,6 +113,14 @@ func (app *Application) handleCreateUser(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := app.Store.CreateUser(r.Context(), &user); err != nil {
+		if errors.Is(err, db.ErrInvalidReference) {
+			app.writeError(w, r, http.StatusNotFound, "tenant_not_found", "tenant does not exist")
+			return
+		}
+		if errors.Is(err, db.ErrDuplicateValue) {
+			app.writeError(w, r, http.StatusConflict, "duplicate_email", "email already exists for this tenant")
+			return
+		}
 		app.writeError(w, r, http.StatusInternalServerError, "user_create_failed", "failed to create user")
 		return
 	}

--- a/11-flagship/01-opslane/internal/handlers/api.go
+++ b/11-flagship/01-opslane/internal/handlers/api.go
@@ -98,6 +98,13 @@ func (app *Application) handleCreateUser(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	displayName := strings.TrimSpace(req.DisplayName)
+	if req.TenantID <= 0 || email == "" || displayName == "" {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_user", "tenant_id, email, and display_name are required")
+		return
+	}
+
 	passwordHash, err := auth.HashPassword(req.Password)
 	if err != nil {
 		app.writeError(w, r, http.StatusBadRequest, "weak_password", "password does not meet policy")
@@ -106,14 +113,10 @@ func (app *Application) handleCreateUser(w http.ResponseWriter, r *http.Request)
 
 	user := models.User{
 		TenantID:     req.TenantID,
-		Email:        strings.ToLower(strings.TrimSpace(req.Email)),
-		DisplayName:  strings.TrimSpace(req.DisplayName),
+		Email:        email,
+		DisplayName:  displayName,
 		PasswordHash: passwordHash,
 		Role:         role,
-	}
-	if user.TenantID <= 0 || user.Email == "" || user.DisplayName == "" {
-		app.writeError(w, r, http.StatusBadRequest, "invalid_user", "tenant_id, email, and display_name are required")
-		return
 	}
 
 	if err := app.Store.CreateUser(r.Context(), &user); err != nil {

--- a/11-flagship/01-opslane/internal/handlers/handlers.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers.go
@@ -56,13 +56,22 @@ func (app *Application) Routes() http.Handler {
 	mux.Handle("POST /api/v1/payments", protected(http.HandlerFunc(app.handleCreatePayment)))
 	mux.Handle("GET /api/v1/orders/{orderID}/payments", protected(http.HandlerFunc(app.handleListPaymentsByOrder)))
 
+	baseHandler := middleware.LogRequest(app.Logger)(
+		middleware.RecoverPanic(app.Logger)(mux),
+	)
+	rateLimitedHandler := middleware.RateLimit(apiRateLimitMaxRequests, apiRateLimitWindow, app.TrustedProxyCIDRs)(baseHandler)
+	httpSurface := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			baseHandler.ServeHTTP(w, r)
+			return
+		}
+
+		rateLimitedHandler.ServeHTTP(w, r)
+	})
+
 	handler := middleware.SecureHeaders(
 		middleware.CORS(
-			middleware.RateLimit(apiRateLimitMaxRequests, apiRateLimitWindow, app.TrustedProxyCIDRs)(
-				middleware.LogRequest(app.Logger)(
-					middleware.RecoverPanic(app.Logger)(mux),
-				),
-			),
+			httpSurface,
 		),
 	)
 

--- a/11-flagship/01-opslane/internal/handlers/handlers.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"net/netip"
 	"time"
 
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
@@ -20,11 +21,12 @@ const apiRateLimitWindow = time.Minute
 const apiRateLimitMaxRequests = 120
 
 type Application struct {
-	Logger      *slog.Logger
-	Store       Store
-	Tokens      *auth.TokenManager
-	ServiceName string
-	Environment string
+	Logger            *slog.Logger
+	Store             Store
+	Tokens            *auth.TokenManager
+	ServiceName       string
+	Environment       string
+	TrustedProxyCIDRs []netip.Prefix
 }
 
 type Store interface {
@@ -56,7 +58,7 @@ func (app *Application) Routes() http.Handler {
 
 	handler := middleware.SecureHeaders(
 		middleware.CORS(
-			middleware.RateLimit(apiRateLimitMaxRequests, apiRateLimitWindow)(
+			middleware.RateLimit(apiRateLimitMaxRequests, apiRateLimitWindow, app.TrustedProxyCIDRs)(
 				middleware.LogRequest(app.Logger)(
 					middleware.RecoverPanic(app.Logger)(mux),
 				),

--- a/11-flagship/01-opslane/internal/handlers/handlers.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers.go
@@ -47,7 +47,7 @@ func (app *Application) Routes() http.Handler {
 	mux.HandleFunc("POST /api/v1/users", app.handleCreateUser)
 	mux.HandleFunc("POST /api/v1/auth/login", app.handleLogin)
 
-	protected := auth.RequireAuth(app.Tokens)
+	protected := app.requireAPIAuth
 	mux.Handle("GET /api/v1/me", protected(http.HandlerFunc(app.handleMe)))
 	mux.Handle("GET /api/v1/orders", protected(http.HandlerFunc(app.handleListOrders)))
 	mux.Handle("POST /api/v1/orders", protected(http.HandlerFunc(app.handleCreateOrder)))

--- a/11-flagship/01-opslane/internal/handlers/handlers.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers.go
@@ -11,18 +11,31 @@ import (
 	"time"
 
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/middleware"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 const healthDatabaseTimeout = 2 * time.Second
+const apiRateLimitWindow = time.Minute
+const apiRateLimitMaxRequests = 120
 
 type Application struct {
 	Logger      *slog.Logger
-	Store       *db.Store
+	Store       Store
 	Tokens      *auth.TokenManager
 	ServiceName string
 	Environment string
+}
+
+type Store interface {
+	Ping(ctx context.Context) error
+	CreateTenant(ctx context.Context, tenant *models.Tenant) error
+	CreateUser(ctx context.Context, user *models.User) error
+	GetUserByEmail(ctx context.Context, tenantID int64, email string) (models.User, error)
+	CreateOrder(ctx context.Context, order *models.Order) error
+	ListOrdersByTenant(ctx context.Context, tenantID int64) ([]models.Order, error)
+	CreatePayment(ctx context.Context, payment *models.Payment) error
+	ListPaymentsByOrder(ctx context.Context, tenantID, orderID int64) ([]models.Payment, error)
 }
 
 func (app *Application) Routes() http.Handler {
@@ -30,10 +43,24 @@ func (app *Application) Routes() http.Handler {
 	mux.HandleFunc("GET /", app.handleIndex)
 	mux.HandleFunc("GET /health", app.handleHealth)
 	mux.Handle("GET /me", auth.RequireAuth(app.Tokens)(http.HandlerFunc(app.handleMe)))
+	mux.HandleFunc("POST /api/v1/tenants", app.handleCreateTenant)
+	mux.HandleFunc("POST /api/v1/users", app.handleCreateUser)
+	mux.HandleFunc("POST /api/v1/auth/login", app.handleLogin)
+
+	protected := auth.RequireAuth(app.Tokens)
+	mux.Handle("GET /api/v1/me", protected(http.HandlerFunc(app.handleMe)))
+	mux.Handle("GET /api/v1/orders", protected(http.HandlerFunc(app.handleListOrders)))
+	mux.Handle("POST /api/v1/orders", protected(http.HandlerFunc(app.handleCreateOrder)))
+	mux.Handle("POST /api/v1/payments", protected(http.HandlerFunc(app.handleCreatePayment)))
+	mux.Handle("GET /api/v1/orders/{orderID}/payments", protected(http.HandlerFunc(app.handleListPaymentsByOrder)))
 
 	handler := middleware.SecureHeaders(
-		middleware.LogRequest(app.Logger)(
-			middleware.RecoverPanic(app.Logger)(mux),
+		middleware.CORS(
+			middleware.RateLimit(apiRateLimitMaxRequests, apiRateLimitWindow)(
+				middleware.LogRequest(app.Logger)(
+					middleware.RecoverPanic(app.Logger)(mux),
+				),
+			),
 		),
 	)
 

--- a/11-flagship/01-opslane/internal/handlers/handlers_test.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
@@ -256,6 +257,41 @@ func TestCreatePaymentUsesAuthenticatedTenant(t *testing.T) {
 	}
 }
 
+func TestCreatePaymentReturnsNotFoundForInvalidOrder(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{createPaymentErr: db.ErrInvalidReference}
+	app := newTestApplication(t, store)
+	token := issueHandlerTestToken(t, app.Tokens, auth.Identity{
+		UserID:   42,
+		TenantID: 7,
+		Email:    "admin@example.com",
+		Role:     models.UserRoleAdmin,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/payments", bytes.NewBufferString(`{
+		"order_id": 404,
+		"provider_reference": "pay_missing",
+		"amount_cents": 2500
+	}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusNotFound)
+	}
+
+	var payload map[string]map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if payload["error"]["code"] != "order_not_found" {
+		t.Fatalf("error code = %q, want order_not_found", payload["error"]["code"])
+	}
+}
+
 func TestListPaymentsByOrderUsesAuthenticatedTenant(t *testing.T) {
 	t.Parallel()
 
@@ -333,6 +369,7 @@ type fakeStore struct {
 	userByEmail          models.User
 	createdOrder         models.Order
 	createdPayment       models.Payment
+	createPaymentErr     error
 	listPaymentsTenantID int64
 	listPaymentsOrderID  int64
 }
@@ -372,6 +409,10 @@ func (s *fakeStore) ListOrdersByTenant(context.Context, int64) ([]models.Order, 
 }
 
 func (s *fakeStore) CreatePayment(_ context.Context, payment *models.Payment) error {
+	if s.createPaymentErr != nil {
+		return s.createPaymentErr
+	}
+
 	payment.ID = 501
 	payment.CreatedAt = time.Now().UTC()
 	payment.UpdatedAt = payment.CreatedAt

--- a/11-flagship/01-opslane/internal/handlers/handlers_test.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers_test.go
@@ -201,6 +201,41 @@ func TestCreateOrderUsesAuthenticatedTenantAndUser(t *testing.T) {
 	}
 }
 
+func TestCreateOrderReturnsConflictForDuplicateIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{createOrderErr: db.ErrDuplicateValue}
+	app := newTestApplication(t, store)
+	token := issueHandlerTestToken(t, app.Tokens, auth.Identity{
+		UserID:   42,
+		TenantID: 7,
+		Email:    "admin@example.com",
+		Role:     models.UserRoleAdmin,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orders", bytes.NewBufferString(`{
+		"total_cents": 2500,
+		"currency": "usd",
+		"idempotency_key": "checkout-123"
+	}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusConflict)
+	}
+
+	var payload map[string]map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if payload["error"]["code"] != "duplicate_idempotency_key" {
+		t.Fatalf("error code = %q, want duplicate_idempotency_key", payload["error"]["code"])
+	}
+}
+
 func TestListOrdersRejectsAnonymousRequest(t *testing.T) {
 	t.Parallel()
 
@@ -368,6 +403,7 @@ type fakeStore struct {
 	createdUser          models.User
 	userByEmail          models.User
 	createdOrder         models.Order
+	createOrderErr       error
 	createdPayment       models.Payment
 	createPaymentErr     error
 	listPaymentsTenantID int64
@@ -397,6 +433,10 @@ func (s *fakeStore) GetUserByEmail(context.Context, int64, string) (models.User,
 }
 
 func (s *fakeStore) CreateOrder(_ context.Context, order *models.Order) error {
+	if s.createOrderErr != nil {
+		return s.createOrderErr
+	}
+
 	order.ID = 101
 	order.CreatedAt = time.Now().UTC()
 	order.UpdatedAt = order.CreatedAt

--- a/11-flagship/01-opslane/internal/handlers/handlers_test.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers_test.go
@@ -96,6 +96,33 @@ func TestCreateTenantReturnsCreatedTenant(t *testing.T) {
 	}
 }
 
+func TestCreateTenantReturnsConflictForDuplicateSlug(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{createTenantErr: db.ErrDuplicateValue}
+	app := newTestApplication(t, store)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants", bytes.NewBufferString(`{
+		"name": "Acme Inc",
+		"slug": "acme"
+	}`))
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusConflict)
+	}
+
+	var payload map[string]map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if payload["error"]["code"] != "duplicate_slug" {
+		t.Fatalf("error code = %q, want duplicate_slug", payload["error"]["code"])
+	}
+}
+
 func TestCreateUserHashesPasswordBeforePersisting(t *testing.T) {
 	t.Parallel()
 
@@ -387,6 +414,41 @@ func TestCreatePaymentReturnsNotFoundForInvalidOrder(t *testing.T) {
 	}
 }
 
+func TestCreatePaymentReturnsConflictForDuplicateProviderReference(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{createPaymentErr: db.ErrDuplicateValue}
+	app := newTestApplication(t, store)
+	token := issueHandlerTestToken(t, app.Tokens, auth.Identity{
+		UserID:   42,
+		TenantID: 7,
+		Email:    "admin@example.com",
+		Role:     models.UserRoleAdmin,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/payments", bytes.NewBufferString(`{
+		"order_id": 101,
+		"provider_reference": "pay_123",
+		"amount_cents": 2500
+	}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusConflict)
+	}
+
+	var payload map[string]map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if payload["error"]["code"] != "duplicate_provider_reference" {
+		t.Fatalf("error code = %q, want duplicate_provider_reference", payload["error"]["code"])
+	}
+}
+
 func TestListPaymentsByOrderUsesAuthenticatedTenant(t *testing.T) {
 	t.Parallel()
 
@@ -460,6 +522,7 @@ func issueHandlerTestToken(t *testing.T, tokens *auth.TokenManager, identity aut
 
 type fakeStore struct {
 	createdTenant        models.Tenant
+	createTenantErr      error
 	createdUser          models.User
 	createUserErr        error
 	userByEmail          models.User
@@ -476,6 +539,10 @@ func (s *fakeStore) Ping(context.Context) error {
 }
 
 func (s *fakeStore) CreateTenant(_ context.Context, tenant *models.Tenant) error {
+	if s.createTenantErr != nil {
+		return s.createTenantErr
+	}
+
 	tenant.ID = 7
 	tenant.CreatedAt = time.Now().UTC()
 	s.createdTenant = *tenant

--- a/11-flagship/01-opslane/internal/handlers/handlers_test.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers_test.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -71,6 +73,213 @@ func TestProtectedMeRouteRejectsAnonymousRequest(t *testing.T) {
 	}
 }
 
+func TestCreateTenantReturnsCreatedTenant(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{}
+	app := newTestApplication(t, store)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants", bytes.NewBufferString(`{
+		"name": "Acme Inc",
+		"slug": "Acme"
+	}`))
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusCreated)
+	}
+
+	if store.createdTenant.Slug != "acme" {
+		t.Fatalf("tenant slug = %q, want acme", store.createdTenant.Slug)
+	}
+}
+
+func TestCreateUserHashesPasswordBeforePersisting(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{}
+	app := newTestApplication(t, store)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewBufferString(`{
+		"tenant_id": 7,
+		"email": "Admin@Example.com",
+		"display_name": "Admin User",
+		"password": "CorrectHorse7Battery",
+		"role": "admin"
+	}`))
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusCreated)
+	}
+
+	if store.createdUser.Email != "admin@example.com" {
+		t.Fatalf("email = %q, want normalized email", store.createdUser.Email)
+	}
+
+	if store.createdUser.PasswordHash == "CorrectHorse7Battery" {
+		t.Fatal("password must be hashed before persistence")
+	}
+}
+
+func TestLoginReturnsAccessToken(t *testing.T) {
+	t.Parallel()
+
+	passwordHash, err := auth.HashPassword("CorrectHorse7Battery")
+	if err != nil {
+		t.Fatalf("HashPassword returned error: %v", err)
+	}
+
+	store := &fakeStore{
+		userByEmail: models.User{
+			ID:           42,
+			TenantID:     7,
+			Email:        "admin@example.com",
+			DisplayName:  "Admin User",
+			PasswordHash: passwordHash,
+			Role:         models.UserRoleAdmin,
+		},
+	}
+	app := newTestApplication(t, store)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", bytes.NewBufferString(`{
+		"tenant_id": 7,
+		"email": "admin@example.com",
+		"password": "CorrectHorse7Battery"
+	}`))
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
+	}
+
+	var payload map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if payload["access_token"] == "" {
+		t.Fatal("access_token should not be empty")
+	}
+}
+
+func TestCreateOrderUsesAuthenticatedTenantAndUser(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{}
+	app := newTestApplication(t, store)
+	token := issueHandlerTestToken(t, app.Tokens, auth.Identity{
+		UserID:   42,
+		TenantID: 7,
+		Email:    "admin@example.com",
+		Role:     models.UserRoleAdmin,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/orders", bytes.NewBufferString(`{
+		"total_cents": 2500,
+		"currency": "usd",
+		"idempotency_key": "checkout-123"
+	}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusCreated)
+	}
+
+	if store.createdOrder.TenantID != 7 || store.createdOrder.UserID != 42 {
+		t.Fatalf("order identity = tenant %d user %d, want tenant 7 user 42", store.createdOrder.TenantID, store.createdOrder.UserID)
+	}
+
+	if store.createdOrder.Currency != "USD" {
+		t.Fatalf("currency = %q, want USD", store.createdOrder.Currency)
+	}
+}
+
+func TestListOrdersRejectsAnonymousRequest(t *testing.T) {
+	t.Parallel()
+
+	app := newTestApplication(t, &fakeStore{})
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/api/v1/orders", nil))
+
+	if res.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestCreatePaymentUsesAuthenticatedTenant(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{}
+	app := newTestApplication(t, store)
+	token := issueHandlerTestToken(t, app.Tokens, auth.Identity{
+		UserID:   42,
+		TenantID: 7,
+		Email:    "admin@example.com",
+		Role:     models.UserRoleAdmin,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/payments", bytes.NewBufferString(`{
+		"order_id": 101,
+		"provider_reference": "pay_123",
+		"amount_cents": 2500
+	}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusCreated)
+	}
+
+	if store.createdPayment.TenantID != 7 {
+		t.Fatalf("payment tenant = %d, want 7", store.createdPayment.TenantID)
+	}
+
+	if store.createdPayment.Status != models.PaymentStatusPending {
+		t.Fatalf("payment status = %q, want pending", store.createdPayment.Status)
+	}
+}
+
+func TestListPaymentsByOrderUsesAuthenticatedTenant(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{
+		createdPayment: models.Payment{
+			ID:       501,
+			TenantID: 7,
+			OrderID:  101,
+			Status:   models.PaymentStatusPending,
+		},
+	}
+	app := newTestApplication(t, store)
+	token := issueHandlerTestToken(t, app.Tokens, auth.Identity{
+		UserID:   42,
+		TenantID: 7,
+		Email:    "admin@example.com",
+		Role:     models.UserRoleAdmin,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/orders/101/payments", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
+	}
+
+	if store.listPaymentsTenantID != 7 || store.listPaymentsOrderID != 101 {
+		t.Fatalf("list payments scope = tenant %d order %d, want tenant 7 order 101", store.listPaymentsTenantID, store.listPaymentsOrderID)
+	}
+}
+
 func newHandlerTestTokenManager(t *testing.T) *auth.TokenManager {
 	t.Helper()
 
@@ -84,4 +293,85 @@ func newHandlerTestTokenManager(t *testing.T) *auth.TokenManager {
 	}
 
 	return tokens
+}
+
+func newTestApplication(t *testing.T, store Store) *Application {
+	t.Helper()
+
+	return &Application{
+		Logger:      slog.Default(),
+		Store:       store,
+		Tokens:      newHandlerTestTokenManager(t),
+		ServiceName: "opslane",
+		Environment: "test",
+	}
+}
+
+func issueHandlerTestToken(t *testing.T, tokens *auth.TokenManager, identity auth.Identity) string {
+	t.Helper()
+
+	token, err := tokens.Issue(identity)
+	if err != nil {
+		t.Fatalf("Issue returned error: %v", err)
+	}
+
+	return token
+}
+
+type fakeStore struct {
+	createdTenant        models.Tenant
+	createdUser          models.User
+	userByEmail          models.User
+	createdOrder         models.Order
+	createdPayment       models.Payment
+	listPaymentsTenantID int64
+	listPaymentsOrderID  int64
+}
+
+func (s *fakeStore) Ping(context.Context) error {
+	return nil
+}
+
+func (s *fakeStore) CreateTenant(_ context.Context, tenant *models.Tenant) error {
+	tenant.ID = 7
+	tenant.CreatedAt = time.Now().UTC()
+	s.createdTenant = *tenant
+	return nil
+}
+
+func (s *fakeStore) CreateUser(_ context.Context, user *models.User) error {
+	user.ID = 42
+	user.CreatedAt = time.Now().UTC()
+	s.createdUser = *user
+	return nil
+}
+
+func (s *fakeStore) GetUserByEmail(context.Context, int64, string) (models.User, error) {
+	return s.userByEmail, nil
+}
+
+func (s *fakeStore) CreateOrder(_ context.Context, order *models.Order) error {
+	order.ID = 101
+	order.CreatedAt = time.Now().UTC()
+	order.UpdatedAt = order.CreatedAt
+	s.createdOrder = *order
+	return nil
+}
+
+func (s *fakeStore) ListOrdersByTenant(context.Context, int64) ([]models.Order, error) {
+	return []models.Order{s.createdOrder}, nil
+}
+
+func (s *fakeStore) CreatePayment(_ context.Context, payment *models.Payment) error {
+	payment.ID = 501
+	payment.CreatedAt = time.Now().UTC()
+	payment.UpdatedAt = payment.CreatedAt
+	s.createdPayment = *payment
+	return nil
+}
+
+func (s *fakeStore) ListPaymentsByOrder(_ context.Context, tenantID, orderID int64) ([]models.Payment, error) {
+	s.listPaymentsTenantID = tenantID
+	s.listPaymentsOrderID = orderID
+	return []models.Payment{s.createdPayment}, nil
 }

--- a/11-flagship/01-opslane/internal/handlers/handlers_test.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers_test.go
@@ -212,6 +212,36 @@ func TestCreateUserReturnsConflictForDuplicateEmail(t *testing.T) {
 	}
 }
 
+func TestCreateUserValidatesRequiredFieldsBeforePasswordHashing(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{}
+	app := newTestApplication(t, store)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewBufferString(`{
+		"tenant_id": 0,
+		"email": "",
+		"display_name": "",
+		"password": "short",
+		"role": "admin"
+	}`))
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusBadRequest)
+	}
+
+	var payload map[string]map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if payload["error"]["code"] != "invalid_user" {
+		t.Fatalf("error code = %q, want invalid_user", payload["error"]["code"])
+	}
+}
+
 func TestLoginReturnsAccessToken(t *testing.T) {
 	t.Parallel()
 
@@ -342,6 +372,23 @@ func TestListOrdersRejectsAnonymousRequest(t *testing.T) {
 
 	if payload["error"]["code"] != "unauthorized" {
 		t.Fatalf("error code = %q, want unauthorized", payload["error"]["code"])
+	}
+}
+
+func TestHealthRouteBypassesRateLimit(t *testing.T) {
+	t.Parallel()
+
+	app := newTestApplication(t, &fakeStore{})
+
+	for i := 0; i < apiRateLimitMaxRequests+5; i++ {
+		res := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+
+		app.Routes().ServeHTTP(res, req)
+
+		if res.Code != http.StatusOK {
+			t.Fatalf("iteration %d status = %d, want %d", i, res.Code, http.StatusOK)
+		}
 	}
 }
 

--- a/11-flagship/01-opslane/internal/handlers/handlers_test.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers_test.go
@@ -125,6 +125,66 @@ func TestCreateUserHashesPasswordBeforePersisting(t *testing.T) {
 	}
 }
 
+func TestCreateUserReturnsNotFoundForUnknownTenant(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{createUserErr: db.ErrInvalidReference}
+	app := newTestApplication(t, store)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewBufferString(`{
+		"tenant_id": 999,
+		"email": "admin@example.com",
+		"display_name": "Admin User",
+		"password": "CorrectHorse7Battery",
+		"role": "admin"
+	}`))
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusNotFound)
+	}
+
+	var payload map[string]map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if payload["error"]["code"] != "tenant_not_found" {
+		t.Fatalf("error code = %q, want tenant_not_found", payload["error"]["code"])
+	}
+}
+
+func TestCreateUserReturnsConflictForDuplicateEmail(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeStore{createUserErr: db.ErrDuplicateValue}
+	app := newTestApplication(t, store)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewBufferString(`{
+		"tenant_id": 7,
+		"email": "admin@example.com",
+		"display_name": "Admin User",
+		"password": "CorrectHorse7Battery",
+		"role": "admin"
+	}`))
+	res := httptest.NewRecorder()
+
+	app.Routes().ServeHTTP(res, req)
+
+	if res.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusConflict)
+	}
+
+	var payload map[string]map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if payload["error"]["code"] != "duplicate_email" {
+		t.Fatalf("error code = %q, want duplicate_email", payload["error"]["code"])
+	}
+}
+
 func TestLoginReturnsAccessToken(t *testing.T) {
 	t.Parallel()
 
@@ -401,6 +461,7 @@ func issueHandlerTestToken(t *testing.T, tokens *auth.TokenManager, identity aut
 type fakeStore struct {
 	createdTenant        models.Tenant
 	createdUser          models.User
+	createUserErr        error
 	userByEmail          models.User
 	createdOrder         models.Order
 	createOrderErr       error
@@ -422,6 +483,10 @@ func (s *fakeStore) CreateTenant(_ context.Context, tenant *models.Tenant) error
 }
 
 func (s *fakeStore) CreateUser(_ context.Context, user *models.User) error {
+	if s.createUserErr != nil {
+		return s.createUserErr
+	}
+
 	user.ID = 42
 	user.CreatedAt = time.Now().UTC()
 	s.createdUser = *user

--- a/11-flagship/01-opslane/internal/handlers/handlers_test.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers_test.go
@@ -211,6 +211,15 @@ func TestListOrdersRejectsAnonymousRequest(t *testing.T) {
 	if res.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want %d", res.Code, http.StatusUnauthorized)
 	}
+
+	var payload map[string]map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if payload["error"]["code"] != "unauthorized" {
+		t.Fatalf("error code = %q, want unauthorized", payload["error"]["code"])
+	}
 }
 
 func TestCreatePaymentUsesAuthenticatedTenant(t *testing.T) {

--- a/11-flagship/01-opslane/internal/middleware/middleware.go
+++ b/11-flagship/01-opslane/internal/middleware/middleware.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 )
@@ -152,6 +153,19 @@ func SecureHeaders(next http.Handler) http.Handler {
 }
 
 func clientAddress(r *http.Request) string {
+	if forwardedFor := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); forwardedFor != "" {
+		firstHop := strings.TrimSpace(strings.Split(forwardedFor, ",")[0])
+		if ip := net.ParseIP(firstHop); ip != nil {
+			return ip.String()
+		}
+	}
+
+	if realIP := strings.TrimSpace(r.Header.Get("X-Real-Ip")); realIP != "" {
+		if ip := net.ParseIP(realIP); ip != nil {
+			return ip.String()
+		}
+	}
+
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err == nil {
 		return host

--- a/11-flagship/01-opslane/internal/middleware/middleware.go
+++ b/11-flagship/01-opslane/internal/middleware/middleware.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/netip"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -88,7 +89,7 @@ type clientWindow struct {
 }
 
 // RateLimit bounds how many requests one client IP can make inside a fixed window.
-func RateLimit(maxRequests int, window time.Duration) func(http.Handler) http.Handler {
+func RateLimit(maxRequests int, window time.Duration, trustedProxyCIDRs []netip.Prefix) func(http.Handler) http.Handler {
 	var mu sync.Mutex
 	clients := make(map[string]clientWindow)
 	nextCleanup := time.Now().Add(window)
@@ -100,7 +101,7 @@ func RateLimit(maxRequests int, window time.Duration) func(http.Handler) http.Ha
 				return
 			}
 
-			clientIP := clientAddress(r)
+			clientIP := clientAddress(r, trustedProxyCIDRs)
 			now := time.Now()
 
 			mu.Lock()
@@ -152,24 +153,60 @@ func SecureHeaders(next http.Handler) http.Handler {
 	})
 }
 
-func clientAddress(r *http.Request) string {
+func clientAddress(r *http.Request, trustedProxyCIDRs []netip.Prefix) string {
+	peerIP := remotePeerIP(r.RemoteAddr)
+	if peerIP.IsValid() && isTrustedProxy(peerIP, trustedProxyCIDRs) {
+		if forwardedIP, ok := forwardedClientIP(r); ok {
+			return forwardedIP.String()
+		}
+	}
+
+	if peerIP.IsValid() {
+		return peerIP.String()
+	}
+
+	return r.RemoteAddr
+}
+
+func remotePeerIP(remoteAddr string) netip.Addr {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err == nil {
+		if ip, parseErr := netip.ParseAddr(host); parseErr == nil {
+			return ip.Unmap()
+		}
+	}
+
+	ip, err := netip.ParseAddr(remoteAddr)
+	if err != nil {
+		return netip.Addr{}
+	}
+
+	return ip.Unmap()
+}
+
+func forwardedClientIP(r *http.Request) (netip.Addr, bool) {
 	if forwardedFor := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); forwardedFor != "" {
 		firstHop := strings.TrimSpace(strings.Split(forwardedFor, ",")[0])
-		if ip := net.ParseIP(firstHop); ip != nil {
-			return ip.String()
+		if ip, err := netip.ParseAddr(firstHop); err == nil {
+			return ip.Unmap(), true
 		}
 	}
 
 	if realIP := strings.TrimSpace(r.Header.Get("X-Real-Ip")); realIP != "" {
-		if ip := net.ParseIP(realIP); ip != nil {
-			return ip.String()
+		if ip, err := netip.ParseAddr(realIP); err == nil {
+			return ip.Unmap(), true
 		}
 	}
 
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err == nil {
-		return host
+	return netip.Addr{}, false
+}
+
+func isTrustedProxy(ip netip.Addr, trustedProxyCIDRs []netip.Prefix) bool {
+	for _, prefix := range trustedProxyCIDRs {
+		if prefix.Contains(ip) {
+			return true
+		}
 	}
 
-	return r.RemoteAddr
+	return false
 }

--- a/11-flagship/01-opslane/internal/middleware/middleware.go
+++ b/11-flagship/01-opslane/internal/middleware/middleware.go
@@ -81,15 +81,16 @@ func CORS(next http.Handler) http.Handler {
 	})
 }
 
+type clientWindow struct {
+	count   int
+	resetAt time.Time
+}
+
 // RateLimit bounds how many requests one client IP can make inside a fixed window.
 func RateLimit(maxRequests int, window time.Duration) func(http.Handler) http.Handler {
-	type clientWindow struct {
-		count   int
-		resetAt time.Time
-	}
-
 	var mu sync.Mutex
 	clients := make(map[string]clientWindow)
+	nextCleanup := time.Now().Add(window)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -102,6 +103,11 @@ func RateLimit(maxRequests int, window time.Duration) func(http.Handler) http.Ha
 			now := time.Now()
 
 			mu.Lock()
+			if !now.Before(nextCleanup) {
+				pruneExpiredClientWindows(clients, now)
+				nextCleanup = now.Add(window)
+			}
+
 			state := clients[clientIP]
 			if state.resetAt.IsZero() || now.After(state.resetAt) {
 				state = clientWindow{resetAt: now.Add(window)}
@@ -120,6 +126,14 @@ func RateLimit(maxRequests int, window time.Duration) func(http.Handler) http.Ha
 
 			next.ServeHTTP(w, r)
 		})
+	}
+}
+
+func pruneExpiredClientWindows(clients map[string]clientWindow, now time.Time) {
+	for clientIP, state := range clients {
+		if !now.Before(state.resetAt) {
+			delete(clients, clientIP)
+		}
 	}
 }
 

--- a/11-flagship/01-opslane/internal/middleware/middleware.go
+++ b/11-flagship/01-opslane/internal/middleware/middleware.go
@@ -5,8 +5,10 @@ package middleware
 
 import (
 	"log/slog"
+	"net"
 	"net/http"
 	"runtime/debug"
+	"sync"
 	"time"
 )
 
@@ -63,6 +65,64 @@ func LogRequest(logger *slog.Logger) func(http.Handler) http.Handler {
 	}
 }
 
+// CORS allows browser-based clients to call the API during local development.
+func CORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// RateLimit bounds how many requests one client IP can make inside a fixed window.
+func RateLimit(maxRequests int, window time.Duration) func(http.Handler) http.Handler {
+	type clientWindow struct {
+		count   int
+		resetAt time.Time
+	}
+
+	var mu sync.Mutex
+	clients := make(map[string]clientWindow)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if maxRequests <= 0 || window <= 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			clientIP := clientAddress(r)
+			now := time.Now()
+
+			mu.Lock()
+			state := clients[clientIP]
+			if state.resetAt.IsZero() || now.After(state.resetAt) {
+				state = clientWindow{resetAt: now.Add(window)}
+			}
+			state.count++
+			clients[clientIP] = state
+			allowed := state.count <= maxRequests
+			mu.Unlock()
+
+			if !allowed {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(`{"error":{"code":"rate_limited","message":"rate limit exceeded"}}`))
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // SecureHeaders sets mandatory security directives for browsers.
 func SecureHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -75,4 +135,13 @@ func SecureHeaders(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+func clientAddress(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil {
+		return host
+	}
+
+	return r.RemoteAddr
 }

--- a/11-flagship/01-opslane/internal/middleware/middleware_test.go
+++ b/11-flagship/01-opslane/internal/middleware/middleware_test.go
@@ -55,3 +55,23 @@ func TestRateLimitRejectsRequestsOverLimit(t *testing.T) {
 		t.Fatalf("body = %q, want %q", second.Body.String(), wantBody)
 	}
 }
+
+func TestPruneExpiredClientWindows(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	clients := map[string]clientWindow{
+		"expired": {count: 1, resetAt: now.Add(-time.Second)},
+		"active":  {count: 1, resetAt: now.Add(time.Second)},
+	}
+
+	pruneExpiredClientWindows(clients, now)
+
+	if _, ok := clients["expired"]; ok {
+		t.Fatal("expired client window should be evicted")
+	}
+
+	if _, ok := clients["active"]; !ok {
+		t.Fatal("active client window should remain")
+	}
+}

--- a/11-flagship/01-opslane/internal/middleware/middleware_test.go
+++ b/11-flagship/01-opslane/internal/middleware/middleware_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"testing"
 	"time"
 )
@@ -30,7 +31,7 @@ func TestCORSHandlesPreflight(t *testing.T) {
 func TestRateLimitRejectsRequestsOverLimit(t *testing.T) {
 	t.Parallel()
 
-	handler := RateLimit(1, time.Minute)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := RateLimit(1, time.Minute, nil)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -59,7 +60,7 @@ func TestRateLimitRejectsRequestsOverLimit(t *testing.T) {
 func TestRateLimitUsesForwardedClientIP(t *testing.T) {
 	t.Parallel()
 
-	handler := RateLimit(1, time.Minute)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := RateLimit(1, time.Minute, []netip.Prefix{netip.MustParsePrefix("10.0.0.10/32")})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -81,6 +82,34 @@ func TestRateLimitUsesForwardedClientIP(t *testing.T) {
 
 	if second.Code != http.StatusOK {
 		t.Fatalf("second status = %d, want %d", second.Code, http.StatusOK)
+	}
+}
+
+func TestRateLimitIgnoresForwardedHeadersFromUntrustedPeer(t *testing.T) {
+	t.Parallel()
+
+	handler := RateLimit(1, time.Minute, []netip.Prefix{netip.MustParsePrefix("127.0.0.1/32")})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	firstReq := httptest.NewRequest(http.MethodGet, "/api/v1/orders", nil)
+	firstReq.RemoteAddr = "198.51.100.20:1234"
+	firstReq.Header.Set("X-Forwarded-For", "203.0.113.10")
+	first := httptest.NewRecorder()
+	handler.ServeHTTP(first, firstReq)
+
+	secondReq := httptest.NewRequest(http.MethodGet, "/api/v1/orders", nil)
+	secondReq.RemoteAddr = "198.51.100.20:5678"
+	secondReq.Header.Set("X-Forwarded-For", "203.0.113.11")
+	second := httptest.NewRecorder()
+	handler.ServeHTTP(second, secondReq)
+
+	if first.Code != http.StatusOK {
+		t.Fatalf("first status = %d, want %d", first.Code, http.StatusOK)
+	}
+
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("second status = %d, want %d", second.Code, http.StatusTooManyRequests)
 	}
 }
 

--- a/11-flagship/01-opslane/internal/middleware/middleware_test.go
+++ b/11-flagship/01-opslane/internal/middleware/middleware_test.go
@@ -1,0 +1,57 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCORSHandlesPreflight(t *testing.T) {
+	t.Parallel()
+
+	handler := CORS(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("next handler should not run for preflight")
+	}))
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/orders", nil)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusNoContent)
+	}
+
+	if res.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Fatal("missing CORS allow-origin header")
+	}
+}
+
+func TestRateLimitRejectsRequestsOverLimit(t *testing.T) {
+	t.Parallel()
+
+	handler := RateLimit(1, time.Minute)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	first := httptest.NewRecorder()
+	handler.ServeHTTP(first, httptest.NewRequest(http.MethodGet, "/api/v1/orders", nil))
+	if first.Code != http.StatusOK {
+		t.Fatalf("first status = %d, want %d", first.Code, http.StatusOK)
+	}
+
+	second := httptest.NewRecorder()
+	handler.ServeHTTP(second, httptest.NewRequest(http.MethodGet, "/api/v1/orders", nil))
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("second status = %d, want %d", second.Code, http.StatusTooManyRequests)
+	}
+
+	if second.Header().Get("Content-Type") != "application/json" {
+		t.Fatalf("content type = %q, want application/json", second.Header().Get("Content-Type"))
+	}
+
+	wantBody := `{"error":{"code":"rate_limited","message":"rate limit exceeded"}}`
+	if second.Body.String() != wantBody {
+		t.Fatalf("body = %q, want %q", second.Body.String(), wantBody)
+	}
+}

--- a/11-flagship/01-opslane/internal/middleware/middleware_test.go
+++ b/11-flagship/01-opslane/internal/middleware/middleware_test.go
@@ -56,6 +56,34 @@ func TestRateLimitRejectsRequestsOverLimit(t *testing.T) {
 	}
 }
 
+func TestRateLimitUsesForwardedClientIP(t *testing.T) {
+	t.Parallel()
+
+	handler := RateLimit(1, time.Minute)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	firstReq := httptest.NewRequest(http.MethodGet, "/api/v1/orders", nil)
+	firstReq.RemoteAddr = "10.0.0.10:1234"
+	firstReq.Header.Set("X-Forwarded-For", "203.0.113.10")
+	first := httptest.NewRecorder()
+	handler.ServeHTTP(first, firstReq)
+
+	secondReq := httptest.NewRequest(http.MethodGet, "/api/v1/orders", nil)
+	secondReq.RemoteAddr = "10.0.0.10:5678"
+	secondReq.Header.Set("X-Forwarded-For", "203.0.113.11")
+	second := httptest.NewRecorder()
+	handler.ServeHTTP(second, secondReq)
+
+	if first.Code != http.StatusOK {
+		t.Fatalf("first status = %d, want %d", first.Code, http.StatusOK)
+	}
+
+	if second.Code != http.StatusOK {
+		t.Fatalf("second status = %d, want %d", second.Code, http.StatusOK)
+	}
+}
+
 func TestPruneExpiredClientWindows(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Closes #382.

This PR adds the Opslane Module 4 HTTP API layer:

- Adds public JSON endpoints for tenant setup, user setup, and login.
- Adds protected tenant-scoped order and payment endpoints.
- Introduces bounded JSON request parsing, validation, and consistent JSON error responses.
- Adds CORS and simple fixed-window in-process rate limiting middleware.
- Updates the Opslane README with the Module 4 API surface and curl examples.

## Validation

- `go test ./11-flagship/01-opslane/...`
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go run ./scripts/validate_curriculum.go`
- `git diff --check`

Note: local Windows `go build` emitted a module stat-cache permission warning, but exited successfully.