### PR TITLE
[FEAT] implement OPSL.5 order processing for Opslane

### DIFF
--- a/11-flagship/01-opslane/MODULES.md
+++ b/11-flagship/01-opslane/MODULES.md
@@ -26,8 +26,8 @@ This file explains what each module means, what proof looks like, and what comes
 | `OPSL.2` | Database and Models | complete |
 | `OPSL.3` | Authentication and Tenant Isolation | complete |
 | `OPSL.4` | HTTP API Layer | complete |
-| `OPSL.5` | Order Processing | next |
-| `OPSL.6` | Payment Pipeline | locked |
+| `OPSL.5` | Order Processing | complete |
+| `OPSL.6` | Payment Pipeline | next |
 | `OPSL.7` | Event Bus and Worker Pools | locked |
 | `OPSL.8` | Caching Layer | locked |
 | `OPSL.9` | Observability | locked |
@@ -126,11 +126,17 @@ Module spec: [modules/04-http-api/README.md](./modules/04-http-api/README.md)
 
 What you build: the order state machine, validation rules, inventory coordination, and idempotent workflow entry.
 
-Target proof surface once this module is implemented:
+Proof surface:
 
-- `go test` passes for the future `11-flagship/01-opslane/internal/services` package
+```bash
+go test ./11-flagship/01-opslane/internal/services/...
+go test ./11-flagship/01-opslane/internal/handlers/...
+```
+
+Behavior proof:
+
 - order state transition tests prove valid and invalid transitions
-- idempotent order creation does not duplicate work on retries
+- idempotent order creation returns the original order instead of creating duplicates
 
 Required files:
 
@@ -138,9 +144,10 @@ Required files:
 - `internal/services/inventory.go`
 - `internal/services/validation.go`
 
-Read this before starting:
+Read this module:
 
 - [modules/05-order-processing/README.md](./modules/05-order-processing/README.md)
+- [modules/05-order-processing/SURFACE.md](./modules/05-order-processing/SURFACE.md)
 
 ## OPSL.6 Payment Pipeline
 

--- a/11-flagship/01-opslane/README.md
+++ b/11-flagship/01-opslane/README.md
@@ -44,7 +44,8 @@ The current repository state is:
 - `OPSL.2` complete: database and models
 - `OPSL.3` complete: authentication and tenant isolation
 - `OPSL.4` complete: HTTP API layer
-- `OPSL.5` next: order processing
+- `OPSL.5` complete: order processing
+- `OPSL.6` next: payment pipeline
 
 Use the progress surface instead of guessing:
 
@@ -59,19 +60,20 @@ Then use the learner map:
 - [OPSL.2 module spec](./modules/02-database/README.md)
 - [OPSL.3 module spec](./modules/03-auth/README.md)
 - [OPSL.4 module spec](./modules/04-http-api/README.md)
+- [OPSL.5 module spec](./modules/05-order-processing/README.md)
 
-## Module 4 Snapshot
+## Module 5 Snapshot
 
-`OPSL.4` establishes:
+`OPSL.5` establishes:
 
-- public JSON API routes for tenant setup, user setup, and login
-- protected order and payment routes that use authenticated tenant identity
-- consistent JSON error responses
-- CORS and simple in-process rate limiting middleware
+- an explicit order service layer instead of direct handler-to-store writes
+- state transition rules for `pending`, `processing`, `paid`, `failed`, and `cancelled`
+- idempotent order entry that returns the existing order on retry
+- an inventory coordination seam that future payment and worker modules can deepen
 
-This slice turns the auth and persistence foundation into a runnable HTTP contract.
-Protected handlers do not accept tenant IDs from request bodies. They read tenant and user identity
-from verified auth context, then pass that trusted identity into repository calls.
+This slice turns order creation into workflow code.
+The HTTP handler now parses the request and trusted identity, then hands business rules to the
+order service instead of writing straight through to persistence.
 
 ## Run the Project
 
@@ -159,6 +161,5 @@ curl http://localhost:8080/api/v1/orders/1/payments \
 
 ## Next Step
 
-After `OPSL.4`, continue to [OPSL.5](./modules/05-order-processing/README.md).
-That module moves Opslane from CRUD surfaces into explicit business state transitions and
-failure-aware workflows.
+After `OPSL.5`, continue to [OPSL.6](./modules/06-payment-pipeline/README.md).
+That module moves payment handling behind its own reliability-focused workflow boundary.

--- a/11-flagship/01-opslane/cmd/server/main.go
+++ b/11-flagship/01-opslane/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/config"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/handlers"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
 const startupDatabaseTimeout = 10 * time.Second
