### PR TITLE
[FEAT] scalable Stage 11 flagship progress system

### DIFF
--- a/10-production/06-code-generation/3-sqlc/main.go
+++ b/10-production/06-code-generation/3-sqlc/main.go
@@ -59,7 +59,7 @@ func main() {
     }`)
 
 	fmt.Println("\n---------------------------------------------------")
-	fmt.Println("NEXT UP: FG.1")
+	fmt.Println("NEXT UP: OPSL.1")
 	fmt.Println("   Current: CG.3 (sqlc workflow)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/11-flagship/01-opslane/MODULES.md
+++ b/11-flagship/01-opslane/MODULES.md
@@ -1,0 +1,244 @@
+# Opslane Module Progress Map
+
+This file is the learner-facing map for the Opslane flagship.
+
+Use it together with the checker:
+
+```bash
+go run ./11-flagship/01-opslane/scripts/progress.go
+```
+
+The checker is authoritative about what is complete in the current tree.
+This file explains what each module means, what proof looks like, and what comes next.
+
+## How To Use This Map
+
+1. Run the progress checker from the repository root.
+2. Open the matching module README in `11-flagship/01-opslane/modules/`.
+3. Finish the proof surface for that module before moving on.
+4. Re-run the checker to confirm the next module unlocked.
+
+## Required Path
+
+| ID | Module | Current repository state |
+| --- | --- | --- |
+| `OPSL.1` | Foundation and Configuration | complete |
+| `OPSL.2` | Database and Models | complete |
+| `OPSL.3` | Authentication and Tenant Isolation | complete |
+| `OPSL.4` | HTTP API Layer | complete |
+| `OPSL.5` | Order Processing | next |
+| `OPSL.6` | Payment Pipeline | locked |
+| `OPSL.7` | Event Bus and Worker Pools | locked |
+| `OPSL.8` | Caching Layer | locked |
+| `OPSL.9` | Observability | locked |
+| `OPSL.10` | Graceful Shutdown and Deployment | locked |
+
+## OPSL.1 Foundation and Configuration
+
+What you build: the runnable server shell and validated startup configuration.
+
+Proof surface:
+
+```bash
+go test ./11-flagship/01-opslane/internal/config/...
+go run ./11-flagship/01-opslane/cmd/server
+```
+
+Required files:
+
+- `cmd/server/main.go`
+- `internal/config/config.go`
+- `internal/config/environment.go`
+- `.env.example`
+- `Dockerfile`
+- `docker-compose.yml`
+
+Module spec: [modules/01-foundation/README.md](./modules/01-foundation/README.md)
+
+## OPSL.2 Database and Models
+
+What you build: the multi-tenant PostgreSQL schema, models, and repository seams.
+
+Proof surface:
+
+```bash
+go test ./11-flagship/01-opslane/internal/db/...
+```
+
+Required files:
+
+- `internal/db/migrations.go`
+- `internal/db/repository.go`
+- `internal/models/tenant.go`
+- `internal/models/user.go`
+- `internal/models/order.go`
+- `internal/models/payment.go`
+
+Module spec: [modules/02-database/README.md](./modules/02-database/README.md)
+
+## OPSL.3 Authentication and Tenant Isolation
+
+What you build: token issuance, password hashing, auth middleware, and trusted tenant identity flow.
+
+Proof surface:
+
+```bash
+go test ./11-flagship/01-opslane/internal/auth/...
+```
+
+Required files:
+
+- `internal/auth/token.go`
+- `internal/auth/password.go`
+- `internal/auth/service.go`
+- `internal/auth/middleware.go`
+- `internal/auth/context.go`
+
+Module spec: [modules/03-auth/README.md](./modules/03-auth/README.md)
+
+## OPSL.4 HTTP API Layer
+
+What you build: the public JSON contract, protected routes, rate limiting, and CORS behavior.
+
+Proof surface:
+
+```bash
+go test ./11-flagship/01-opslane/internal/handlers/...
+go test ./11-flagship/01-opslane/internal/middleware/...
+```
+
+Manual spot checks:
+
+```bash
+curl http://localhost:8080/health
+curl -X POST http://localhost:8080/api/v1/auth/login -H "Content-Type: application/json" -d "{\"tenant_id\":1,\"email\":\"admin@example.com\",\"password\":\"CorrectHorse7Battery\"}"
+```
+
+Required files:
+
+- `internal/handlers/handlers.go`
+- `internal/handlers/api.go`
+- `internal/middleware/middleware.go`
+
+Module spec: [modules/04-http-api/README.md](./modules/04-http-api/README.md)
+
+## OPSL.5 Order Processing
+
+What you build: the order state machine, validation rules, inventory coordination, and idempotent workflow entry.
+
+Target proof surface once this module is implemented:
+
+- `go test` passes for the future `11-flagship/01-opslane/internal/services` package
+- order state transition tests prove valid and invalid transitions
+- idempotent order creation does not duplicate work on retries
+
+Required files:
+
+- `internal/services/order.go`
+- `internal/services/inventory.go`
+- `internal/services/validation.go`
+
+Read this before starting:
+
+- [modules/05-order-processing/README.md](./modules/05-order-processing/README.md)
+
+## OPSL.6 Payment Pipeline
+
+What you build: payment retries, duplicate protection, and reconciliation-safe gateway flow.
+
+Target proof surface once this module is implemented:
+
+- `go test` passes for the future `11-flagship/01-opslane/internal/payment` package
+- retry and reconciliation tests prove duplicate protection
+- timeout handling is explicit and bounded
+
+Required files:
+
+- `internal/payment/gateway.go`
+- `internal/payment/worker.go`
+- `internal/services/payment.go`
+
+Read this before starting:
+
+- [modules/06-payment-pipeline/README.md](./modules/06-payment-pipeline/README.md)
+
+## OPSL.7 Event Bus and Worker Pools
+
+What you build: bounded asynchronous work, observable worker lifecycle, and queue-pressure handling.
+
+Target proof surface once this module is implemented:
+
+- `go test` passes for the future `internal/events` and `internal/workers` packages
+- pool saturation tests prove backpressure behavior
+- shutdown tests prove workers drain or stop intentionally
+
+Required files:
+
+- `internal/events/bus.go`
+- `internal/events/types.go`
+- `internal/workers/pool.go`
+- `internal/workers/order_processor.go`
+- `internal/workers/payment_processor.go`
+- `internal/workers/notification_worker.go`
+
+Read this before starting:
+
+- [modules/07-event-workers/README.md](./modules/07-event-workers/README.md)
+
+## OPSL.8 Caching Layer
+
+What you build: cache-aside reads, invalidation boundaries, and bounded TTL behavior.
+
+Target proof surface once this module is implemented:
+
+- `go test` passes for the future `11-flagship/01-opslane/internal/cache` package
+- cache invalidation tests prove stale order and payment data is not served indefinitely
+
+Required files:
+
+- `internal/cache/cache.go`
+- `internal/cache/store.go`
+- `internal/middleware/cache.go`
+
+Read this before starting:
+
+- [modules/08-caching/README.md](./modules/08-caching/README.md)
+
+## OPSL.9 Observability
+
+What you build: structured logs, correlation IDs, metrics, and trace-friendly request flow.
+
+Target proof surface once this module is implemented:
+
+- `go test` passes for the future `internal/logging` and `internal/metrics` packages
+- request correlation tests prove one order can be traced across layers
+
+Required files:
+
+- `internal/logging/logger.go`
+- `internal/logging/middleware.go`
+- `internal/metrics/metrics.go`
+- `internal/tracing/tracing.go`
+
+Read this before starting:
+
+- [modules/09-observability/README.md](./modules/09-observability/README.md)
+
+## OPSL.10 Graceful Shutdown and Deployment
+
+What you build: safe drain behavior, deployment packaging, and final integrated system proof.
+
+Target proof surface once this module is implemented:
+
+- `go build` succeeds for the Opslane server
+- the full Opslane test suite stays green
+- drain behavior is verified under shutdown pressure
+
+Required files:
+
+- `cmd/server/shutdown.go`
+- `.github/workflows/ci.yml`
+
+Read this before starting:
+
+- [modules/10-shutdown-deploy/README.md](./modules/10-shutdown-deploy/README.md)

--- a/11-flagship/01-opslane/MODULES.md
+++ b/11-flagship/01-opslane/MODULES.md
@@ -237,7 +237,7 @@ Target proof surface once this module is implemented:
 Required files:
 
 - `cmd/server/shutdown.go`
-- `.github/workflows/ci.yml`
+- repository root `.github/workflows/ci.yml`
 
 Read this before starting:
 

--- a/11-flagship/01-opslane/README.md
+++ b/11-flagship/01-opslane/README.md
@@ -34,9 +34,35 @@ This project exists so the curriculum has one integrated system where earlier st
 | `docker-compose.yml` | runs the application with PostgreSQL and the flagship API |
 | `internal/` | holds the application boundaries that later modules will deepen |
 
-## Module 4 Focus
+## Current Progress
 
-Module 4 establishes:
+Opslane now uses an explicit module system instead of one static flagship label.
+
+The current repository state is:
+
+- `OPSL.1` complete: foundation and configuration
+- `OPSL.2` complete: database and models
+- `OPSL.3` complete: authentication and tenant isolation
+- `OPSL.4` complete: HTTP API layer
+- `OPSL.5` next: order processing
+
+Use the progress surface instead of guessing:
+
+```bash
+go run ./11-flagship/01-opslane/scripts/progress.go
+```
+
+Then use the learner map:
+
+- [Opslane module map](./MODULES.md)
+- [OPSL.1 module spec](./modules/01-foundation/README.md)
+- [OPSL.2 module spec](./modules/02-database/README.md)
+- [OPSL.3 module spec](./modules/03-auth/README.md)
+- [OPSL.4 module spec](./modules/04-http-api/README.md)
+
+## Module 4 Snapshot
+
+`OPSL.4` establishes:
 
 - public JSON API routes for tenant setup, user setup, and login
 - protected order and payment routes that use authenticated tenant identity
@@ -44,9 +70,8 @@ Module 4 establishes:
 - CORS and simple in-process rate limiting middleware
 
 This slice turns the auth and persistence foundation into a runnable HTTP contract.
-The important rule is still zero magic: protected handlers do not accept tenant IDs from request
-bodies. They read tenant and user identity from verified auth context, then pass that trusted
-identity into repository calls.
+Protected handlers do not accept tenant IDs from request bodies. They read tenant and user identity
+from verified auth context, then pass that trusted identity into repository calls.
 
 ## Run the Project
 
@@ -134,5 +159,6 @@ curl http://localhost:8080/api/v1/orders/1/payments \
 
 ## Next Step
 
-After Module 4 is in place, the next build slice is order processing so Opslane can move from CRUD
-surfaces into explicit business state transitions and failure-aware workflows.
+After `OPSL.4`, continue to [OPSL.5](./modules/05-order-processing/README.md).
+That module moves Opslane from CRUD surfaces into explicit business state transitions and
+failure-aware workflows.

--- a/11-flagship/01-opslane/modules/01-foundation/README.md
+++ b/11-flagship/01-opslane/modules/01-foundation/README.md
@@ -1,0 +1,46 @@
+# OPSL.1 Foundation and Configuration
+
+## Mission
+
+Make Opslane start as a real service with validated configuration instead of magic defaults.
+
+## What This Module Builds
+
+- the server entrypoint
+- environment-aware configuration loading
+- startup validation
+- local container wiring for PostgreSQL
+
+## You Are Here If
+
+- you can run the Opslane server from `cmd/server`
+- you understand where runtime configuration comes from
+- you can explain which values are safe defaults and which must be explicit
+
+## Proof Surface
+
+```bash
+go test ./11-flagship/01-opslane/internal/config/...
+go run ./11-flagship/01-opslane/cmd/server
+```
+
+## Required Files and Boundaries
+
+- `cmd/server/main.go`
+- `internal/config/config.go`
+- `internal/config/environment.go`
+- `.env.example`
+- `Dockerfile`
+- `docker-compose.yml`
+
+Do not move tenant, auth, or business logic into the config package.
+
+## Engineering Questions
+
+- Which settings should fail fast at startup instead of surfacing after traffic arrives?
+- Which secrets should never have production defaults?
+- How do you keep local overrides explicit without hard-coding environment behavior in handlers?
+
+## Next Module
+
+Continue to [OPSL.2 Database and Models](../02-database/README.md).

--- a/11-flagship/01-opslane/modules/01-foundation/README.md
+++ b/11-flagship/01-opslane/modules/01-foundation/README.md
@@ -33,6 +33,8 @@ go run ./11-flagship/01-opslane/cmd/server
 - `Dockerfile`
 - `docker-compose.yml`
 
+Implemented code surface: [SURFACE.md](./SURFACE.md)
+
 Do not move tenant, auth, or business logic into the config package.
 
 ## Engineering Questions

--- a/11-flagship/01-opslane/modules/01-foundation/SURFACE.md
+++ b/11-flagship/01-opslane/modules/01-foundation/SURFACE.md
@@ -1,0 +1,23 @@
+# OPSL.1 Implemented Code Surface
+
+This module is already implemented in the current tree.
+
+## Primary Code Files
+
+- [`cmd/server/main.go`](../../cmd/server/main.go)
+- [`internal/config/config.go`](../../internal/config/config.go)
+- [`internal/config/environment.go`](../../internal/config/environment.go)
+- [`Dockerfile`](../../Dockerfile)
+- [`docker-compose.yml`](../../docker-compose.yml)
+- [`.env.example`](../../.env.example)
+
+## Proof Commands
+
+```bash
+go test ./11-flagship/01-opslane/internal/config/...
+go run ./11-flagship/01-opslane/cmd/server
+```
+
+## What To Read Next
+
+If you want the current learner map, go back to [MODULES.md](../../MODULES.md).

--- a/11-flagship/01-opslane/modules/02-database/README.md
+++ b/11-flagship/01-opslane/modules/02-database/README.md
@@ -1,0 +1,45 @@
+# OPSL.2 Database and Models
+
+## Mission
+
+Define the multi-tenant data model and persistence seams before adding more public behavior.
+
+## What This Module Builds
+
+- tenant-aware domain models
+- PostgreSQL schema creation
+- repository boundaries
+- transaction seams for later business workflows
+
+## You Are Here If
+
+- you can explain why tenant ownership is stored directly in the schema
+- you understand where repository methods stop and higher-level workflows should begin
+- you can read the current migrations without guessing how orders and payments relate
+
+## Proof Surface
+
+```bash
+go test ./11-flagship/01-opslane/internal/db/...
+```
+
+## Required Files and Boundaries
+
+- `internal/db/migrations.go`
+- `internal/db/repository.go`
+- `internal/models/tenant.go`
+- `internal/models/user.go`
+- `internal/models/order.go`
+- `internal/models/payment.go`
+
+The repository layer owns persistence concerns. It should not absorb auth rules or HTTP parsing.
+
+## Engineering Questions
+
+- Which relationships must be tenant-scoped in the database itself, not just in handlers?
+- Where do transactions belong when multiple rows must change together?
+- What query patterns deserve indexes now versus later?
+
+## Next Module
+
+Continue to [OPSL.3 Authentication and Tenant Isolation](../03-auth/README.md).

--- a/11-flagship/01-opslane/modules/02-database/README.md
+++ b/11-flagship/01-opslane/modules/02-database/README.md
@@ -32,6 +32,8 @@ go test ./11-flagship/01-opslane/internal/db/...
 - `internal/models/order.go`
 - `internal/models/payment.go`
 
+Implemented code surface: [SURFACE.md](./SURFACE.md)
+
 The repository layer owns persistence concerns. It should not absorb auth rules or HTTP parsing.
 
 ## Engineering Questions

--- a/11-flagship/01-opslane/modules/02-database/SURFACE.md
+++ b/11-flagship/01-opslane/modules/02-database/SURFACE.md
@@ -1,0 +1,22 @@
+# OPSL.2 Implemented Code Surface
+
+This module is already implemented in the current tree.
+
+## Primary Code Files
+
+- [`internal/db/migrations.go`](../../internal/db/migrations.go)
+- [`internal/db/repository.go`](../../internal/db/repository.go)
+- [`internal/models/tenant.go`](../../internal/models/tenant.go)
+- [`internal/models/user.go`](../../internal/models/user.go)
+- [`internal/models/order.go`](../../internal/models/order.go)
+- [`internal/models/payment.go`](../../internal/models/payment.go)
+
+## Proof Commands
+
+```bash
+go test ./11-flagship/01-opslane/internal/db/...
+```
+
+## What To Read Next
+
+If you want the current learner map, go back to [MODULES.md](../../MODULES.md).

--- a/11-flagship/01-opslane/modules/03-auth/README.md
+++ b/11-flagship/01-opslane/modules/03-auth/README.md
@@ -31,6 +31,8 @@ go test ./11-flagship/01-opslane/internal/auth/...
 - `internal/auth/middleware.go`
 - `internal/auth/context.go`
 
+Implemented code surface: [SURFACE.md](./SURFACE.md)
+
 Identity becomes trusted only after middleware verification. Repository calls should receive that trusted identity, not raw request claims.
 
 ## Engineering Questions

--- a/11-flagship/01-opslane/modules/03-auth/README.md
+++ b/11-flagship/01-opslane/modules/03-auth/README.md
@@ -1,0 +1,44 @@
+# OPSL.3 Authentication and Tenant Isolation
+
+## Mission
+
+Add identity and tenant-scoped request trust so later modules can rely on verified context.
+
+## What This Module Builds
+
+- password hashing
+- signed token creation and verification
+- auth middleware
+- tenant and user identity propagation through request context
+
+## You Are Here If
+
+- you can explain why protected handlers do not accept tenant IDs from request bodies
+- you understand where token verification happens
+- you can trace a request from bearer token to trusted identity
+
+## Proof Surface
+
+```bash
+go test ./11-flagship/01-opslane/internal/auth/...
+```
+
+## Required Files and Boundaries
+
+- `internal/auth/token.go`
+- `internal/auth/password.go`
+- `internal/auth/service.go`
+- `internal/auth/middleware.go`
+- `internal/auth/context.go`
+
+Identity becomes trusted only after middleware verification. Repository calls should receive that trusted identity, not raw request claims.
+
+## Engineering Questions
+
+- Where should tenant identity be enforced first: middleware, service, or repository?
+- What error shape should a tampered token produce?
+- Which auth behavior belongs in middleware and which belongs in business services?
+
+## Next Module
+
+Continue to [OPSL.4 HTTP API Layer](../04-http-api/README.md).

--- a/11-flagship/01-opslane/modules/03-auth/SURFACE.md
+++ b/11-flagship/01-opslane/modules/03-auth/SURFACE.md
@@ -1,0 +1,21 @@
+# OPSL.3 Implemented Code Surface
+
+This module is already implemented in the current tree.
+
+## Primary Code Files
+
+- [`internal/auth/token.go`](../../internal/auth/token.go)
+- [`internal/auth/password.go`](../../internal/auth/password.go)
+- [`internal/auth/service.go`](../../internal/auth/service.go)
+- [`internal/auth/middleware.go`](../../internal/auth/middleware.go)
+- [`internal/auth/context.go`](../../internal/auth/context.go)
+
+## Proof Commands
+
+```bash
+go test ./11-flagship/01-opslane/internal/auth/...
+```
+
+## What To Read Next
+
+If you want the current learner map, go back to [MODULES.md](../../MODULES.md).

--- a/11-flagship/01-opslane/modules/04-http-api/README.md
+++ b/11-flagship/01-opslane/modules/04-http-api/README.md
@@ -1,0 +1,55 @@
+# OPSL.4 HTTP API Layer
+
+## Mission
+
+Turn the auth and persistence foundation into a stable public JSON contract.
+
+## What This Module Builds
+
+- tenant and user setup endpoints
+- login endpoint
+- protected order and payment routes
+- JSON error responses
+- rate limiting and CORS middleware
+
+## You Are Here If
+
+- you can call the API and receive stable JSON responses
+- you understand why authenticated routes read tenant identity from auth context
+- you can explain where middleware stops and handlers begin
+
+## Proof Surface
+
+```bash
+go test ./11-flagship/01-opslane/internal/handlers/...
+go test ./11-flagship/01-opslane/internal/middleware/...
+go run ./11-flagship/01-opslane/cmd/server
+```
+
+Manual checks:
+
+```bash
+curl http://localhost:8080/health
+curl -X POST http://localhost:8080/api/v1/auth/login -H "Content-Type: application/json" -d "{\"tenant_id\":1,\"email\":\"admin@example.com\",\"password\":\"CorrectHorse7Battery\"}"
+curl http://localhost:8080/api/v1/orders
+```
+
+The final request above must return `401` without a bearer token.
+
+## Required Files and Boundaries
+
+- `internal/handlers/handlers.go`
+- `internal/handlers/api.go`
+- `internal/middleware/middleware.go`
+
+Handlers parse and shape HTTP traffic. They should not become the order-processing engine.
+
+## Engineering Questions
+
+- Which requests should be rate-limited and which should stay exempt?
+- How do you keep duplicate database conflicts from leaking raw driver errors to clients?
+- Which timeouts and cleanup rules belong at the HTTP boundary?
+
+## Next Module
+
+Continue to [OPSL.5 Order Processing](../05-order-processing/README.md).

--- a/11-flagship/01-opslane/modules/04-http-api/README.md
+++ b/11-flagship/01-opslane/modules/04-http-api/README.md
@@ -42,6 +42,8 @@ The final request above must return `401` without a bearer token.
 - `internal/handlers/api.go`
 - `internal/middleware/middleware.go`
 
+Implemented code surface: [SURFACE.md](./SURFACE.md)
+
 Handlers parse and shape HTTP traffic. They should not become the order-processing engine.
 
 ## Engineering Questions

--- a/11-flagship/01-opslane/modules/04-http-api/SURFACE.md
+++ b/11-flagship/01-opslane/modules/04-http-api/SURFACE.md
@@ -1,0 +1,22 @@
+# OPSL.4 Implemented Code Surface
+
+This module is already implemented in the current tree.
+
+## Primary Code Files
+
+- [`internal/handlers/handlers.go`](../../internal/handlers/handlers.go)
+- [`internal/handlers/api.go`](../../internal/handlers/api.go)
+- [`internal/middleware/middleware.go`](../../internal/middleware/middleware.go)
+- [`cmd/server/main.go`](../../cmd/server/main.go)
+
+## Proof Commands
+
+```bash
+go test ./11-flagship/01-opslane/internal/handlers/...
+go test ./11-flagship/01-opslane/internal/middleware/...
+go run ./11-flagship/01-opslane/cmd/server
+```
+
+## What To Read Next
+
+If you want the current learner map, go back to [MODULES.md](../../MODULES.md).

--- a/11-flagship/01-opslane/modules/05-order-processing/README.md
+++ b/11-flagship/01-opslane/modules/05-order-processing/README.md
@@ -1,0 +1,49 @@
+# OPSL.5 Order Processing
+
+## Mission
+
+Move Opslane from CRUD-shaped handlers into a real business workflow with explicit state transitions.
+
+## What This Module Builds
+
+- order service layer
+- validation rules for order creation and transitions
+- inventory coordination seam
+- idempotent order workflow entry
+
+## You Are Here If
+
+- `OPSL.4` is complete
+- you can explain why handlers should stop at request parsing and response shaping
+- you are ready to model state transitions instead of direct table writes
+
+## Proof Surface
+
+This module is not implemented in the current tree yet.
+
+When it is complete:
+
+- `go test` must pass for the future `11-flagship/01-opslane/internal/services` package
+- state transition tests must cover valid and invalid order movement
+- idempotency tests must prove retries do not create duplicate orders
+
+Expected new files:
+
+- `internal/services/order.go`
+- `internal/services/inventory.go`
+- `internal/services/validation.go`
+
+## Required Files and Boundaries
+
+The order service should own workflow rules.
+Handlers should call into it, and repositories should stay focused on persistence.
+
+## Engineering Questions
+
+- What happens when 1,000 orders arrive together?
+- What happens when inventory is reserved but payment fails?
+- What happens when work stops halfway through a transition?
+
+## Next Module
+
+Continue to [OPSL.6 Payment Pipeline](../06-payment-pipeline/README.md) after the order state machine is provable.

--- a/11-flagship/01-opslane/modules/06-payment-pipeline/README.md
+++ b/11-flagship/01-opslane/modules/06-payment-pipeline/README.md
@@ -1,0 +1,49 @@
+# OPSL.6 Payment Pipeline
+
+## Mission
+
+Model payment work as a reliability problem, not just another insert statement.
+
+## What This Module Builds
+
+- payment service workflow
+- gateway integration seam
+- retry and timeout behavior
+- reconciliation-safe duplicate protection
+
+## You Are Here If
+
+- `OPSL.5` is complete
+- order state transitions exist
+- payment handling can move into a dedicated workflow layer
+
+## Proof Surface
+
+This module is not implemented in the current tree yet.
+
+When it is complete:
+
+- `go test` must pass for the future `internal/payment` package
+- payment workflow tests must prove retries and duplicate protection
+- reconciliation tests must cover missing callback and timeout scenarios
+
+Expected new files:
+
+- `internal/payment/gateway.go`
+- `internal/payment/worker.go`
+- `internal/services/payment.go`
+
+## Required Files and Boundaries
+
+Keep gateway behavior behind an explicit boundary.
+Do not scatter payment retry logic across handlers and repositories.
+
+## Engineering Questions
+
+- What happens on gateway timeout?
+- How do you stop duplicate payment attempts from becoming duplicate charges?
+- What should happen when success is observed locally but the follow-up callback never arrives?
+
+## Next Module
+
+Continue to [OPSL.7 Event Bus and Worker Pools](../07-event-workers/README.md).

--- a/11-flagship/01-opslane/modules/07-event-workers/README.md
+++ b/11-flagship/01-opslane/modules/07-event-workers/README.md
@@ -1,0 +1,52 @@
+# OPSL.7 Event Bus and Worker Pools
+
+## Mission
+
+Add bounded asynchronous work without turning background processing into invisible chaos.
+
+## What This Module Builds
+
+- event bus primitives
+- worker pool boundaries
+- queueing and backpressure behavior
+- safe drain rules for background work
+
+## You Are Here If
+
+- `OPSL.6` is complete
+- payment and order workflows are ready to emit asynchronous follow-up work
+- you are prepared to reason about bounded concurrency
+
+## Proof Surface
+
+This module is not implemented in the current tree yet.
+
+When it is complete:
+
+- `go test` must pass for the future `internal/events` package
+- `go test` must pass for the future `internal/workers` package
+- saturation and drain tests must prove bounded behavior
+
+Expected new files:
+
+- `internal/events/bus.go`
+- `internal/events/types.go`
+- `internal/workers/pool.go`
+- `internal/workers/order_processor.go`
+- `internal/workers/payment_processor.go`
+- `internal/workers/notification_worker.go`
+
+## Required Files and Boundaries
+
+Worker coordination should stay explicit and bounded.
+Avoid untracked goroutine spawning inside handlers or repositories.
+
+## Engineering Questions
+
+- What happens when the queue is full?
+- When should the system reject work instead of buffering more?
+- How do you inspect or drain a stuck worker safely?
+
+## Next Module
+
+Continue to [OPSL.8 Caching Layer](../08-caching/README.md).

--- a/11-flagship/01-opslane/modules/08-caching/README.md
+++ b/11-flagship/01-opslane/modules/08-caching/README.md
@@ -1,0 +1,48 @@
+# OPSL.8 Caching Layer
+
+## Mission
+
+Introduce cache-aware behavior without pretending cache invalidation is free.
+
+## What This Module Builds
+
+- cache storage boundary
+- cache-aside reads
+- TTL behavior
+- invalidation rules around changing order and payment state
+
+## You Are Here If
+
+- `OPSL.7` is complete
+- there are read paths worth caching
+- asynchronous work exists that can make stale data more dangerous
+
+## Proof Surface
+
+This module is not implemented in the current tree yet.
+
+When it is complete:
+
+- `go test` must pass for the future `11-flagship/01-opslane/internal/cache` package
+- invalidation tests must prove cache updates follow writes intentionally
+
+Expected new files:
+
+- `internal/cache/cache.go`
+- `internal/cache/store.go`
+- `internal/middleware/cache.go`
+
+## Required Files and Boundaries
+
+Caching should be additive, not a hidden source of truth.
+PostgreSQL remains the system of record.
+
+## Engineering Questions
+
+- Which reads are safe to cache?
+- What should invalidate cached order or payment data?
+- How will you prevent stampedes when hot keys expire?
+
+## Next Module
+
+Continue to [OPSL.9 Observability](../09-observability/README.md).

--- a/11-flagship/01-opslane/modules/09-observability/README.md
+++ b/11-flagship/01-opslane/modules/09-observability/README.md
@@ -1,0 +1,49 @@
+# OPSL.9 Observability
+
+## Mission
+
+Make Opslane explain itself under load, failure, and change.
+
+## What This Module Builds
+
+- structured logging surfaces
+- correlation IDs
+- metrics
+- trace-friendly request and background-work context
+
+## You Are Here If
+
+- `OPSL.8` is complete
+- background work and cache behavior now exist
+- debugging the system requires better evidence than raw logs
+
+## Proof Surface
+
+This module is not implemented in the current tree yet.
+
+When it is complete:
+
+- `go test` must pass for the future `internal/logging` package
+- `go test` must pass for the future `internal/metrics` package
+- correlation tests must prove one request can be followed across layers
+
+Expected new files:
+
+- `internal/logging/logger.go`
+- `internal/logging/middleware.go`
+- `internal/metrics/metrics.go`
+- `internal/tracing/tracing.go`
+
+## Required Files and Boundaries
+
+Instrumentation should help answer why the system is degrading, not just generate more text.
+
+## Engineering Questions
+
+- Which metrics would warn about degradation before users complain?
+- What is the minimum log context needed to follow one failed order?
+- How should tracing connect HTTP requests to background work?
+
+## Next Module
+
+Continue to [OPSL.10 Graceful Shutdown and Deployment](../10-shutdown-deploy/README.md).

--- a/11-flagship/01-opslane/modules/10-shutdown-deploy/README.md
+++ b/11-flagship/01-opslane/modules/10-shutdown-deploy/README.md
@@ -1,0 +1,53 @@
+# OPSL.10 Graceful Shutdown and Deployment
+
+## Mission
+
+Finish Opslane as a production-shaped service that can stop, recover, and deploy safely.
+
+## What This Module Builds
+
+- explicit shutdown handling
+- drain behavior for requests and workers
+- deployment packaging and health semantics
+- final integrated proof for the required flagship path
+
+## You Are Here If
+
+- `OPSL.9` is complete
+- the service has background work and observability
+- the final concern is safe operation under deploy and shutdown pressure
+
+## Proof Surface
+
+This module is not implemented in the current tree yet.
+
+When it is complete:
+
+- `go build` must succeed for the Opslane server
+- the full Opslane test suite must stay green
+- shutdown drills must prove drain behavior under in-flight work
+
+Expected new files:
+
+- `cmd/server/shutdown.go`
+- any supporting worker drain and readiness logic required by the final design
+
+Existing deployment surfaces that should still participate:
+
+- `Dockerfile`
+- `docker-compose.yml`
+- `.github/workflows/ci.yml`
+
+## Required Files and Boundaries
+
+Shutdown behavior must coordinate HTTP, database, and background work. This is the final integrated proof, not a one-file patch.
+
+## Engineering Questions
+
+- What should the health endpoint return during drain?
+- What guarantees do we make about in-flight requests and queued work?
+- Which operational promises are enforceable, and which are only best-effort?
+
+## Next Module
+
+This completes the required Opslane flagship path.

--- a/11-flagship/01-opslane/modules/10-shutdown-deploy/README.md
+++ b/11-flagship/01-opslane/modules/10-shutdown-deploy/README.md
@@ -36,7 +36,7 @@ Existing deployment surfaces that should still participate:
 
 - `Dockerfile`
 - `docker-compose.yml`
-- `.github/workflows/ci.yml`
+- repository root `.github/workflows/ci.yml`
 
 ## Required Files and Boundaries
 

--- a/11-flagship/01-opslane/scripts/progress.go
+++ b/11-flagship/01-opslane/scripts/progress.go
@@ -1,0 +1,307 @@
+//go:build ignore
+
+// Copyright (c) 2026 Rasel Hossen
+// Licensed under The Go Engineer License v1.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type moduleSpec struct {
+	id            string
+	title         string
+	testPkgs      []string
+	requiredFiles []string
+	readmeDir     string
+	nextStep      string
+}
+
+var modules = []moduleSpec{
+	{
+		id:    "OPSL.1",
+		title: "Foundation and Configuration",
+		testPkgs: []string{
+			"./internal/config/...",
+		},
+		requiredFiles: []string{
+			"cmd/server/main.go",
+			"internal/config/config.go",
+			"internal/config/environment.go",
+			".env.example",
+			"Dockerfile",
+			"docker-compose.yml",
+		},
+		readmeDir: "modules/01-foundation",
+		nextStep:  "Continue into OPSL.2 after the server boots with validated configuration.",
+	},
+	{
+		id:    "OPSL.2",
+		title: "Database and Models",
+		testPkgs: []string{
+			"./internal/db/...",
+		},
+		requiredFiles: []string{
+			"internal/db/migrations.go",
+			"internal/db/repository.go",
+			"internal/models/tenant.go",
+			"internal/models/user.go",
+			"internal/models/order.go",
+			"internal/models/payment.go",
+		},
+		readmeDir: "modules/02-database",
+		nextStep:  "Continue into OPSL.3 after the schema and repository layer are stable.",
+	},
+	{
+		id:    "OPSL.3",
+		title: "Authentication and Tenant Isolation",
+		testPkgs: []string{
+			"./internal/auth/...",
+		},
+		requiredFiles: []string{
+			"internal/auth/token.go",
+			"internal/auth/password.go",
+			"internal/auth/service.go",
+			"internal/auth/middleware.go",
+			"internal/auth/context.go",
+		},
+		readmeDir: "modules/03-auth",
+		nextStep:  "Continue into OPSL.4 after tenant identity is trusted middleware state.",
+	},
+	{
+		id:    "OPSL.4",
+		title: "HTTP API Layer",
+		testPkgs: []string{
+			"./internal/handlers/...",
+			"./internal/middleware/...",
+		},
+		requiredFiles: []string{
+			"internal/handlers/handlers.go",
+			"internal/handlers/api.go",
+			"internal/middleware/middleware.go",
+		},
+		readmeDir: "modules/04-http-api",
+		nextStep:  "Continue into OPSL.5 to replace CRUD-shaped writes with order workflow logic.",
+	},
+	{
+		id:    "OPSL.5",
+		title: "Order Processing",
+		testPkgs: []string{
+			"./internal/services/...",
+		},
+		requiredFiles: []string{
+			"internal/services/order.go",
+			"internal/services/inventory.go",
+			"internal/services/validation.go",
+		},
+		readmeDir: "modules/05-order-processing",
+		nextStep:  "Build the order service and state machine before starting OPSL.6.",
+	},
+	{
+		id:    "OPSL.6",
+		title: "Payment Pipeline",
+		testPkgs: []string{
+			"./internal/payment/...",
+		},
+		requiredFiles: []string{
+			"internal/payment/gateway.go",
+			"internal/payment/worker.go",
+			"internal/services/payment.go",
+		},
+		readmeDir: "modules/06-payment-pipeline",
+		nextStep:  "Add payment workflow boundaries after OPSL.5 is provable.",
+	},
+	{
+		id:    "OPSL.7",
+		title: "Event Bus and Worker Pools",
+		testPkgs: []string{
+			"./internal/events/...",
+			"./internal/workers/...",
+		},
+		requiredFiles: []string{
+			"internal/events/bus.go",
+			"internal/events/types.go",
+			"internal/workers/pool.go",
+			"internal/workers/order_processor.go",
+			"internal/workers/payment_processor.go",
+			"internal/workers/notification_worker.go",
+		},
+		readmeDir: "modules/07-event-workers",
+		nextStep:  "Start bounded async processing after payment workflow logic exists.",
+	},
+	{
+		id:    "OPSL.8",
+		title: "Caching Layer",
+		testPkgs: []string{
+			"./internal/cache/...",
+		},
+		requiredFiles: []string{
+			"internal/cache/cache.go",
+			"internal/cache/store.go",
+			"internal/middleware/cache.go",
+		},
+		readmeDir: "modules/08-caching",
+		nextStep:  "Introduce cache behavior only after OPSL.7 has clear read paths to optimize.",
+	},
+	{
+		id:    "OPSL.9",
+		title: "Observability",
+		testPkgs: []string{
+			"./internal/logging/...",
+			"./internal/metrics/...",
+		},
+		requiredFiles: []string{
+			"internal/logging/logger.go",
+			"internal/logging/middleware.go",
+			"internal/metrics/metrics.go",
+			"internal/tracing/tracing.go",
+		},
+		readmeDir: "modules/09-observability",
+		nextStep:  "Add logs, metrics, and traces before the final deployment module.",
+	},
+	{
+		id:    "OPSL.10",
+		title: "Graceful Shutdown and Deployment",
+		testPkgs: []string{
+			"./cmd/server",
+		},
+		requiredFiles: []string{
+			"cmd/server/shutdown.go",
+			".github/workflows/ci.yml",
+		},
+		readmeDir: "modules/10-shutdown-deploy",
+		nextStep:  "Finish the full flagship path by proving safe shutdown and deployment behavior.",
+	},
+}
+
+type moduleResult struct {
+	complete       bool
+	missingFiles   []string
+	failedPackages []string
+}
+
+func main() {
+	root, err := findOpslaneRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Opslane module progress")
+	fmt.Println(strings.Repeat("=", 72))
+
+	results := make([]moduleResult, len(modules))
+	currentIndex := -1
+
+	for i, module := range modules {
+		results[i] = checkModule(root, module)
+		if currentIndex == -1 && !results[i].complete {
+			currentIndex = i
+		}
+	}
+
+	for i, module := range modules {
+		status := "locked"
+		switch {
+		case results[i].complete:
+			status = "complete"
+		case i == currentIndex:
+			status = "current"
+		}
+		fmt.Printf("%-8s %-36s %s\n", module.id, module.title, status)
+	}
+
+	if currentIndex == -1 {
+		fmt.Println()
+		fmt.Println("All Opslane modules are complete.")
+		return
+	}
+
+	module := modules[currentIndex]
+	result := results[currentIndex]
+
+	fmt.Println()
+	fmt.Printf("Current module: %s %s\n", module.id, module.title)
+	fmt.Printf("Module guide   : 11-flagship/01-opslane/%s/README.md\n", module.readmeDir)
+
+	if len(result.missingFiles) > 0 {
+		fmt.Println("Missing files:")
+		for _, file := range result.missingFiles {
+			fmt.Printf("  - %s\n", file)
+		}
+	}
+
+	if len(result.failedPackages) > 0 {
+		fmt.Println("Proof checks to fix:")
+		for _, pkg := range result.failedPackages {
+			fmt.Printf("  - %s\n", pkg)
+		}
+	}
+
+	fmt.Println("Next step:")
+	fmt.Printf("  %s\n", module.nextStep)
+}
+
+func checkModule(root string, module moduleSpec) moduleResult {
+	result := moduleResult{}
+
+	for _, relativePath := range module.requiredFiles {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(relativePath))); os.IsNotExist(err) {
+			result.missingFiles = append(result.missingFiles, relativePath)
+		}
+	}
+
+	for _, pkg := range module.testPkgs {
+		dir := strings.TrimPrefix(pkg, "./")
+		dir = strings.TrimSuffix(dir, "/...")
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(dir))); os.IsNotExist(err) {
+			result.failedPackages = append(result.failedPackages, pkg+" (package missing)")
+			continue
+		}
+
+		cmd := exec.Command("go", "test", "-count=1", "-timeout=60s", pkg)
+		cmd.Dir = root
+		if err := os.MkdirAll(filepath.Join(root, ".cache", "go-build"), 0o755); err == nil {
+			cmd.Env = append(os.Environ(), "GOCACHE="+filepath.Join(root, ".cache", "go-build"))
+		}
+		if output, err := cmd.CombinedOutput(); err != nil {
+			summary := strings.TrimSpace(string(output))
+			lines := strings.Split(summary, "\n")
+			if len(lines) > 0 {
+				summary = lines[len(lines)-1]
+			}
+			result.failedPackages = append(result.failedPackages, fmt.Sprintf("%s (%s)", pkg, summary))
+		}
+	}
+
+	result.complete = len(result.missingFiles) == 0 && len(result.failedPackages) == 0
+	return result
+}
+
+func findOpslaneRoot() (string, error) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("cannot determine progress.go location")
+	}
+
+	root := filepath.Dir(filepath.Dir(currentFile))
+	markers := []string{
+		"cmd/server/main.go",
+		"internal/config/config.go",
+		"docker-compose.yml",
+	}
+
+	for _, marker := range markers {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(marker))); err != nil {
+			return "", fmt.Errorf("cannot find Opslane root from %s", currentFile)
+		}
+	}
+
+	return root, nil
+}

--- a/11-flagship/01-opslane/scripts/progress.go
+++ b/11-flagship/01-opslane/scripts/progress.go
@@ -15,12 +15,13 @@ import (
 )
 
 type moduleSpec struct {
-	id            string
-	title         string
-	testPkgs      []string
-	requiredFiles []string
-	readmeDir     string
-	nextStep      string
+	id                string
+	title             string
+	testPkgs          []string
+	requiredFiles     []string
+	requiredRepoFiles []string
+	readmeDir         string
+	nextStep          string
 }
 
 var modules = []moduleSpec{
@@ -173,6 +174,8 @@ var modules = []moduleSpec{
 		},
 		requiredFiles: []string{
 			"cmd/server/shutdown.go",
+		},
+		requiredRepoFiles: []string{
 			".github/workflows/ci.yml",
 		},
 		readmeDir: "modules/10-shutdown-deploy",
@@ -187,7 +190,7 @@ type moduleResult struct {
 }
 
 func main() {
-	root, err := findOpslaneRoot()
+	root, repoRoot, err := findOpslaneRoot()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
@@ -200,7 +203,7 @@ func main() {
 	currentIndex := -1
 
 	for i, module := range modules {
-		results[i] = checkModule(root, module)
+		results[i] = checkModule(root, repoRoot, module)
 		if currentIndex == -1 && !results[i].complete {
 			currentIndex = i
 		}
@@ -248,12 +251,18 @@ func main() {
 	fmt.Printf("  %s\n", module.nextStep)
 }
 
-func checkModule(root string, module moduleSpec) moduleResult {
+func checkModule(root, repoRoot string, module moduleSpec) moduleResult {
 	result := moduleResult{}
 
 	for _, relativePath := range module.requiredFiles {
 		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(relativePath))); os.IsNotExist(err) {
 			result.missingFiles = append(result.missingFiles, relativePath)
+		}
+	}
+
+	for _, relativePath := range module.requiredRepoFiles {
+		if _, err := os.Stat(filepath.Join(repoRoot, filepath.FromSlash(relativePath))); os.IsNotExist(err) {
+			result.missingFiles = append(result.missingFiles, "repo:"+relativePath)
 		}
 	}
 
@@ -284,10 +293,10 @@ func checkModule(root string, module moduleSpec) moduleResult {
 	return result
 }
 
-func findOpslaneRoot() (string, error) {
+func findOpslaneRoot() (string, string, error) {
 	_, currentFile, _, ok := runtime.Caller(0)
 	if !ok {
-		return "", fmt.Errorf("cannot determine progress.go location")
+		return "", "", fmt.Errorf("cannot determine progress.go location")
 	}
 
 	root := filepath.Dir(filepath.Dir(currentFile))
@@ -299,9 +308,21 @@ func findOpslaneRoot() (string, error) {
 
 	for _, marker := range markers {
 		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(marker))); err != nil {
-			return "", fmt.Errorf("cannot find Opslane root from %s", currentFile)
+			return "", "", fmt.Errorf("cannot find Opslane root from %s", currentFile)
 		}
 	}
 
-	return root, nil
+	repoRoot := filepath.Dir(filepath.Dir(root))
+	repoMarkers := []string{
+		"curriculum.v2.json",
+		".github/workflows/ci.yml",
+	}
+
+	for _, marker := range repoMarkers {
+		if _, err := os.Stat(filepath.Join(repoRoot, filepath.FromSlash(marker))); err != nil {
+			return "", "", fmt.Errorf("cannot find repository root from %s", currentFile)
+		}
+	}
+
+	return root, repoRoot, nil
 }

--- a/11-flagship/01-opslane/scripts/progress.go
+++ b/11-flagship/01-opslane/scripts/progress.go
@@ -314,8 +314,8 @@ func findOpslaneRoot() (string, string, error) {
 
 	repoRoot := filepath.Dir(filepath.Dir(root))
 	repoMarkers := []string{
+		"go.mod",
 		"curriculum.v2.json",
-		".github/workflows/ci.yml",
 	}
 
 	for _, marker := range repoMarkers {

--- a/11-flagship/README.md
+++ b/11-flagship/README.md
@@ -11,20 +11,35 @@ By the end of this stage, a learner should be able to:
 - understand how multiple engineering layers meet in one project
 - extend a production-style service without learning a brand-new tool category mid-capstone
 
-## Stage Map
+## Required Flagship Path
 
-| Track | Surface | Core Job |
+| Project | Module Path | Core Job |
 | --- | --- | --- |
-| `FG.1` | [Opslane](./01-opslane) | integrated flagship SaaS backend proof surface |
+| `Opslane` | `OPSL.1 -> OPSL.10` | integrated SaaS backend with explicit module-by-module proof |
 
 ## Suggested Learning Flow
 
 1. Start with [Opslane](./01-opslane).
-2. Bring Section 10's code-generation lessons with you as supporting tooling, not new flagship scope.
+2. Use [`MODULES.md`](./01-opslane/MODULES.md) and the Opslane progress checker to verify each
+   module boundary before moving forward.
+3. Bring Section 10's code-generation lessons with you as supporting tooling, not new flagship
+   scope.
+
+## Additional Flagship Projects
+
+Stage 11 is now designed to hold more than one flagship project.
+
+Opslane is the canonical required path today. Future flagship projects should:
+
+- live under `11-flagship/NN-project-name/`
+- use their own unique project prefix, such as `CRMX.*` or `BILL.*`
+- keep their own `MODULES.md`, module READMEs, and `scripts/progress.go`
+
+They can be added as optional flagship expansions without changing the required Opslane path.
 
 ## Finish This Stage When
 
-- you can explain how the flagship system is structured
+- you can complete the required Opslane path through `OPSL.10`
 - you can follow code across layers without losing the big picture
 - you can explain how earlier production lessons show up inside one integrated system
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ This file is the curriculum shape after the restructure plan has been applied.
 | s08 | Quality & Testing | TE, PR | TE.10, PR.6 |
 | s09 | Architecture & Security | PD, ARCH, SEC | PD.3, ARCH.9, SEC.11 |
 | s10 | Production Operations | SL, GS, CFG, OPS, DOCKER, DEPLOY, CG | SL.5, GS.3, CFG.5, OPS.5, DEPLOY.3, CG.3 |
-| s11 | Flagship | FG | FG.1 |
+| s11 | Flagship | OPSL (+ future flagship prefixes) | OPSL.10 |
 
 ## Structural Notes
 
@@ -31,3 +31,4 @@ This file is the curriculum shape after the restructure plan has been applied.
 - Section 09 now includes both architecture-pattern and security tracks.
 - Section 10 now includes configuration, observability, deployment, and code-generation tracks alongside logging and shutdown.
 - Code generation is locked into Section 10 because learners usually first meet `go generate` inside Docker and CI workflows before they apply it inside the flagship capstone.
+- `FG` is now a human-facing umbrella for Stage 11, while individual flagship projects use their own prefixes such as `OPSL`.

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -256,10 +256,10 @@
       "summary": "Integrate larger project work into one final proof stage after the production tooling path is already established.",
       "status": "pilot",
       "entry_points": [
-        "FG.1"
+        "OPSL.1"
       ],
       "outputs": [
-        "FG.1"
+        "OPSL.10"
       ],
       "prerequisites": [
         "s10"
@@ -4586,22 +4586,211 @@
       "test_command": "",
       "starter_path": "",
       "next_items": [
-        "FG.1"
+        "OPSL.1"
       ]
     },
     {
-      "id": "FG.1",
+      "id": "OPSL.1",
       "section_id": "s11",
-      "slug": "opslane",
-      "title": "Opslane",
-      "type": "capstone",
+      "slug": "foundation-and-configuration",
+      "title": "Opslane Foundation and Configuration",
+      "type": "checkpoint",
       "subtype": "",
       "level": "production",
       "status": "implemented",
-      "verification_mode": "rubric",
-      "path": "11-flagship/01-opslane",
+      "verification_mode": "mixed",
+      "path": "11-flagship/01-opslane/modules/01-foundation",
       "prerequisites": [
         "CG.3"
+      ],
+      "run_command": "go run ./11-flagship/01-opslane/cmd/server",
+      "test_command": "go test ./11-flagship/01-opslane/internal/config/...",
+      "starter_path": "",
+      "next_items": [
+        "OPSL.2"
+      ]
+    },
+    {
+      "id": "OPSL.2",
+      "section_id": "s11",
+      "slug": "database-and-models",
+      "title": "Opslane Database and Models",
+      "type": "checkpoint",
+      "subtype": "",
+      "level": "production",
+      "status": "implemented",
+      "verification_mode": "test",
+      "path": "11-flagship/01-opslane/modules/02-database",
+      "prerequisites": [
+        "OPSL.1"
+      ],
+      "run_command": "",
+      "test_command": "go test ./11-flagship/01-opslane/internal/db/...",
+      "starter_path": "",
+      "next_items": [
+        "OPSL.3"
+      ]
+    },
+    {
+      "id": "OPSL.3",
+      "section_id": "s11",
+      "slug": "authentication-and-tenant-isolation",
+      "title": "Opslane Authentication and Tenant Isolation",
+      "type": "checkpoint",
+      "subtype": "",
+      "level": "production",
+      "status": "implemented",
+      "verification_mode": "test",
+      "path": "11-flagship/01-opslane/modules/03-auth",
+      "prerequisites": [
+        "OPSL.2"
+      ],
+      "run_command": "",
+      "test_command": "go test ./11-flagship/01-opslane/internal/auth/...",
+      "starter_path": "",
+      "next_items": [
+        "OPSL.4"
+      ]
+    },
+    {
+      "id": "OPSL.4",
+      "section_id": "s11",
+      "slug": "http-api-layer",
+      "title": "Opslane HTTP API Layer",
+      "type": "checkpoint",
+      "subtype": "",
+      "level": "production",
+      "status": "implemented",
+      "verification_mode": "mixed",
+      "path": "11-flagship/01-opslane/modules/04-http-api",
+      "prerequisites": [
+        "OPSL.3"
+      ],
+      "run_command": "go run ./11-flagship/01-opslane/cmd/server",
+      "test_command": "go test ./11-flagship/01-opslane/internal/handlers/... ./11-flagship/01-opslane/internal/middleware/...",
+      "starter_path": "",
+      "next_items": [
+        "OPSL.5"
+      ]
+    },
+    {
+      "id": "OPSL.5",
+      "section_id": "s11",
+      "slug": "order-processing",
+      "title": "Opslane Order Processing",
+      "type": "checkpoint",
+      "subtype": "",
+      "level": "production",
+      "status": "placeholder",
+      "verification_mode": "test",
+      "path": "11-flagship/01-opslane/modules/05-order-processing",
+      "prerequisites": [
+        "OPSL.4"
+      ],
+      "run_command": "",
+      "test_command": "go test ./11-flagship/01-opslane/internal/services/...",
+      "starter_path": "",
+      "next_items": [
+        "OPSL.6"
+      ]
+    },
+    {
+      "id": "OPSL.6",
+      "section_id": "s11",
+      "slug": "payment-pipeline",
+      "title": "Opslane Payment Pipeline",
+      "type": "checkpoint",
+      "subtype": "",
+      "level": "production",
+      "status": "placeholder",
+      "verification_mode": "test",
+      "path": "11-flagship/01-opslane/modules/06-payment-pipeline",
+      "prerequisites": [
+        "OPSL.5"
+      ],
+      "run_command": "",
+      "test_command": "go test ./11-flagship/01-opslane/internal/payment/...",
+      "starter_path": "",
+      "next_items": [
+        "OPSL.7"
+      ]
+    },
+    {
+      "id": "OPSL.7",
+      "section_id": "s11",
+      "slug": "event-bus-and-worker-pools",
+      "title": "Opslane Event Bus and Worker Pools",
+      "type": "checkpoint",
+      "subtype": "",
+      "level": "production",
+      "status": "placeholder",
+      "verification_mode": "test",
+      "path": "11-flagship/01-opslane/modules/07-event-workers",
+      "prerequisites": [
+        "OPSL.6"
+      ],
+      "run_command": "",
+      "test_command": "go test ./11-flagship/01-opslane/internal/events/... ./11-flagship/01-opslane/internal/workers/...",
+      "starter_path": "",
+      "next_items": [
+        "OPSL.8"
+      ]
+    },
+    {
+      "id": "OPSL.8",
+      "section_id": "s11",
+      "slug": "caching-layer",
+      "title": "Opslane Caching Layer",
+      "type": "checkpoint",
+      "subtype": "",
+      "level": "production",
+      "status": "placeholder",
+      "verification_mode": "test",
+      "path": "11-flagship/01-opslane/modules/08-caching",
+      "prerequisites": [
+        "OPSL.7"
+      ],
+      "run_command": "",
+      "test_command": "go test ./11-flagship/01-opslane/internal/cache/...",
+      "starter_path": "",
+      "next_items": [
+        "OPSL.9"
+      ]
+    },
+    {
+      "id": "OPSL.9",
+      "section_id": "s11",
+      "slug": "observability",
+      "title": "Opslane Observability",
+      "type": "checkpoint",
+      "subtype": "",
+      "level": "production",
+      "status": "placeholder",
+      "verification_mode": "test",
+      "path": "11-flagship/01-opslane/modules/09-observability",
+      "prerequisites": [
+        "OPSL.8"
+      ],
+      "run_command": "",
+      "test_command": "go test ./11-flagship/01-opslane/internal/logging/... ./11-flagship/01-opslane/internal/metrics/...",
+      "starter_path": "",
+      "next_items": [
+        "OPSL.10"
+      ]
+    },
+    {
+      "id": "OPSL.10",
+      "section_id": "s11",
+      "slug": "graceful-shutdown-and-deployment",
+      "title": "Opslane Graceful Shutdown and Deployment",
+      "type": "capstone",
+      "subtype": "",
+      "level": "production",
+      "status": "placeholder",
+      "verification_mode": "rubric",
+      "path": "11-flagship/01-opslane/modules/10-shutdown-deploy",
+      "prerequisites": [
+        "OPSL.9"
       ],
       "run_command": "",
       "test_command": "",

--- a/scripts/internal/curriculumvalidator/validator.go
+++ b/scripts/internal/curriculumvalidator/validator.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -75,6 +77,7 @@ type Result struct {
 var runPathPattern = regexp.MustCompile(`\./[A-Za-z0-9._/\-]+`)
 var nextUpIDPattern = regexp.MustCompile(`NEXT UP:\s*([A-Z]{2,6}\.\d+)`)
 var markdownLinkPattern = regexp.MustCompile(`\[[^\]]+\]\(([^)]+)\)`)
+var flagshipPrefixPattern = regexp.MustCompile(`^[A-Z]{3,6}$`)
 
 var (
 	allowedItemTypes = map[string]bool{
@@ -223,6 +226,9 @@ func validateCurriculumPaths(root string, report func(string)) (int, int, error)
 
 func shouldScanRunPaths(path string) bool {
 	if filepath.Ext(path) == ".go" {
+		if strings.HasSuffix(filepath.Base(path), "_test.go") {
+			return false
+		}
 		return true
 	}
 
@@ -532,11 +538,200 @@ func validateV2Curriculum(root string, report func(string)) (int, int, int, int,
 	}
 
 	errorsFound += validateV2LessonNavigation(root, cur.Items, report)
+	errorsFound += validateFlagshipProjects(root, sectionIDs, cur.Items, report)
 	errorsFound += validateV2SectionLabels(root, sectionIDs, cur.Items, report)
 	errorsFound += validateV2TextEncoding(root, sectionIDs, cur.Items, report)
 	errorsFound += validateFoundationsReadmeContracts(root, cur.Items, report)
 
 	return len(cur.Sections), len(cur.Items), placeholderCount, errorsFound, true, nil
+}
+
+func validateFlagshipProjects(root string, sections map[string]V2Section, items []V2Item, report func(string)) int {
+	stage, exists := sections["s11"]
+	if !exists {
+		return 0
+	}
+
+	errorsFound := 0
+	reservedPrefixes := make(map[string]bool)
+	type groupedItem struct {
+		item   V2Item
+		number int
+	}
+
+	projectItems := make(map[string][]groupedItem)
+	projectRoots := make(map[string]string)
+	rootOwners := make(map[string]string)
+
+	for _, item := range items {
+		prefix, _, ok := splitCurriculumID(item.ID)
+		if !ok {
+			continue
+		}
+
+		if item.SectionID != "s11" {
+			reservedPrefixes[prefix] = true
+		}
+	}
+
+	for _, item := range items {
+		prefix, number, ok := splitCurriculumID(item.ID)
+		if !ok || item.SectionID != "s11" {
+			continue
+		}
+
+		if reservedPrefixes[prefix] {
+			report(fmt.Sprintf("Invalid flagship project prefix: %s -> %s is already used outside s11", item.ID, prefix))
+			errorsFound++
+		}
+
+		projectItems[prefix] = append(projectItems[prefix], groupedItem{item: item, number: number})
+
+		projectRoot, ok := flagshipProjectRoot(item.Path)
+		if !ok {
+			report(fmt.Sprintf("Invalid flagship project path: %s -> %s", item.ID, item.Path))
+			errorsFound++
+			continue
+		}
+
+		if existingRoot, exists := projectRoots[prefix]; exists && existingRoot != projectRoot {
+			report(fmt.Sprintf("Invalid flagship project root alignment: %s -> %s and %s", prefix, existingRoot, projectRoot))
+			errorsFound++
+		} else {
+			projectRoots[prefix] = projectRoot
+		}
+
+		if existingPrefix, exists := rootOwners[projectRoot]; exists && existingPrefix != prefix {
+			report(fmt.Sprintf("Invalid flagship project root reuse: %s and %s both map to %s", existingPrefix, prefix, projectRoot))
+			errorsFound++
+		} else {
+			rootOwners[projectRoot] = prefix
+		}
+	}
+
+	if len(stage.EntryPoints) != 1 {
+		report(fmt.Sprintf("Invalid flagship stage contract: s11 requires exactly 1 entry point, found %d", len(stage.EntryPoints)))
+		errorsFound++
+	}
+	if len(stage.Outputs) != 1 {
+		report(fmt.Sprintf("Invalid flagship stage contract: s11 requires exactly 1 output, found %d", len(stage.Outputs)))
+		errorsFound++
+	}
+
+	canonicalPrefix := ""
+	if len(stage.EntryPoints) == 1 {
+		prefix, number, ok := splitCurriculumID(stage.EntryPoints[0])
+		if !ok || number != 1 {
+			report(fmt.Sprintf("Invalid flagship stage entry point: s11 -> %s", stage.EntryPoints[0]))
+			errorsFound++
+		} else {
+			canonicalPrefix = prefix
+		}
+	}
+	if len(stage.Outputs) == 1 {
+		outputPrefix, _, ok := splitCurriculumID(stage.Outputs[0])
+		if !ok {
+			report(fmt.Sprintf("Invalid flagship stage output: s11 -> %s", stage.Outputs[0]))
+			errorsFound++
+		} else if canonicalPrefix != "" && outputPrefix != canonicalPrefix {
+			report(fmt.Sprintf("Invalid flagship stage contract: s11 entry prefix %s does not match output prefix %s", canonicalPrefix, outputPrefix))
+			errorsFound++
+		}
+	}
+
+	for prefix, grouped := range projectItems {
+		if !flagshipPrefixPattern.MatchString(prefix) {
+			report(fmt.Sprintf("Invalid flagship project prefix: %s must be 3-6 uppercase letters", prefix))
+			errorsFound++
+		}
+
+		sort.Slice(grouped, func(i, j int) bool {
+			return grouped[i].number < grouped[j].number
+		})
+
+		for idx, entry := range grouped {
+			expectedNumber := idx + 1
+			if entry.number != expectedNumber {
+				report(fmt.Sprintf("Invalid flagship module numbering: %s expected %s.%d", entry.item.ID, prefix, expectedNumber))
+				errorsFound++
+			}
+		}
+
+		for idx, entry := range grouped {
+			if idx == len(grouped)-1 {
+				if len(entry.item.NextItems) != 0 {
+					report(fmt.Sprintf("Invalid flagship module chain: %s must terminate the project chain", entry.item.ID))
+					errorsFound++
+				}
+				continue
+			}
+
+			expectedNext := grouped[idx+1].item.ID
+			if len(entry.item.NextItems) != 1 || entry.item.NextItems[0] != expectedNext {
+				report(fmt.Sprintf("Invalid flagship module chain: %s must point to %s", entry.item.ID, expectedNext))
+				errorsFound++
+			}
+		}
+
+		projectRoot := projectRoots[prefix]
+		if projectRoot == "" {
+			continue
+		}
+
+		if !pathExists(root, filepath.ToSlash(filepath.Join(projectRoot, "README.md"))) {
+			report(fmt.Sprintf("Missing flagship project README: %s -> %s/README.md", prefix, filepath.ToSlash(projectRoot)))
+			errorsFound++
+		}
+		if !pathExists(root, filepath.ToSlash(filepath.Join(projectRoot, "MODULES.md"))) {
+			report(fmt.Sprintf("Missing flagship project module map: %s -> %s/MODULES.md", prefix, filepath.ToSlash(projectRoot)))
+			errorsFound++
+		}
+
+		implementedProject := false
+		for _, entry := range grouped {
+			if isImplementedItem(entry.item) {
+				implementedProject = true
+				break
+			}
+		}
+		if implementedProject && !pathExists(root, filepath.ToSlash(filepath.Join(projectRoot, "scripts", "progress.go"))) {
+			report(fmt.Sprintf("Missing flagship progress checker: %s -> %s/scripts/progress.go", prefix, filepath.ToSlash(projectRoot)))
+			errorsFound++
+		}
+
+		if canonicalPrefix == prefix && len(stage.Outputs) == 1 {
+			expectedFinal := grouped[len(grouped)-1].item.ID
+			if stage.Outputs[0] != expectedFinal {
+				report(fmt.Sprintf("Invalid flagship stage output: s11 -> %s (expected %s)", stage.Outputs[0], expectedFinal))
+				errorsFound++
+			}
+		}
+	}
+
+	return errorsFound
+}
+
+func splitCurriculumID(id string) (string, int, bool) {
+	prefix, suffix, found := strings.Cut(id, ".")
+	if !found || prefix == "" || suffix == "" {
+		return "", 0, false
+	}
+
+	number, err := strconv.Atoi(suffix)
+	if err != nil {
+		return "", 0, false
+	}
+
+	return prefix, number, true
+}
+
+func flagshipProjectRoot(itemPath string) (string, bool) {
+	parts := strings.Split(filepath.ToSlash(filepath.Clean(itemPath)), "/")
+	if len(parts) < 2 || parts[0] != "11-flagship" {
+		return "", false
+	}
+
+	return filepath.ToSlash(filepath.Join(parts[0], parts[1])), true
 }
 
 func allowedPathPrefixesForSection(section V2Section) []string {

--- a/scripts/internal/curriculumvalidator/validator.go
+++ b/scripts/internal/curriculumvalidator/validator.go
@@ -306,8 +306,9 @@ func validateRunPaths(root string, report func(string)) (int, int, error) {
 					continue
 				}
 
-				target := filepath.Clean(strings.TrimPrefix(match, "./"))
-				alternateTarget := filepath.Clean(filepath.Join(filepath.Dir(cleanPath), strings.TrimPrefix(match, "./")))
+				trimmedMatch := strings.TrimSuffix(match, "/...")
+				target := filepath.Clean(strings.TrimPrefix(trimmedMatch, "./"))
+				alternateTarget := filepath.Clean(filepath.Join(filepath.Dir(cleanPath), strings.TrimPrefix(trimmedMatch, "./")))
 
 				if pathExists(root, target) || pathExists(root, alternateTarget) {
 					continue

--- a/scripts/internal/curriculumvalidator/validator.go
+++ b/scripts/internal/curriculumvalidator/validator.go
@@ -74,7 +74,7 @@ type Result struct {
 	ErrorCount       int
 }
 
-var runPathPattern = regexp.MustCompile(`\./[A-Za-z0-9._/\-]+`)
+var runPathPattern = regexp.MustCompile(`\./[A-Za-z0-9._/\-]+(?:/\.\.\.)?`)
 var nextUpIDPattern = regexp.MustCompile(`NEXT UP:\s*([A-Z]{2,6}\.\d+)`)
 var markdownLinkPattern = regexp.MustCompile(`\[[^\]]+\]\(([^)]+)\)`)
 var flagshipPrefixPattern = regexp.MustCompile(`^[A-Z]{3,6}$`)
@@ -177,18 +177,31 @@ func pathExists(root, path string) bool {
 	return err == nil
 }
 
-func extractCommandTarget(command string) (string, error) {
+func extractCommandTargets(command string) ([]string, error) {
 	command = strings.TrimSpace(command)
 	if command == "" {
-		return "", errors.New("command is empty")
+		return nil, errors.New("command is empty")
 	}
 
-	match := runPathPattern.FindString(command)
-	if match == "" || match == "./..." || isPlaceholderPath(match) {
-		return "", fmt.Errorf("command does not contain a concrete ./path target: %q", command)
+	matches := runPathPattern.FindAllString(command, -1)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("command does not contain a concrete ./path target: %q", command)
 	}
 
-	return filepath.Clean(strings.TrimPrefix(match, "./")), nil
+	targets := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if match == "./..." || isPlaceholderPath(match) {
+			continue
+		}
+		target := strings.TrimSuffix(match, "/...")
+		targets = append(targets, filepath.Clean(strings.TrimPrefix(target, "./")))
+	}
+
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("command does not contain a concrete ./path target: %q", command)
+	}
+
+	return targets, nil
 }
 
 func validateCurriculumPaths(root string, report func(string)) (int, int, error) {
@@ -443,24 +456,34 @@ func validateV2Curriculum(root string, report func(string)) (int, int, int, int,
 		}
 
 		if item.RunCommand != "" {
-			target, err := extractCommandTarget(item.RunCommand)
+			targets, err := extractCommandTargets(item.RunCommand)
 			if err != nil {
 				report(fmt.Sprintf("Invalid v2 run command: %s -> %v", item.ID, err))
 				errorsFound++
-			} else if !pathExists(root, target) {
-				report(fmt.Sprintf("Invalid v2 run command target: %s -> %s", item.ID, item.RunCommand))
-				errorsFound++
+			} else {
+				for _, target := range targets {
+					if !pathExists(root, target) {
+						report(fmt.Sprintf("Invalid v2 run command target: %s -> %s", item.ID, item.RunCommand))
+						errorsFound++
+						break
+					}
+				}
 			}
 		}
 
 		if item.TestCommand != "" {
-			target, err := extractCommandTarget(item.TestCommand)
+			targets, err := extractCommandTargets(item.TestCommand)
 			if err != nil {
 				report(fmt.Sprintf("Invalid v2 test command: %s -> %v", item.ID, err))
 				errorsFound++
-			} else if !pathExists(root, target) {
-				report(fmt.Sprintf("Invalid v2 test command target: %s -> %s", item.ID, item.TestCommand))
-				errorsFound++
+			} else {
+				for _, target := range targets {
+					if !pathExists(root, target) {
+						report(fmt.Sprintf("Invalid v2 test command target: %s -> %s", item.ID, item.TestCommand))
+						errorsFound++
+						break
+					}
+				}
 			}
 		}
 

--- a/scripts/internal/curriculumvalidator/validator_test.go
+++ b/scripts/internal/curriculumvalidator/validator_test.go
@@ -1,6 +1,7 @@
 package curriculumvalidator
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -868,6 +869,333 @@ func TestValidateRejectsFoundationsExerciseMissingVerificationSurface(t *testing
 	if !containsReport(reports, "Invalid foundations README contract: TI.10 -> 04-types-design/10-payroll-processor/README.md missing ## Verification Surface") {
 		t.Fatalf("expected verification-surface error in reports: %v", reports)
 	}
+}
+
+func TestValidateAcceptsFlagshipProjectSplit(t *testing.T) {
+	root := t.TempDir()
+
+	writeValidOpslaneFlagshipFixture(t, root, false)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount != 0 {
+		t.Fatalf("expected 0 validation errors, got %d with reports %v", result.ErrorCount, reports)
+	}
+}
+
+func TestValidateRejectsFlagshipReservedPrefixCollision(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, "curriculum.v2.json", `{
+  "schema_version": 1,
+  "sections": [
+    {
+      "id": "s10",
+      "number": "10",
+      "slug": "production-operations",
+      "title": "Production Operations",
+      "path_prefix": "10-production",
+      "entry_points": ["OPS.5"],
+      "outputs": ["OPS.5"],
+      "prerequisites": []
+    },
+    {
+      "id": "s11",
+      "number": "11",
+      "slug": "flagship",
+      "title": "Flagship",
+      "path_prefix": "11-flagship",
+      "entry_points": ["OPS.1"],
+      "outputs": ["OPS.2"],
+      "prerequisites": ["s10"]
+    }
+  ],
+  "items": [
+    {
+      "id": "OPS.5",
+      "section_id": "s10",
+      "slug": "operations-handoff",
+      "title": "Operations Handoff",
+      "type": "reference",
+      "subtype": "",
+      "level": "production",
+      "status": "implemented",
+      "verification_mode": "rubric",
+      "path": "10-production",
+      "prerequisites": [],
+      "run_command": "",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": []
+    },
+    {
+      "id": "OPS.1",
+      "section_id": "s11",
+      "slug": "foundation",
+      "title": "Reserved Prefix Foundation",
+      "type": "checkpoint",
+      "subtype": "",
+      "level": "production",
+      "status": "implemented",
+      "verification_mode": "test",
+      "path": "11-flagship/01-ops-flagship/modules/01-foundation",
+      "prerequisites": [],
+      "run_command": "",
+      "test_command": "go test ./11-flagship/01-ops-flagship/internal/config/...",
+      "starter_path": "",
+      "next_items": ["OPS.2"]
+    },
+    {
+      "id": "OPS.2",
+      "section_id": "s11",
+      "slug": "database",
+      "title": "Reserved Prefix Database",
+      "type": "capstone",
+      "subtype": "",
+      "level": "production",
+      "status": "implemented",
+      "verification_mode": "rubric",
+      "path": "11-flagship/01-ops-flagship/modules/02-database",
+      "prerequisites": ["OPS.1"],
+      "run_command": "",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": []
+    }
+  ]
+}`)
+
+	mustMkdir(t, root, "10-production")
+	writeFlagshipProjectSurface(t, root, "11-flagship/01-ops-flagship", []string{
+		"modules/01-foundation",
+		"modules/02-database",
+	}, true, true, true)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount == 0 {
+		t.Fatalf("expected a validation error for reserved prefix collision")
+	}
+	if !containsReport(reports, "Invalid flagship project prefix: OPS.1 -> OPS is already used outside s11") {
+		t.Fatalf("expected reserved-prefix error in reports: %v", reports)
+	}
+}
+
+func TestValidateRejectsFlagshipMissingModuleMap(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, "curriculum.v2.json", validOpslaneFlagshipCurriculum(false, false))
+	writeFlagshipProjectSurface(t, root, "11-flagship/01-opslane", opslaneModuleDirs(), false, true, true)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount == 0 {
+		t.Fatalf("expected a validation error for missing MODULES.md")
+	}
+	if !containsReport(reports, "Missing flagship project module map: OPSL -> 11-flagship/01-opslane/MODULES.md") {
+		t.Fatalf("expected missing module map error in reports: %v", reports)
+	}
+}
+
+func TestValidateRejectsFlagshipMissingProgressChecker(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, "curriculum.v2.json", validOpslaneFlagshipCurriculum(false, false))
+	writeFlagshipProjectSurface(t, root, "11-flagship/01-opslane", opslaneModuleDirs(), true, false, true)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount == 0 {
+		t.Fatalf("expected a validation error for missing progress checker")
+	}
+	if !containsReport(reports, "Missing flagship progress checker: OPSL -> 11-flagship/01-opslane/scripts/progress.go") {
+		t.Fatalf("expected missing progress checker error in reports: %v", reports)
+	}
+}
+
+func TestValidateRejectsBrokenFlagshipChain(t *testing.T) {
+	root := t.TempDir()
+
+	writeValidOpslaneFlagshipFixture(t, root, true)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount == 0 {
+		t.Fatalf("expected a validation error for broken flagship chain")
+	}
+	if !containsReport(reports, "Invalid flagship module chain: OPSL.4 must point to OPSL.5") {
+		t.Fatalf("expected broken chain error in reports: %v", reports)
+	}
+}
+
+func TestValidateAcceptsOptionalSecondFlagshipProject(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, "curriculum.v2.json", validOpslaneFlagshipCurriculum(true, false))
+	writeFlagshipProjectSurface(t, root, "11-flagship/01-opslane", opslaneModuleDirs(), true, true, true)
+	writeFlagshipProjectSurface(t, root, "11-flagship/02-crmx", []string{
+		"modules/01-foundation",
+		"modules/02-capstone",
+	}, true, false, false)
+
+	var reports []string
+	result, err := Validate(root, func(message string) {
+		reports = append(reports, message)
+	})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if result.ErrorCount != 0 {
+		t.Fatalf("expected 0 validation errors, got %d with reports %v", result.ErrorCount, reports)
+	}
+}
+
+func writeValidOpslaneFlagshipFixture(t *testing.T, root string, brokenChain bool) {
+	t.Helper()
+
+	writeFile(t, root, "curriculum.v2.json", validOpslaneFlagshipCurriculum(false, brokenChain))
+	writeFlagshipProjectSurface(t, root, "11-flagship/01-opslane", opslaneModuleDirs(), true, true, true)
+}
+
+func validOpslaneFlagshipCurriculum(includeOptionalProject, brokenChain bool) string {
+	opsl4Next := "OPSL.5"
+	if brokenChain {
+		opsl4Next = "OPSL.6"
+	}
+
+	coreItems := []string{
+		flagshipItemJSON("OPSL.1", "s11", "foundation-and-configuration", "Opslane Foundation and Configuration", "checkpoint", "implemented", "mixed", "11-flagship/01-opslane/modules/01-foundation", "", "go run ./11-flagship/01-opslane/cmd/server", "go test ./11-flagship/01-opslane/internal/config/...", "OPSL.2"),
+		flagshipItemJSON("OPSL.2", "s11", "database-and-models", "Opslane Database and Models", "checkpoint", "implemented", "test", "11-flagship/01-opslane/modules/02-database", "OPSL.1", "", "go test ./11-flagship/01-opslane/internal/db/...", "OPSL.3"),
+		flagshipItemJSON("OPSL.3", "s11", "authentication-and-tenant-isolation", "Opslane Authentication and Tenant Isolation", "checkpoint", "implemented", "test", "11-flagship/01-opslane/modules/03-auth", "OPSL.2", "", "go test ./11-flagship/01-opslane/internal/auth/...", "OPSL.4"),
+		flagshipItemJSON("OPSL.4", "s11", "http-api-layer", "Opslane HTTP API Layer", "checkpoint", "implemented", "mixed", "11-flagship/01-opslane/modules/04-http-api", "OPSL.3", "go run ./11-flagship/01-opslane/cmd/server", "go test ./11-flagship/01-opslane/internal/handlers/... ./11-flagship/01-opslane/internal/middleware/...", opsl4Next),
+		flagshipItemJSON("OPSL.5", "s11", "order-processing", "Opslane Order Processing", "checkpoint", "placeholder", "test", "11-flagship/01-opslane/modules/05-order-processing", "OPSL.4", "", "go test ./11-flagship/01-opslane/internal/services/...", "OPSL.6"),
+		flagshipItemJSON("OPSL.6", "s11", "payment-pipeline", "Opslane Payment Pipeline", "checkpoint", "placeholder", "test", "11-flagship/01-opslane/modules/06-payment-pipeline", "OPSL.5", "", "go test ./11-flagship/01-opslane/internal/payment/...", "OPSL.7"),
+		flagshipItemJSON("OPSL.7", "s11", "event-bus-and-worker-pools", "Opslane Event Bus and Worker Pools", "checkpoint", "placeholder", "test", "11-flagship/01-opslane/modules/07-event-workers", "OPSL.6", "", "go test ./11-flagship/01-opslane/internal/events/... ./11-flagship/01-opslane/internal/workers/...", "OPSL.8"),
+		flagshipItemJSON("OPSL.8", "s11", "caching-layer", "Opslane Caching Layer", "checkpoint", "placeholder", "test", "11-flagship/01-opslane/modules/08-caching", "OPSL.7", "", "go test ./11-flagship/01-opslane/internal/cache/...", "OPSL.9"),
+		flagshipItemJSON("OPSL.9", "s11", "observability", "Opslane Observability", "checkpoint", "placeholder", "test", "11-flagship/01-opslane/modules/09-observability", "OPSL.8", "", "go test ./11-flagship/01-opslane/internal/logging/... ./11-flagship/01-opslane/internal/metrics/...", "OPSL.10"),
+		flagshipItemJSON("OPSL.10", "s11", "graceful-shutdown-and-deployment", "Opslane Graceful Shutdown and Deployment", "capstone", "placeholder", "rubric", "11-flagship/01-opslane/modules/10-shutdown-deploy", "OPSL.9", "", "", ""),
+	}
+
+	if includeOptionalProject {
+		coreItems = append(coreItems,
+			flagshipItemJSON("CRMX.1", "s11", "foundation", "CRMX Foundation", "checkpoint", "placeholder", "rubric", "11-flagship/02-crmx/modules/01-foundation", "", "", "", "CRMX.2"),
+			flagshipItemJSON("CRMX.2", "s11", "capstone", "CRMX Capstone", "capstone", "placeholder", "rubric", "11-flagship/02-crmx/modules/02-capstone", "CRMX.1", "", "", ""),
+		)
+	}
+
+	return fmt.Sprintf(`{
+  "schema_version": 1,
+  "sections": [
+    {
+      "id": "s11",
+      "number": "11",
+      "slug": "flagship",
+      "title": "Flagship",
+      "path_prefix": "11-flagship",
+      "entry_points": ["OPSL.1"],
+      "outputs": ["OPSL.10"],
+      "prerequisites": []
+    }
+  ],
+  "items": [
+%s
+  ]
+}`, strings.Join(coreItems, ",\n"))
+}
+
+func flagshipItemJSON(id, sectionID, slug, title, itemType, status, verificationMode, path, prereq, runCommand, testCommand, next string) string {
+	prerequisites := "[]"
+	if prereq != "" {
+		prerequisites = fmt.Sprintf(`["%s"]`, prereq)
+	}
+	nextItems := "[]"
+	if next != "" {
+		nextItems = fmt.Sprintf(`["%s"]`, next)
+	}
+
+	return fmt.Sprintf(`    {
+      "id": "%s",
+      "section_id": "%s",
+      "slug": "%s",
+      "title": "%s",
+      "type": "%s",
+      "subtype": "",
+      "level": "production",
+      "status": "%s",
+      "verification_mode": "%s",
+      "path": "%s",
+      "prerequisites": %s,
+      "run_command": "%s",
+      "test_command": "%s",
+      "starter_path": "",
+      "next_items": %s
+    }`, id, sectionID, slug, title, itemType, status, verificationMode, path, prerequisites, runCommand, testCommand, nextItems)
+}
+
+func opslaneModuleDirs() []string {
+	return []string{
+		"modules/01-foundation",
+		"modules/02-database",
+		"modules/03-auth",
+		"modules/04-http-api",
+		"modules/05-order-processing",
+		"modules/06-payment-pipeline",
+		"modules/07-event-workers",
+		"modules/08-caching",
+		"modules/09-observability",
+		"modules/10-shutdown-deploy",
+	}
+}
+
+func writeFlagshipProjectSurface(t *testing.T, root, projectRoot string, moduleDirs []string, includeModuleMap, includeProgress, includeImplementedTargets bool) {
+	t.Helper()
+
+	writeFile(t, root, filepath.ToSlash(filepath.Join(projectRoot, "README.md")), "# Flagship Project\n")
+	if includeModuleMap {
+		writeFile(t, root, filepath.ToSlash(filepath.Join(projectRoot, "MODULES.md")), "# Module Map\n")
+	}
+	if includeProgress {
+		writeFile(t, root, filepath.ToSlash(filepath.Join(projectRoot, "scripts", "progress.go")), "//go:build ignore\n\npackage main\n\nfunc main() {}\n")
+	}
+	for _, moduleDir := range moduleDirs {
+		writeFile(t, root, filepath.ToSlash(filepath.Join(projectRoot, moduleDir, "README.md")), "# Module\n")
+	}
+	if !includeImplementedTargets {
+		return
+	}
+
+	writeFile(t, root, filepath.ToSlash(filepath.Join(projectRoot, "cmd", "server", "main.go")), "package main\nfunc main() {}\n")
+	writeFile(t, root, filepath.ToSlash(filepath.Join(projectRoot, "internal", "config", "config.go")), "package config\n")
+	writeFile(t, root, filepath.ToSlash(filepath.Join(projectRoot, "internal", "db", "repository.go")), "package db\n")
+	writeFile(t, root, filepath.ToSlash(filepath.Join(projectRoot, "internal", "auth", "service.go")), "package auth\n")
+	writeFile(t, root, filepath.ToSlash(filepath.Join(projectRoot, "internal", "handlers", "handlers.go")), "package handlers\n")
+	writeFile(t, root, filepath.ToSlash(filepath.Join(projectRoot, "internal", "middleware", "middleware.go")), "package middleware\n")
+	writeFile(t, root, ".github/workflows/ci.yml", "name: ci\n")
 }
 
 func validFoundationsLessonReadme(runCommand string) string {


### PR DESCRIPTION
Closes #393

## Summary
- split the Stage 11 flagship path into `OPSL.1` through `OPSL.10`
- add the Opslane learner progress system with `MODULES.md`, module specs, and `scripts/progress.go`
- tighten the curriculum validator so scalable flagship projects are enforced by prefix, root surfaces, and module chain rules

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test ./scripts/internal/curriculumvalidator/...`
- `go run ./scripts/validate_curriculum.go`
- `go run ./11-flagship/01-opslane/scripts/progress.go`