@@ -55,6 +56,7 @@ func main() {
 	app := &handlers.Application{
 		Logger:            logger,
 		Store:             store,
+		Orders:            services.NewOrderService(store, services.NewNoopInventoryCoordinator()),
 		Tokens:            tokens,
 		ServiceName:       cfg.App.Name,
 		Environment:       cfg.App.Env,

--- a/11-flagship/01-opslane/internal/db/repository.go
+++ b/11-flagship/01-opslane/internal/db/repository.go
@@ -34,6 +34,9 @@ type UserRepository interface {
 
 type OrderRepository interface {
 	CreateOrder(ctx context.Context, order *models.Order) error
+	GetOrderByID(ctx context.Context, tenantID, orderID int64) (models.Order, error)
+	GetOrderByIdempotencyKey(ctx context.Context, tenantID int64, idempotencyKey string) (models.Order, error)
+	UpdateOrderStatus(ctx context.Context, tenantID, orderID int64, status models.OrderStatus) (models.Order, error)
 	ListOrdersByTenant(ctx context.Context, tenantID int64) ([]models.Order, error)
 }
 
@@ -283,6 +286,94 @@ func (s *Store) ListOrdersByTenant(ctx context.Context, tenantID int64) ([]model
 	}
 
 	return orders, nil
+}
+
+func (s *Store) GetOrderByID(ctx context.Context, tenantID, orderID int64) (models.Order, error) {
+	var order models.Order
+
+	err := s.q.QueryRowContext(
+		ctx,
+		`SELECT id, tenant_id, user_id, status, total_cents, currency, idempotency_key, created_at, updated_at
+		 FROM orders
+		 WHERE tenant_id = $1 AND id = $2`,
+		tenantID,
+		orderID,
+	).Scan(
+		&order.ID,
+		&order.TenantID,
+		&order.UserID,
+		&order.Status,
+		&order.TotalCents,
+		&order.Currency,
+		&order.IdempotencyKey,
+		&order.CreatedAt,
+		&order.UpdatedAt,
+	)
+	if err != nil {
+		return models.Order{}, fmt.Errorf("get order by id: %w", err)
+	}
+
+	return order, nil
+}
+
+func (s *Store) GetOrderByIdempotencyKey(ctx context.Context, tenantID int64, idempotencyKey string) (models.Order, error) {
+	var order models.Order
+
+	err := s.q.QueryRowContext(
+		ctx,
+		`SELECT id, tenant_id, user_id, status, total_cents, currency, idempotency_key, created_at, updated_at
+		 FROM orders
+		 WHERE tenant_id = $1 AND idempotency_key = $2`,
+		tenantID,
+		idempotencyKey,
+	).Scan(
+		&order.ID,
+		&order.TenantID,
+		&order.UserID,
+		&order.Status,
+		&order.TotalCents,
+		&order.Currency,
+		&order.IdempotencyKey,
+		&order.CreatedAt,
+		&order.UpdatedAt,
+	)
+	if err != nil {
+		return models.Order{}, fmt.Errorf("get order by idempotency key: %w", err)
+	}
+
+	return order, nil
+}
+
+func (s *Store) UpdateOrderStatus(ctx context.Context, tenantID, orderID int64, status models.OrderStatus) (models.Order, error) {
+	var order models.Order
+	updatedAt := time.Now().UTC()
+
+	err := s.q.QueryRowContext(
+		ctx,
+		`UPDATE orders
+		 SET status = $3, updated_at = $4
+		 WHERE tenant_id = $1 AND id = $2
+		 RETURNING id, tenant_id, user_id, status, total_cents, currency, idempotency_key, created_at, updated_at`,
+		tenantID,
+		orderID,
+		status,
+		updatedAt,
+	).Scan(
+		&order.ID,
+		&order.TenantID,
+		&order.UserID,
+		&order.Status,
+		&order.TotalCents,
+		&order.Currency,
+		&order.IdempotencyKey,
+		&order.CreatedAt,
+		&order.UpdatedAt,
+	)
+	if err != nil {
+		return models.Order{}, fmt.Errorf("update order status: %w", err)
+	}
+
+	return order, nil
 }
 
 func (s *Store) CreatePayment(ctx context.Context, payment *models.Payment) error {

--- a/11-flagship/01-opslane/internal/handlers/api.go
+++ b/11-flagship/01-opslane/internal/handlers/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
 const maxJSONBodySize = 1 << 20
@@ -202,30 +203,36 @@ func (app *Application) handleCreateOrder(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	currency := strings.ToUpper(strings.TrimSpace(req.Currency))
-	if req.TotalCents <= 0 || currency == "" || strings.TrimSpace(req.IdempotencyKey) == "" {
-		app.writeError(w, r, http.StatusBadRequest, "invalid_order", "total_cents, currency, and idempotency_key are required")
+	if app.Orders == nil {
+		app.writeError(w, r, http.StatusInternalServerError, "order_service_unavailable", "order service is not configured")
 		return
 	}
 
-	order := models.Order{
+	result, err := app.Orders.CreateOrder(r.Context(), services.CreateOrderInput{
 		TenantID:       identity.TenantID,
 		UserID:         identity.UserID,
-		Status:         models.OrderStatusPending,
 		TotalCents:     req.TotalCents,
-		Currency:       currency,
-		IdempotencyKey: strings.TrimSpace(req.IdempotencyKey),
-	}
-	if err := app.Store.CreateOrder(r.Context(), &order); err != nil {
-		if errors.Is(err, db.ErrDuplicateValue) {
-			app.writeError(w, r, http.StatusConflict, "duplicate_idempotency_key", "an order with this idempotency_key already exists for this tenant")
-			return
+		Currency:       req.Currency,
+		IdempotencyKey: req.IdempotencyKey,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrInvalidOrder):
+			app.writeError(w, r, http.StatusBadRequest, "invalid_order", "total_cents, currency, and idempotency_key are required")
+		case errors.Is(err, services.ErrInventoryUnavailable):
+			app.writeError(w, r, http.StatusConflict, "inventory_unavailable", "inventory could not be reserved for this order")
+		default:
+			app.writeError(w, r, http.StatusInternalServerError, "order_create_failed", "failed to create order")
 		}
-		app.writeError(w, r, http.StatusInternalServerError, "order_create_failed", "failed to create order")
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, order)
+	statusCode := http.StatusCreated
+	if !result.Created {
+		statusCode = http.StatusOK
+	}
+
+	writeJSON(w, statusCode, result.Order)
 }
 
 func (app *Application) handleCreatePayment(w http.ResponseWriter, r *http.Request) {

--- a/11-flagship/01-opslane/internal/handlers/handlers.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/middleware"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
 const healthDatabaseTimeout = 2 * time.Second
@@ -23,10 +24,15 @@ const apiRateLimitMaxRequests = 120
 type Application struct {
 	Logger            *slog.Logger
 	Store             Store
+	Orders            OrderWorkflow
 	Tokens            *auth.TokenManager
 	ServiceName       string
 	Environment       string
 	TrustedProxyCIDRs []netip.Prefix
+}
+
+type OrderWorkflow interface {
+	CreateOrder(ctx context.Context, input services.CreateOrderInput) (services.CreateOrderResult, error)
 }
 
 type Store interface {
@@ -35,6 +41,9 @@ type Store interface {
 	CreateUser(ctx context.Context, user *models.User) error
 	GetUserByEmail(ctx context.Context, tenantID int64, email string) (models.User, error)
 	CreateOrder(ctx context.Context, order *models.Order) error
+	GetOrderByID(ctx context.Context, tenantID, orderID int64) (models.Order, error)
+	GetOrderByIdempotencyKey(ctx context.Context, tenantID int64, idempotencyKey string) (models.Order, error)
+	UpdateOrderStatus(ctx context.Context, tenantID, orderID int64, status models.OrderStatus) (models.Order, error)
 	ListOrdersByTenant(ctx context.Context, tenantID int64) ([]models.Order, error)
 	CreatePayment(ctx context.Context, payment *models.Payment) error
 	ListPaymentsByOrder(ctx context.Context, tenantID, orderID int64) ([]models.Payment, error)

--- a/11-flagship/01-opslane/internal/handlers/handlers_test.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
 func TestProtectedMeRouteReturnsAuthenticatedTenantIdentity(t *testing.T) {
@@ -318,10 +320,22 @@ func TestCreateOrderUsesAuthenticatedTenantAndUser(t *testing.T) {
 	}
 }
 
-func TestCreateOrderReturnsConflictForDuplicateIdempotencyKey(t *testing.T) {
+func TestCreateOrderReturnsExistingOrderForIdempotentRetry(t *testing.T) {
 	t.Parallel()
 
-	store := &fakeStore{createOrderErr: db.ErrDuplicateValue}
+	store := &fakeStore{
+		orderByIdempotencyKey: models.Order{
+			ID:             101,
+			TenantID:       7,
+			UserID:         42,
+			Status:         models.OrderStatusPending,
+			TotalCents:     2500,
+			Currency:       "USD",
+			IdempotencyKey: "checkout-123",
+			CreatedAt:      time.Now().UTC(),
+			UpdatedAt:      time.Now().UTC(),
+		},
+	}
 	app := newTestApplication(t, store)
 	token := issueHandlerTestToken(t, app.Tokens, auth.Identity{
 		UserID:   42,
@@ -339,17 +353,20 @@ func TestCreateOrderReturnsConflictForDuplicateIdempotencyKey(t *testing.T) {
 
 	app.Routes().ServeHTTP(res, req)
 
-	if res.Code != http.StatusConflict {
-		t.Fatalf("status = %d, want %d", res.Code, http.StatusConflict)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
 	}
 
-	var payload map[string]map[string]string
+	var payload models.Order
 	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
 
-	if payload["error"]["code"] != "duplicate_idempotency_key" {
-		t.Fatalf("error code = %q, want duplicate_idempotency_key", payload["error"]["code"])
+	if payload.ID != 101 {
+		t.Fatalf("order id = %d, want 101", payload.ID)
+	}
+	if store.createOrderCalls != 0 {
+		t.Fatalf("createOrderCalls = %d, want 0", store.createOrderCalls)
 	}
 }
 
@@ -550,6 +567,7 @@ func newTestApplication(t *testing.T, store Store) *Application {
 	return &Application{
 		Logger:      slog.Default(),
 		Store:       store,
+		Orders:      services.NewOrderService(store, services.NewNoopInventoryCoordinator()),
 		Tokens:      newHandlerTestTokenManager(t),
 		ServiceName: "opslane",
 		Environment: "test",
@@ -568,17 +586,24 @@ func issueHandlerTestToken(t *testing.T, tokens *auth.TokenManager, identity aut
 }
 
 type fakeStore struct {
-	createdTenant        models.Tenant
-	createTenantErr      error
-	createdUser          models.User
-	createUserErr        error
-	userByEmail          models.User
-	createdOrder         models.Order
-	createOrderErr       error
-	createdPayment       models.Payment
-	createPaymentErr     error
-	listPaymentsTenantID int64
-	listPaymentsOrderID  int64
+	createdTenant         models.Tenant
+	createTenantErr       error
+	createdUser           models.User
+	createUserErr         error
+	userByEmail           models.User
+	orderByID             models.Order
+	orderByIDErr          error
+	orderByIdempotencyKey models.Order
+	orderByIdempotencyErr error
+	createdOrder          models.Order
+	createOrderCalls      int
+	createOrderErr        error
+	updatedOrder          models.Order
+	updateOrderStatusErr  error
+	createdPayment        models.Payment
+	createPaymentErr      error
+	listPaymentsTenantID  int64
+	listPaymentsOrderID   int64
 }
 
 func (s *fakeStore) Ping(context.Context) error {
@@ -612,6 +637,7 @@ func (s *fakeStore) GetUserByEmail(context.Context, int64, string) (models.User,
 }
 
 func (s *fakeStore) CreateOrder(_ context.Context, order *models.Order) error {
+	s.createOrderCalls++
 	if s.createOrderErr != nil {
 		return s.createOrderErr
 	}
@@ -621,6 +647,39 @@ func (s *fakeStore) CreateOrder(_ context.Context, order *models.Order) error {
 	order.UpdatedAt = order.CreatedAt
 	s.createdOrder = *order
 	return nil
+}
+
+func (s *fakeStore) GetOrderByID(context.Context, int64, int64) (models.Order, error) {
+	if s.orderByIDErr != nil {
+		return models.Order{}, s.orderByIDErr
+	}
+	if s.orderByID.ID == 0 {
+		return models.Order{}, sql.ErrNoRows
+	}
+
+	return s.orderByID, nil
+}
+
+func (s *fakeStore) GetOrderByIdempotencyKey(context.Context, int64, string) (models.Order, error) {
+	if s.orderByIdempotencyErr != nil {
+		return models.Order{}, s.orderByIdempotencyErr
+	}
+	if s.orderByIdempotencyKey.ID == 0 {
+		return models.Order{}, sql.ErrNoRows
+	}
+
+	return s.orderByIdempotencyKey, nil
+}
+
+func (s *fakeStore) UpdateOrderStatus(_ context.Context, _ int64, _ int64, status models.OrderStatus) (models.Order, error) {
+	if s.updateOrderStatusErr != nil {
+		return models.Order{}, s.updateOrderStatusErr
+	}
+
+	s.updatedOrder = s.orderByID
+	s.updatedOrder.Status = status
+	s.updatedOrder.UpdatedAt = time.Now().UTC()
+	return s.updatedOrder, nil
 }
 
 func (s *fakeStore) ListOrdersByTenant(context.Context, int64) ([]models.Order, error) {

--- a/11-flagship/01-opslane/internal/services/inventory.go
+++ b/11-flagship/01-opslane/internal/services/inventory.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package services
+
+import "context"
+
+// InventoryReservation describes the tenant-scoped stock hold the order workflow needs.
+type InventoryReservation struct {
+	TenantID       int64
+	UserID         int64
+	OrderID        int64
+	TotalCents     int64
+	Currency       string
+	IdempotencyKey string
+}
+
+// InventoryCoordinator is the seam between the order workflow and stock reservation behavior.
+type InventoryCoordinator interface {
+	Reserve(ctx context.Context, reservation InventoryReservation) error
+	Release(ctx context.Context, reservation InventoryReservation) error
+}
+
+// NoopInventoryCoordinator keeps Module 5 focused on the workflow boundary before real stock logic exists.
+type NoopInventoryCoordinator struct{}
+
+func NewNoopInventoryCoordinator() NoopInventoryCoordinator {
+	return NoopInventoryCoordinator{}
+}
+
+func (NoopInventoryCoordinator) Reserve(context.Context, InventoryReservation) error {
+	return nil
+}
+
+func (NoopInventoryCoordinator) Release(context.Context, InventoryReservation) error {
+	return nil
+}

--- a/11-flagship/01-opslane/internal/services/inventory.go
+++ b/11-flagship/01-opslane/internal/services/inventory.go
@@ -18,6 +18,9 @@ type InventoryReservation struct {
 // InventoryCoordinator is the seam between the order workflow and stock reservation behavior.
 type InventoryCoordinator interface {
 	Reserve(ctx context.Context, reservation InventoryReservation) error
+	// Release must be safe for cleanup retries on duplicate or idempotent order creation flows.
+	// Future implementations should treat repeat calls for the same reservation identity as
+	// reconciliation, not as a signal to drop the canonical order hold.
 	Release(ctx context.Context, reservation InventoryReservation) error
 }
 

--- a/11-flagship/01-opslane/internal/services/order.go
+++ b/11-flagship/01-opslane/internal/services/order.go
@@ -112,7 +112,9 @@ func (s *OrderService) CreateOrder(ctx context.Context, input CreateOrderInput) 
 			return CreateOrderResult{}, fmt.Errorf("load duplicate order by idempotency key: %w", lookupErr)
 		}
 
-		_ = s.inventory.Release(ctx, reservation)
+		if releaseErr := s.inventory.Release(ctx, reservation); releaseErr != nil {
+			return CreateOrderResult{}, fmt.Errorf("create order: %w; rollback inventory reservation: %w: %v", err, ErrInventoryUnavailable, releaseErr)
+		}
 		return CreateOrderResult{}, fmt.Errorf("create order: %w", err)
 	}
 
@@ -142,13 +144,6 @@ func (s *OrderService) TransitionOrder(ctx context.Context, req TransitionOrderR
 		return models.Order{}, fmt.Errorf("get order by id: %w", err)
 	}
 
-	if current.Status == req.Status {
-		return current, nil
-	}
-	if !canTransitionOrder(current.Status, req.Status) {
-		return models.Order{}, ErrInvalidStatusTransition
-	}
-
 	reservation := InventoryReservation{
 		TenantID:       current.TenantID,
 		UserID:         current.UserID,
@@ -156,6 +151,18 @@ func (s *OrderService) TransitionOrder(ctx context.Context, req TransitionOrderR
 		TotalCents:     current.TotalCents,
 		Currency:       current.Currency,
 		IdempotencyKey: current.IdempotencyKey,
+	}
+
+	if current.Status == req.Status {
+		if shouldRetryReleaseForSameStatus(current.Status) {
+			if err := s.inventory.Release(ctx, reservation); err != nil {
+				return current, fmt.Errorf("release inventory on idempotent terminal transition: %w: %v", ErrInventoryUnavailable, err)
+			}
+		}
+		return current, nil
+	}
+	if !canTransitionOrder(current.Status, req.Status) {
+		return models.Order{}, ErrInvalidStatusTransition
 	}
 
 	if shouldReserveForTransition(current.Status, req.Status) {

--- a/11-flagship/01-opslane/internal/services/order.go
+++ b/11-flagship/01-opslane/internal/services/order.go
@@ -74,6 +74,9 @@ func (s *OrderService) CreateOrder(ctx context.Context, input CreateOrderInput) 
 	existingOrder, err := s.orders.GetOrderByIdempotencyKey(ctx, normalized.TenantID, normalized.IdempotencyKey)
 	switch {
 	case err == nil:
+		if releaseErr := s.inventory.Release(ctx, inventoryReservationFromOrder(existingOrder)); releaseErr != nil {
+			return CreateOrderResult{}, fmt.Errorf("release inventory on idempotent create retry: %w: %v", ErrInventoryUnavailable, releaseErr)
+		}
 		return CreateOrderResult{Order: existingOrder, Created: false}, nil
 	case !errors.Is(err, sql.ErrNoRows):
 		return CreateOrderResult{}, fmt.Errorf("lookup order by idempotency key: %w", err)
@@ -192,4 +195,15 @@ func (s *OrderService) TransitionOrder(ctx context.Context, req TransitionOrderR
 	}
 
 	return updated, nil
+}
+
+func inventoryReservationFromOrder(order models.Order) InventoryReservation {
+	return InventoryReservation{
+		TenantID:       order.TenantID,
+		UserID:         order.UserID,
+		OrderID:        order.ID,
+		TotalCents:     order.TotalCents,
+		Currency:       order.Currency,
+		IdempotencyKey: order.IdempotencyKey,
+	}
 }

--- a/11-flagship/01-opslane/internal/services/order.go
+++ b/11-flagship/01-opslane/internal/services/order.go
@@ -174,7 +174,9 @@ func (s *OrderService) TransitionOrder(ctx context.Context, req TransitionOrderR
 	updated, err := s.orders.UpdateOrderStatus(ctx, req.TenantID, req.OrderID, req.Status)
 	if err != nil {
 		if shouldReserveForTransition(current.Status, req.Status) {
-			_ = s.inventory.Release(ctx, reservation)
+			if releaseErr := s.inventory.Release(ctx, reservation); releaseErr != nil {
+				return models.Order{}, fmt.Errorf("update order status: %w; rollback inventory reservation: %w: %v", err, ErrInventoryUnavailable, releaseErr)
+			}
 		}
 		if errors.Is(err, sql.ErrNoRows) {
 			return models.Order{}, ErrOrderNotFound

--- a/11-flagship/01-opslane/internal/services/order.go
+++ b/11-flagship/01-opslane/internal/services/order.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+)
+
+// OrderRepository is the minimum persistence surface the order workflow needs.
+type OrderRepository interface {
+	CreateOrder(ctx context.Context, order *models.Order) error
+	GetOrderByID(ctx context.Context, tenantID, orderID int64) (models.Order, error)
+	GetOrderByIdempotencyKey(ctx context.Context, tenantID int64, idempotencyKey string) (models.Order, error)
+	UpdateOrderStatus(ctx context.Context, tenantID, orderID int64, status models.OrderStatus) (models.Order, error)
+}
+
+// CreateOrderInput carries the tenant-scoped values required to begin an order workflow.
+type CreateOrderInput struct {
+	TenantID       int64
+	UserID         int64
+	TotalCents     int64
+	Currency       string
+	IdempotencyKey string
+}
+
+// CreateOrderResult differentiates a brand-new order from an idempotent replay.
+type CreateOrderResult struct {
+	Order   models.Order
+	Created bool
+}
+
+// TransitionOrderRequest describes a tenant-scoped order status change.
+type TransitionOrderRequest struct {
+	TenantID int64
+	OrderID  int64
+	Status   models.OrderStatus
+}
+
+// OrderService moves order creation and state changes out of handlers and into business workflow code.
+type OrderService struct {
+	orders    OrderRepository
+	inventory InventoryCoordinator
+}
+
+func NewOrderService(orders OrderRepository, inventory InventoryCoordinator) *OrderService {
+	if inventory == nil {
+		noop := NewNoopInventoryCoordinator()
+		inventory = noop
+	}
+
+	return &OrderService{
+		orders:    orders,
+		inventory: inventory,
+	}
+}
+
+func (s *OrderService) CreateOrder(ctx context.Context, input CreateOrderInput) (CreateOrderResult, error) {
+	if s == nil || s.orders == nil || s.inventory == nil {
+		return CreateOrderResult{}, fmt.Errorf("order service is not configured")
+	}
+
+	normalized, err := normalizeCreateOrderInput(input)
+	if err != nil {
+		return CreateOrderResult{}, err
+	}
+
+	existingOrder, err := s.orders.GetOrderByIdempotencyKey(ctx, normalized.TenantID, normalized.IdempotencyKey)
+	switch {
+	case err == nil:
+		return CreateOrderResult{Order: existingOrder, Created: false}, nil
+	case !errors.Is(err, sql.ErrNoRows):
+		return CreateOrderResult{}, fmt.Errorf("lookup order by idempotency key: %w", err)
+	}
+
+	reservation := InventoryReservation{
+		TenantID:       normalized.TenantID,
+		UserID:         normalized.UserID,
+		TotalCents:     normalized.TotalCents,
+		Currency:       normalized.Currency,
+		IdempotencyKey: normalized.IdempotencyKey,
+	}
+
+	if err := s.inventory.Reserve(ctx, reservation); err != nil {
+		return CreateOrderResult{}, fmt.Errorf("reserve inventory: %w: %v", ErrInventoryUnavailable, err)
+	}
+
+	order := models.Order{
+		TenantID:       normalized.TenantID,
+		UserID:         normalized.UserID,
+		Status:         models.OrderStatusPending,
+		TotalCents:     normalized.TotalCents,
+		Currency:       normalized.Currency,
+		IdempotencyKey: normalized.IdempotencyKey,
+	}
+
+	if err := s.orders.CreateOrder(ctx, &order); err != nil {
+		if errors.Is(err, db.ErrDuplicateValue) {
+			existingOrder, lookupErr := s.orders.GetOrderByIdempotencyKey(ctx, normalized.TenantID, normalized.IdempotencyKey)
+			if releaseErr := s.inventory.Release(ctx, reservation); releaseErr != nil {
+				return CreateOrderResult{}, fmt.Errorf("release inventory after duplicate order: %w: %v", ErrInventoryUnavailable, releaseErr)
+			}
+			if lookupErr == nil {
+				return CreateOrderResult{Order: existingOrder, Created: false}, nil
+			}
+			return CreateOrderResult{}, fmt.Errorf("load duplicate order by idempotency key: %w", lookupErr)
+		}
+
+		_ = s.inventory.Release(ctx, reservation)
+		return CreateOrderResult{}, fmt.Errorf("create order: %w", err)
+	}
+
+	return CreateOrderResult{
+		Order:   order,
+		Created: true,
+	}, nil
+}
+
+func (s *OrderService) TransitionOrder(ctx context.Context, req TransitionOrderRequest) (models.Order, error) {
+	if s == nil || s.orders == nil || s.inventory == nil {
+		return models.Order{}, fmt.Errorf("order service is not configured")
+	}
+
+	if req.TenantID <= 0 || req.OrderID <= 0 {
+		return models.Order{}, ErrInvalidOrder
+	}
+	if err := validateTransitionTarget(req.Status); err != nil {
+		return models.Order{}, err
+	}
+
+	current, err := s.orders.GetOrderByID(ctx, req.TenantID, req.OrderID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return models.Order{}, ErrOrderNotFound
+		}
+		return models.Order{}, fmt.Errorf("get order by id: %w", err)
+	}
+
+	if current.Status == req.Status {
+		return current, nil
+	}
+	if !canTransitionOrder(current.Status, req.Status) {
+		return models.Order{}, ErrInvalidStatusTransition
+	}
+
+	reservation := InventoryReservation{
+		TenantID:       current.TenantID,
+		UserID:         current.UserID,
+		OrderID:        current.ID,
+		TotalCents:     current.TotalCents,
+		Currency:       current.Currency,
+		IdempotencyKey: current.IdempotencyKey,
+	}
+
+	if shouldReserveForTransition(current.Status, req.Status) {
+		if err := s.inventory.Reserve(ctx, reservation); err != nil {
+			return models.Order{}, fmt.Errorf("reserve inventory: %w: %v", ErrInventoryUnavailable, err)
+		}
+	}
+
+	updated, err := s.orders.UpdateOrderStatus(ctx, req.TenantID, req.OrderID, req.Status)
+	if err != nil {
+		if shouldReserveForTransition(current.Status, req.Status) {
+			_ = s.inventory.Release(ctx, reservation)
+		}
+		if errors.Is(err, sql.ErrNoRows) {
+			return models.Order{}, ErrOrderNotFound
+		}
+		return models.Order{}, fmt.Errorf("update order status: %w", err)
+	}
+
+	// Release happens after persistence so the system does not oversell inventory if the DB update fails.
+	if shouldReleaseForTransition(current.Status, req.Status) {
+		if err := s.inventory.Release(ctx, reservation); err != nil {
+			return updated, fmt.Errorf("release inventory: %w: %v", ErrInventoryUnavailable, err)
+		}
+	}
+
+	return updated, nil
+}

--- a/11-flagship/01-opslane/internal/services/order_test.go
+++ b/11-flagship/01-opslane/internal/services/order_test.go
@@ -280,6 +280,50 @@ func TestOrderServiceTransitionOrderReservesInventoryForRetry(t *testing.T) {
 	}
 }
 
+func TestOrderServiceTransitionOrderSurfacesRollbackReleaseFailure(t *testing.T) {
+	t.Parallel()
+
+	updateErr := errors.New("update failed")
+
+	repo := newStubOrderRepository()
+	repo.updateErr = updateErr
+	repo.seedOrder(models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusFailed,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+
+	inventory := &stubInventoryCoordinator{
+		releaseErr: errors.New("release failed"),
+	}
+	service := NewOrderService(repo, inventory)
+
+	_, err := service.TransitionOrder(context.Background(), TransitionOrderRequest{
+		TenantID: 7,
+		OrderID:  101,
+		Status:   models.OrderStatusProcessing,
+	})
+	if err == nil {
+		t.Fatal("TransitionOrder error = nil, want failure")
+	}
+	if !errors.Is(err, updateErr) {
+		t.Fatalf("TransitionOrder error = %v, want wrapped update error", err)
+	}
+	if !errors.Is(err, ErrInventoryUnavailable) {
+		t.Fatalf("TransitionOrder error = %v, want ErrInventoryUnavailable", err)
+	}
+	if len(inventory.reserveCalls) != 1 {
+		t.Fatalf("reserve calls = %d, want 1", len(inventory.reserveCalls))
+	}
+	if len(inventory.releaseCalls) != 1 {
+		t.Fatalf("release calls = %d, want 1", len(inventory.releaseCalls))
+	}
+}
+
 func TestOrderServiceTransitionOrderRetriesReleaseForIdempotentTerminalState(t *testing.T) {
 	t.Parallel()
 

--- a/11-flagship/01-opslane/internal/services/order_test.go
+++ b/11-flagship/01-opslane/internal/services/order_test.go
@@ -86,8 +86,53 @@ func TestOrderServiceCreateOrderReturnsExistingOrderForIdempotentRetry(t *testin
 	if len(inventory.reserveCalls) != 0 {
 		t.Fatalf("reserve calls = %d, want 0", len(inventory.reserveCalls))
 	}
+	if len(inventory.releaseCalls) != 1 {
+		t.Fatalf("release calls = %d, want 1", len(inventory.releaseCalls))
+	}
 	if repo.createCalls != 0 {
 		t.Fatalf("create calls = %d, want 0", repo.createCalls)
+	}
+}
+
+func TestOrderServiceCreateOrderSurfacesReleaseFailureOnIdempotentRetry(t *testing.T) {
+	t.Parallel()
+
+	repo := newStubOrderRepository()
+	repo.ordersByKey[repo.makeKey(7, "checkout-123")] = models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusPending,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}
+
+	inventory := &stubInventoryCoordinator{
+		releaseErr: errors.New("release failed"),
+	}
+	service := NewOrderService(repo, inventory)
+
+	_, err := service.CreateOrder(context.Background(), CreateOrderInput{
+		TenantID:       7,
+		UserID:         42,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+	if err == nil {
+		t.Fatal("CreateOrder error = nil, want failure")
+	}
+	if !errors.Is(err, ErrInventoryUnavailable) {
+		t.Fatalf("CreateOrder error = %v, want ErrInventoryUnavailable", err)
+	}
+	if len(inventory.reserveCalls) != 0 {
+		t.Fatalf("reserve calls = %d, want 0", len(inventory.reserveCalls))
+	}
+	if len(inventory.releaseCalls) != 1 {
+		t.Fatalf("release calls = %d, want 1", len(inventory.releaseCalls))
 	}
 }
 

--- a/11-flagship/01-opslane/internal/services/order_test.go
+++ b/11-flagship/01-opslane/internal/services/order_test.go
@@ -135,6 +135,40 @@ func TestOrderServiceCreateOrderReleasesInventoryAfterDuplicateInsertRace(t *tes
 	}
 }
 
+func TestOrderServiceCreateOrderSurfacesRollbackReleaseFailure(t *testing.T) {
+	t.Parallel()
+
+	createErr := errors.New("insert failed")
+
+	repo := newStubOrderRepository()
+	repo.createErr = createErr
+
+	inventory := &stubInventoryCoordinator{
+		releaseErr: errors.New("release failed"),
+	}
+	service := NewOrderService(repo, inventory)
+
+	_, err := service.CreateOrder(context.Background(), CreateOrderInput{
+		TenantID:       7,
+		UserID:         42,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+	if err == nil {
+		t.Fatal("CreateOrder error = nil, want failure")
+	}
+	if !errors.Is(err, createErr) {
+		t.Fatalf("CreateOrder error = %v, want wrapped create error", err)
+	}
+	if !errors.Is(err, ErrInventoryUnavailable) {
+		t.Fatalf("CreateOrder error = %v, want ErrInventoryUnavailable", err)
+	}
+	if len(inventory.releaseCalls) != 1 {
+		t.Fatalf("release calls = %d, want 1", len(inventory.releaseCalls))
+	}
+}
+
 func TestOrderServiceCreateOrderRejectsInvalidInput(t *testing.T) {
 	t.Parallel()
 
@@ -243,6 +277,39 @@ func TestOrderServiceTransitionOrderReservesInventoryForRetry(t *testing.T) {
 	}
 	if len(inventory.reserveCalls) != 1 {
 		t.Fatalf("reserve calls = %d, want 1", len(inventory.reserveCalls))
+	}
+}
+
+func TestOrderServiceTransitionOrderRetriesReleaseForIdempotentTerminalState(t *testing.T) {
+	t.Parallel()
+
+	repo := newStubOrderRepository()
+	repo.seedOrder(models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusFailed,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+
+	inventory := &stubInventoryCoordinator{}
+	service := NewOrderService(repo, inventory)
+
+	order, err := service.TransitionOrder(context.Background(), TransitionOrderRequest{
+		TenantID: 7,
+		OrderID:  101,
+		Status:   models.OrderStatusFailed,
+	})
+	if err != nil {
+		t.Fatalf("TransitionOrder returned error: %v", err)
+	}
+	if order.Status != models.OrderStatusFailed {
+		t.Fatalf("status = %q, want failed", order.Status)
+	}
+	if len(inventory.releaseCalls) != 1 {
+		t.Fatalf("release calls = %d, want 1", len(inventory.releaseCalls))
 	}
 }
 

--- a/11-flagship/01-opslane/internal/services/order_test.go
+++ b/11-flagship/01-opslane/internal/services/order_test.go
@@ -1,0 +1,342 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+)
+
+func TestOrderServiceCreateOrderCreatesPendingOrderAndReservesInventory(t *testing.T) {
+	t.Parallel()
+
+	repo := newStubOrderRepository()
+	inventory := &stubInventoryCoordinator{}
+	service := NewOrderService(repo, inventory)
+
+	result, err := service.CreateOrder(context.Background(), CreateOrderInput{
+		TenantID:       7,
+		UserID:         42,
+		TotalCents:     2500,
+		Currency:       "usd",
+		IdempotencyKey: " checkout-123 ",
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder returned error: %v", err)
+	}
+
+	if !result.Created {
+		t.Fatal("Created = false, want true")
+	}
+	if result.Order.Status != models.OrderStatusPending {
+		t.Fatalf("status = %q, want pending", result.Order.Status)
+	}
+	if result.Order.Currency != "USD" {
+		t.Fatalf("currency = %q, want USD", result.Order.Currency)
+	}
+	if len(inventory.reserveCalls) != 1 {
+		t.Fatalf("reserve calls = %d, want 1", len(inventory.reserveCalls))
+	}
+	if repo.createCalls != 1 {
+		t.Fatalf("create calls = %d, want 1", repo.createCalls)
+	}
+}
+
+func TestOrderServiceCreateOrderReturnsExistingOrderForIdempotentRetry(t *testing.T) {
+	t.Parallel()
+
+	repo := newStubOrderRepository()
+	repo.ordersByKey[repo.makeKey(7, "checkout-123")] = models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusPending,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}
+
+	inventory := &stubInventoryCoordinator{}
+	service := NewOrderService(repo, inventory)
+
+	result, err := service.CreateOrder(context.Background(), CreateOrderInput{
+		TenantID:       7,
+		UserID:         42,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder returned error: %v", err)
+	}
+
+	if result.Created {
+		t.Fatal("Created = true, want false")
+	}
+	if result.Order.ID != 101 {
+		t.Fatalf("order id = %d, want 101", result.Order.ID)
+	}
+	if len(inventory.reserveCalls) != 0 {
+		t.Fatalf("reserve calls = %d, want 0", len(inventory.reserveCalls))
+	}
+	if repo.createCalls != 0 {
+		t.Fatalf("create calls = %d, want 0", repo.createCalls)
+	}
+}
+
+func TestOrderServiceCreateOrderReleasesInventoryAfterDuplicateInsertRace(t *testing.T) {
+	t.Parallel()
+
+	repo := newStubOrderRepository()
+	repo.createErr = db.ErrDuplicateValue
+	repo.createHook = func(order *models.Order) {
+		repo.seedOrder(models.Order{
+			ID:             101,
+			TenantID:       order.TenantID,
+			UserID:         order.UserID,
+			Status:         models.OrderStatusPending,
+			TotalCents:     order.TotalCents,
+			Currency:       order.Currency,
+			IdempotencyKey: order.IdempotencyKey,
+			CreatedAt:      time.Now().UTC(),
+			UpdatedAt:      time.Now().UTC(),
+		})
+	}
+
+	inventory := &stubInventoryCoordinator{}
+	service := NewOrderService(repo, inventory)
+
+	result, err := service.CreateOrder(context.Background(), CreateOrderInput{
+		TenantID:       7,
+		UserID:         42,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder returned error: %v", err)
+	}
+
+	if result.Created {
+		t.Fatal("Created = true, want false")
+	}
+	if len(inventory.reserveCalls) != 1 {
+		t.Fatalf("reserve calls = %d, want 1", len(inventory.reserveCalls))
+	}
+	if len(inventory.releaseCalls) != 1 {
+		t.Fatalf("release calls = %d, want 1", len(inventory.releaseCalls))
+	}
+}
+
+func TestOrderServiceCreateOrderRejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	service := NewOrderService(newStubOrderRepository(), &stubInventoryCoordinator{})
+
+	_, err := service.CreateOrder(context.Background(), CreateOrderInput{
+		TenantID:       7,
+		UserID:         42,
+		TotalCents:     0,
+		Currency:       "US",
+		IdempotencyKey: "",
+	})
+	if !errors.Is(err, ErrInvalidOrder) {
+		t.Fatalf("CreateOrder error = %v, want ErrInvalidOrder", err)
+	}
+}
+
+func TestOrderServiceTransitionOrderRejectsInvalidStatusMove(t *testing.T) {
+	t.Parallel()
+
+	repo := newStubOrderRepository()
+	repo.seedOrder(models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusPending,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+
+	service := NewOrderService(repo, &stubInventoryCoordinator{})
+
+	_, err := service.TransitionOrder(context.Background(), TransitionOrderRequest{
+		TenantID: 7,
+		OrderID:  101,
+		Status:   models.OrderStatusPaid,
+	})
+	if !errors.Is(err, ErrInvalidStatusTransition) {
+		t.Fatalf("TransitionOrder error = %v, want ErrInvalidStatusTransition", err)
+	}
+}
+
+func TestOrderServiceTransitionOrderReleasesInventoryOnFailure(t *testing.T) {
+	t.Parallel()
+
+	repo := newStubOrderRepository()
+	repo.seedOrder(models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusProcessing,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+
+	inventory := &stubInventoryCoordinator{}
+	service := NewOrderService(repo, inventory)
+
+	order, err := service.TransitionOrder(context.Background(), TransitionOrderRequest{
+		TenantID: 7,
+		OrderID:  101,
+		Status:   models.OrderStatusFailed,
+	})
+	if err != nil {
+		t.Fatalf("TransitionOrder returned error: %v", err)
+	}
+
+	if order.Status != models.OrderStatusFailed {
+		t.Fatalf("status = %q, want failed", order.Status)
+	}
+	if len(inventory.releaseCalls) != 1 {
+		t.Fatalf("release calls = %d, want 1", len(inventory.releaseCalls))
+	}
+}
+
+func TestOrderServiceTransitionOrderReservesInventoryForRetry(t *testing.T) {
+	t.Parallel()
+
+	repo := newStubOrderRepository()
+	repo.seedOrder(models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusFailed,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+
+	inventory := &stubInventoryCoordinator{}
+	service := NewOrderService(repo, inventory)
+
+	order, err := service.TransitionOrder(context.Background(), TransitionOrderRequest{
+		TenantID: 7,
+		OrderID:  101,
+		Status:   models.OrderStatusProcessing,
+	})
+	if err != nil {
+		t.Fatalf("TransitionOrder returned error: %v", err)
+	}
+
+	if order.Status != models.OrderStatusProcessing {
+		t.Fatalf("status = %q, want processing", order.Status)
+	}
+	if len(inventory.reserveCalls) != 1 {
+		t.Fatalf("reserve calls = %d, want 1", len(inventory.reserveCalls))
+	}
+}
+
+type stubOrderRepository struct {
+	ordersByID  map[int64]models.Order
+	ordersByKey map[string]models.Order
+	createErr   error
+	createHook  func(order *models.Order)
+	updateErr   error
+	createCalls int
+	nextOrderID int64
+}
+
+func newStubOrderRepository() *stubOrderRepository {
+	return &stubOrderRepository{
+		ordersByID:  make(map[int64]models.Order),
+		ordersByKey: make(map[string]models.Order),
+		nextOrderID: 101,
+	}
+}
+
+func (r *stubOrderRepository) CreateOrder(_ context.Context, order *models.Order) error {
+	r.createCalls++
+	if r.createHook != nil {
+		r.createHook(order)
+	}
+	if r.createErr != nil {
+		return r.createErr
+	}
+
+	order.ID = r.nextOrderID
+	r.nextOrderID++
+	order.CreatedAt = time.Now().UTC()
+	order.UpdatedAt = order.CreatedAt
+	r.seedOrder(*order)
+	return nil
+}
+
+func (r *stubOrderRepository) GetOrderByID(_ context.Context, tenantID, orderID int64) (models.Order, error) {
+	order, ok := r.ordersByID[orderID]
+	if !ok || order.TenantID != tenantID {
+		return models.Order{}, sql.ErrNoRows
+	}
+
+	return order, nil
+}
+
+func (r *stubOrderRepository) GetOrderByIdempotencyKey(_ context.Context, tenantID int64, idempotencyKey string) (models.Order, error) {
+	order, ok := r.ordersByKey[r.makeKey(tenantID, idempotencyKey)]
+	if !ok {
+		return models.Order{}, sql.ErrNoRows
+	}
+
+	return order, nil
+}
+
+func (r *stubOrderRepository) UpdateOrderStatus(_ context.Context, tenantID, orderID int64, status models.OrderStatus) (models.Order, error) {
+	if r.updateErr != nil {
+		return models.Order{}, r.updateErr
+	}
+
+	order, ok := r.ordersByID[orderID]
+	if !ok || order.TenantID != tenantID {
+		return models.Order{}, sql.ErrNoRows
+	}
+
+	order.Status = status
+	order.UpdatedAt = time.Now().UTC()
+	r.seedOrder(order)
+	return order, nil
+}
+
+func (r *stubOrderRepository) seedOrder(order models.Order) {
+	r.ordersByID[order.ID] = order
+	r.ordersByKey[r.makeKey(order.TenantID, order.IdempotencyKey)] = order
+}
+
+func (r *stubOrderRepository) makeKey(tenantID int64, idempotencyKey string) string {
+	return fmt.Sprintf("%d::%s", tenantID, idempotencyKey)
+}
+
+type stubInventoryCoordinator struct {
+	reserveCalls []InventoryReservation
+	releaseCalls []InventoryReservation
+	reserveErr   error
+	releaseErr   error
+}
+
+func (s *stubInventoryCoordinator) Reserve(_ context.Context, reservation InventoryReservation) error {
+	s.reserveCalls = append(s.reserveCalls, reservation)
+	return s.reserveErr
+}
+
+func (s *stubInventoryCoordinator) Release(_ context.Context, reservation InventoryReservation) error {
+	s.releaseCalls = append(s.releaseCalls, reservation)
+	return s.releaseErr
+}

--- a/11-flagship/01-opslane/internal/services/validation.go
+++ b/11-flagship/01-opslane/internal/services/validation.go
@@ -78,3 +78,7 @@ func shouldReleaseForTransition(current, next models.OrderStatus) bool {
 		return false
 	}
 }
+
+func shouldRetryReleaseForSameStatus(status models.OrderStatus) bool {
+	return status == models.OrderStatusFailed || status == models.OrderStatusCancelled
+}

--- a/11-flagship/01-opslane/internal/services/validation.go
+++ b/11-flagship/01-opslane/internal/services/validation.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package services
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+)
+
+var (
+	ErrInvalidOrder            = errors.New("invalid order")
+	ErrOrderNotFound           = errors.New("order not found")
+	ErrInvalidStatusTransition = errors.New("invalid order status transition")
+	ErrInventoryUnavailable    = errors.New("inventory unavailable")
+)
+
+func normalizeCreateOrderInput(input CreateOrderInput) (CreateOrderInput, error) {
+	input.Currency = strings.ToUpper(strings.TrimSpace(input.Currency))
+	input.IdempotencyKey = strings.TrimSpace(input.IdempotencyKey)
+
+	if input.TenantID <= 0 || input.UserID <= 0 || input.TotalCents <= 0 || input.IdempotencyKey == "" {
+		return CreateOrderInput{}, ErrInvalidOrder
+	}
+
+	if len(input.Currency) != 3 {
+		return CreateOrderInput{}, ErrInvalidOrder
+	}
+
+	return input, nil
+}
+
+func validateTransitionTarget(status models.OrderStatus) error {
+	if !isKnownOrderStatus(status) {
+		return ErrInvalidStatusTransition
+	}
+
+	return nil
+}
+
+func isKnownOrderStatus(status models.OrderStatus) bool {
+	switch status {
+	case models.OrderStatusPending,
+		models.OrderStatusProcessing,
+		models.OrderStatusPaid,
+		models.OrderStatusFailed,
+		models.OrderStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func canTransitionOrder(current, next models.OrderStatus) bool {
+	switch current {
+	case models.OrderStatusPending:
+		return next == models.OrderStatusProcessing || next == models.OrderStatusFailed || next == models.OrderStatusCancelled
+	case models.OrderStatusProcessing:
+		return next == models.OrderStatusPaid || next == models.OrderStatusFailed || next == models.OrderStatusCancelled
+	case models.OrderStatusFailed:
+		return next == models.OrderStatusProcessing || next == models.OrderStatusCancelled
+	default:
+		return false
+	}
+}
+
+func shouldReserveForTransition(current, next models.OrderStatus) bool {
+	return current == models.OrderStatusFailed && next == models.OrderStatusProcessing
+}
+
+func shouldReleaseForTransition(current, next models.OrderStatus) bool {
+	switch current {
+	case models.OrderStatusPending, models.OrderStatusProcessing:
+		return next == models.OrderStatusFailed || next == models.OrderStatusCancelled
+	default:
+		return false
+	}
+}

--- a/11-flagship/01-opslane/modules/05-order-processing/README.md
+++ b/11-flagship/01-opslane/modules/05-order-processing/README.md
@@ -19,15 +19,15 @@ Move Opslane from CRUD-shaped handlers into a real business workflow with explic
 
 ## Proof Surface
 
-This module is not implemented in the current tree yet.
+- `go test ./11-flagship/01-opslane/internal/services/...`
+- state transition tests cover valid and invalid order movement
+- idempotency tests prove retries do not create duplicate orders
 
-When it is complete:
+Implemented code surface:
 
-- `go test` must pass for the future `11-flagship/01-opslane/internal/services` package
-- state transition tests must cover valid and invalid order movement
-- idempotency tests must prove retries do not create duplicate orders
+- [SURFACE.md](./SURFACE.md)
 
-Expected new files:
+Primary files:
 
 - `internal/services/order.go`
 - `internal/services/inventory.go`

--- a/11-flagship/01-opslane/modules/05-order-processing/SURFACE.md
+++ b/11-flagship/01-opslane/modules/05-order-processing/SURFACE.md
@@ -1,0 +1,22 @@
+# OPSL.5 Implemented Code Surface
+
+This module is now implemented in the current tree.
+
+## Primary Code Files
+
+- [`internal/services/order.go`](../../internal/services/order.go)
+- [`internal/services/inventory.go`](../../internal/services/inventory.go)
+- [`internal/services/validation.go`](../../internal/services/validation.go)
+- [`internal/handlers/api.go`](../../internal/handlers/api.go)
+- [`internal/db/repository.go`](../../internal/db/repository.go)
+
+## Proof Commands
+
+```bash
+go test ./11-flagship/01-opslane/internal/services/...
+go test ./11-flagship/01-opslane/internal/handlers/...
+```
+
+## What To Read Next
+
+If you want the current learner map, go back to [MODULES.md](../../MODULES.md).

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -4681,7 +4681,7 @@
       "type": "checkpoint",
       "subtype": "",
       "level": "production",
-      "status": "placeholder",
+      "status": "implemented",
       "verification_mode": "test",
       "path": "11-flagship/01-opslane/modules/05-order-processing",
       "prerequisites": [


### PR DESCRIPTION
## Summary
- implement OPSL.5 with a dedicated order service layer and inventory coordination seam
- add idempotent order workflow handling plus order status transition rules and tests
- promote OPSL.5 to implemented across Opslane learner surfaces and curriculum metadata

## Scope
- Stage: s11
- Module IDs: OPSL.5
- Refs #395

## Validation
- go build ./...
- go vet ./...
- go test ./...
- go run ./scripts/validate_curriculum.go
- go run ./11-flagship/01-opslane/scripts/progress.go