### PR TITLE
feat: implement Opslane OPSL.6 payment pipeline

### DIFF
--- a/11-flagship/01-opslane/MODULES.md
+++ b/11-flagship/01-opslane/MODULES.md
@@ -27,8 +27,8 @@ This file explains what each module means, what proof looks like, and what comes
 | `OPSL.3` | Authentication and Tenant Isolation | complete |
 | `OPSL.4` | HTTP API Layer | complete |
 | `OPSL.5` | Order Processing | complete |
-| `OPSL.6` | Payment Pipeline | next |
-| `OPSL.7` | Event Bus and Worker Pools | locked |
+| `OPSL.6` | Payment Pipeline | complete |
+| `OPSL.7` | Event Bus and Worker Pools | next |
 | `OPSL.8` | Caching Layer | locked |
 | `OPSL.9` | Observability | locked |
 | `OPSL.10` | Graceful Shutdown and Deployment | locked |
@@ -153,11 +153,19 @@ Read this module:
 
 What you build: payment retries, duplicate protection, and reconciliation-safe gateway flow.
 
-Target proof surface once this module is implemented:
+Proof surface:
 
-- `go test` passes for the future `11-flagship/01-opslane/internal/payment` package
-- retry and reconciliation tests prove duplicate protection
-- timeout handling is explicit and bounded
+```bash
+go test ./11-flagship/01-opslane/internal/payment/...
+go test ./11-flagship/01-opslane/internal/services/...
+go test ./11-flagship/01-opslane/internal/handlers/...
+```
+
+Behavior proof:
+
+- gateway timeout tests prove pending payments stay reconciliation-safe
+- duplicate provider references return existing payments instead of creating duplicate charges
+- reconciliation tests prove a delayed success can settle an existing pending payment
 
 Required files:
 
@@ -165,9 +173,10 @@ Required files:
 - `internal/payment/worker.go`
 - `internal/services/payment.go`
 
-Read this before starting:
+Read this module:
 
 - [modules/06-payment-pipeline/README.md](./modules/06-payment-pipeline/README.md)
+- [modules/06-payment-pipeline/SURFACE.md](./modules/06-payment-pipeline/SURFACE.md)
 
 ## OPSL.7 Event Bus and Worker Pools
 

--- a/11-flagship/01-opslane/README.md
+++ b/11-flagship/01-opslane/README.md
@@ -45,7 +45,8 @@ The current repository state is:
 - `OPSL.3` complete: authentication and tenant isolation
 - `OPSL.4` complete: HTTP API layer
 - `OPSL.5` complete: order processing
-- `OPSL.6` next: payment pipeline
+- `OPSL.6` complete: payment pipeline
+- `OPSL.7` next: event bus and worker pools
 
 Use the progress surface instead of guessing:
 
@@ -61,6 +62,7 @@ Then use the learner map:
 - [OPSL.3 module spec](./modules/03-auth/README.md)
 - [OPSL.4 module spec](./modules/04-http-api/README.md)
 - [OPSL.5 module spec](./modules/05-order-processing/README.md)
+- [OPSL.6 module spec](./modules/06-payment-pipeline/README.md)
 
 ## Module 5 Snapshot
 
@@ -74,6 +76,20 @@ Then use the learner map:
 This slice turns order creation into workflow code.
 The HTTP handler now parses the request and trusted identity, then hands business rules to the
 order service instead of writing straight through to persistence.
+
+## Module 6 Snapshot
+
+`OPSL.6` establishes:
+
+- an explicit payment gateway interface
+- a payment worker boundary for queued payment jobs
+- payment service logic for duplicate provider references, retries, and timeouts
+- reconciliation-safe pending payments when the gateway outcome is unknown
+- order workflow integration so settled payments mark orders paid and failed payments mark orders failed
+
+This slice turns payment creation into reliability-focused workflow code.
+The HTTP handler now creates a tenant-scoped payment job and lets the payment service decide how the
+database, gateway, and order state machine should cooperate.
 
 ## Run the Project
 
@@ -161,5 +177,5 @@ curl http://localhost:8080/api/v1/orders/1/payments \
 
 ## Next Step
 
-After `OPSL.5`, continue to [OPSL.6](./modules/06-payment-pipeline/README.md).
-That module moves payment handling behind its own reliability-focused workflow boundary.
+After `OPSL.6`, continue to [OPSL.7](./modules/07-event-workers/README.md).
+That module moves the payment and order workflow work into bounded asynchronous processing.

--- a/11-flagship/01-opslane/cmd/server/main.go
+++ b/11-flagship/01-opslane/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/config"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/handlers"
+	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
@@ -53,10 +54,12 @@ func main() {
 	}
 
 	store := db.NewStore(database)
+	orders := services.NewOrderService(store, services.NewNoopInventoryCoordinator())
 	app := &handlers.Application{
 		Logger:            logger,
 		Store:             store,
-		Orders:            services.NewOrderService(store, services.NewNoopInventoryCoordinator()),
+		Orders:            orders,
+		Payments:          services.NewPaymentService(store, store, orders, paymentflow.NewSimulatedGateway(), services.PaymentServiceOptions{}),
 		Tokens:            tokens,
 		ServiceName:       cfg.App.Name,
 		Environment:       cfg.App.Env,

--- a/11-flagship/01-opslane/internal/db/repository.go
+++ b/11-flagship/01-opslane/internal/db/repository.go
@@ -42,6 +42,8 @@ type OrderRepository interface {
 
 type PaymentRepository interface {
 	CreatePayment(ctx context.Context, payment *models.Payment) error
+	GetPaymentByProviderReference(ctx context.Context, tenantID int64, providerReference string) (models.Payment, error)
+	UpdatePaymentStatus(ctx context.Context, tenantID int64, providerReference string, status models.PaymentStatus, failureReason string) (models.Payment, error)
 	ListPaymentsByOrder(ctx context.Context, tenantID, orderID int64) ([]models.Payment, error)
 }
 
@@ -410,6 +412,67 @@ func (s *Store) CreatePayment(ctx context.Context, payment *models.Payment) erro
 	}
 
 	return nil
+}
+
+func (s *Store) GetPaymentByProviderReference(ctx context.Context, tenantID int64, providerReference string) (models.Payment, error) {
+	var payment models.Payment
+
+	err := s.q.QueryRowContext(
+		ctx,
+		`SELECT id, tenant_id, order_id, status, provider_reference, amount_cents, failure_reason, created_at, updated_at
+		 FROM payments
+		 WHERE tenant_id = $1 AND provider_reference = $2`,
+		tenantID,
+		providerReference,
+	).Scan(
+		&payment.ID,
+		&payment.TenantID,
+		&payment.OrderID,
+		&payment.Status,
+		&payment.ProviderReference,
+		&payment.AmountCents,
+		&payment.FailureReason,
+		&payment.CreatedAt,
+		&payment.UpdatedAt,
+	)
+	if err != nil {
+		return models.Payment{}, fmt.Errorf("get payment by provider reference: %w", err)
+	}
+
+	return payment, nil
+}
+
+func (s *Store) UpdatePaymentStatus(ctx context.Context, tenantID int64, providerReference string, status models.PaymentStatus, failureReason string) (models.Payment, error) {
+	var payment models.Payment
+	updatedAt := time.Now().UTC()
+
+	err := s.q.QueryRowContext(
+		ctx,
+		`UPDATE payments
+		 SET status = $3, failure_reason = $4, updated_at = $5
+		 WHERE tenant_id = $1 AND provider_reference = $2
+		 RETURNING id, tenant_id, order_id, status, provider_reference, amount_cents, failure_reason, created_at, updated_at`,
+		tenantID,
+		providerReference,
+		status,
+		failureReason,
+		updatedAt,
+	).Scan(
+		&payment.ID,
+		&payment.TenantID,
+		&payment.OrderID,
+		&payment.Status,
+		&payment.ProviderReference,
+		&payment.AmountCents,
+		&payment.FailureReason,
+		&payment.CreatedAt,
+		&payment.UpdatedAt,
+	)
+	if err != nil {
+		return models.Payment{}, fmt.Errorf("update payment status: %w", err)
+	}
+
+	return payment, nil
 }
 
 func (s *Store) ListPaymentsByOrder(ctx context.Context, tenantID, orderID int64) ([]models.Payment, error) {

--- a/11-flagship/01-opslane/internal/handlers/api.go
+++ b/11-flagship/01-opslane/internal/handlers/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
@@ -248,37 +249,42 @@ func (app *Application) handleCreatePayment(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	status := req.Status
-	if status == "" {
-		status = models.PaymentStatusPending
-	}
-	if !isAllowedPaymentStatus(status) || req.OrderID <= 0 || req.AmountCents <= 0 || strings.TrimSpace(req.ProviderReference) == "" {
-		app.writeError(w, r, http.StatusBadRequest, "invalid_payment", "order_id, amount_cents, provider_reference, and valid status are required")
+	if req.OrderID <= 0 || req.AmountCents <= 0 || strings.TrimSpace(req.ProviderReference) == "" {
+		app.writeError(w, r, http.StatusBadRequest, "invalid_payment", "order_id, amount_cents, and provider_reference are required")
 		return
 	}
 
-	payment := models.Payment{
+	if app.Payments == nil {
+		app.writeError(w, r, http.StatusInternalServerError, "payment_service_unavailable", "payment service is not configured")
+		return
+	}
+
+	result, err := app.Payments.ProcessPayment(r.Context(), paymentflow.Job{
 		TenantID:          identity.TenantID,
 		OrderID:           req.OrderID,
-		Status:            status,
 		ProviderReference: strings.TrimSpace(req.ProviderReference),
 		AmountCents:       req.AmountCents,
-		FailureReason:     strings.TrimSpace(req.FailureReason),
-	}
-	if err := app.Store.CreatePayment(r.Context(), &payment); err != nil {
-		if errors.Is(err, db.ErrInvalidReference) {
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrInvalidPayment):
+			app.writeError(w, r, http.StatusBadRequest, "invalid_payment", "payment does not match the tenant-scoped order")
+		case errors.Is(err, services.ErrOrderNotFound):
 			app.writeError(w, r, http.StatusNotFound, "order_not_found", "order does not exist for this tenant")
-			return
+		case errors.Is(err, paymentflow.ErrGatewayTimeout), errors.Is(err, paymentflow.ErrGatewayUnavailable):
+			writeJSON(w, http.StatusAccepted, result.Payment)
+		default:
+			app.writeError(w, r, http.StatusInternalServerError, "payment_create_failed", "failed to create payment")
 		}
-		if errors.Is(err, db.ErrDuplicateValue) {
-			app.writeError(w, r, http.StatusConflict, "duplicate_provider_reference", "provider_reference already exists for this tenant")
-			return
-		}
-		app.writeError(w, r, http.StatusInternalServerError, "payment_create_failed", "failed to create payment")
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, payment)
+	statusCode := http.StatusCreated
+	if !result.Created {
+		statusCode = http.StatusOK
+	}
+
+	writeJSON(w, statusCode, result.Payment)
 }
 
 func (app *Application) handleListPaymentsByOrder(w http.ResponseWriter, r *http.Request) {

--- a/11-flagship/01-opslane/internal/handlers/api.go
+++ b/11-flagship/01-opslane/internal/handlers/api.go
@@ -271,6 +271,8 @@ func (app *Application) handleCreatePayment(w http.ResponseWriter, r *http.Reque
 			app.writeError(w, r, http.StatusBadRequest, "invalid_payment", "payment does not match the tenant-scoped order")
 		case errors.Is(err, services.ErrOrderNotFound):
 			app.writeError(w, r, http.StatusNotFound, "order_not_found", "order does not exist for this tenant")
+		case errors.Is(err, services.ErrOrderNotPayable):
+			app.writeError(w, r, http.StatusConflict, "order_not_payable", "order is not in a payable state")
 		case errors.Is(err, paymentflow.ErrGatewayTimeout), errors.Is(err, paymentflow.ErrGatewayUnavailable):
 			writeJSON(w, http.StatusAccepted, result.Payment)
 		default:

--- a/11-flagship/01-opslane/internal/handlers/handlers.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/middleware"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
@@ -25,6 +26,7 @@ type Application struct {
 	Logger            *slog.Logger
 	Store             Store
 	Orders            OrderWorkflow
+	Payments          PaymentWorkflow
 	Tokens            *auth.TokenManager
 	ServiceName       string
 	Environment       string
@@ -33,6 +35,10 @@ type Application struct {
 
 type OrderWorkflow interface {
 	CreateOrder(ctx context.Context, input services.CreateOrderInput) (services.CreateOrderResult, error)
+}
+
+type PaymentWorkflow interface {
+	ProcessPayment(ctx context.Context, job paymentflow.Job) (services.ProcessPaymentResult, error)
 }
 
 type Store interface {
@@ -46,6 +52,8 @@ type Store interface {
 	UpdateOrderStatus(ctx context.Context, tenantID, orderID int64, status models.OrderStatus) (models.Order, error)
 	ListOrdersByTenant(ctx context.Context, tenantID int64) ([]models.Order, error)
 	CreatePayment(ctx context.Context, payment *models.Payment) error
+	GetPaymentByProviderReference(ctx context.Context, tenantID int64, providerReference string) (models.Payment, error)
+	UpdatePaymentStatus(ctx context.Context, tenantID int64, providerReference string, status models.PaymentStatus, failureReason string) (models.Payment, error)
 	ListPaymentsByOrder(ctx context.Context, tenantID, orderID int64) ([]models.Payment, error)
 }
 

--- a/11-flagship/01-opslane/internal/handlers/handlers_test.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
 	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
@@ -412,7 +413,7 @@ func TestHealthRouteBypassesRateLimit(t *testing.T) {
 func TestCreatePaymentUsesAuthenticatedTenant(t *testing.T) {
 	t.Parallel()
 
-	store := &fakeStore{}
+	store := &fakeStore{orderByID: paymentTestOrder()}
 	app := newTestApplication(t, store)
 	token := issueHandlerTestToken(t, app.Tokens, auth.Identity{
 		UserID:   42,
@@ -438,15 +439,15 @@ func TestCreatePaymentUsesAuthenticatedTenant(t *testing.T) {
 		t.Fatalf("payment tenant = %d, want 7", store.createdPayment.TenantID)
 	}
 
-	if store.createdPayment.Status != models.PaymentStatusPending {
-		t.Fatalf("payment status = %q, want pending", store.createdPayment.Status)
+	if store.updatedPayment.Status != models.PaymentStatusSettled {
+		t.Fatalf("payment status = %q, want settled", store.updatedPayment.Status)
 	}
 }
 
 func TestCreatePaymentReturnsNotFoundForInvalidOrder(t *testing.T) {
 	t.Parallel()
 
-	store := &fakeStore{createPaymentErr: db.ErrInvalidReference}
+	store := &fakeStore{}
 	app := newTestApplication(t, store)
 	token := issueHandlerTestToken(t, app.Tokens, auth.Identity{
 		UserID:   42,
@@ -478,10 +479,22 @@ func TestCreatePaymentReturnsNotFoundForInvalidOrder(t *testing.T) {
 	}
 }
 
-func TestCreatePaymentReturnsConflictForDuplicateProviderReference(t *testing.T) {
+func TestCreatePaymentReturnsExistingPaymentForDuplicateProviderReference(t *testing.T) {
 	t.Parallel()
 
-	store := &fakeStore{createPaymentErr: db.ErrDuplicateValue}
+	store := &fakeStore{
+		orderByID: paymentTestOrder(),
+		paymentByReference: models.Payment{
+			ID:                501,
+			TenantID:          7,
+			OrderID:           101,
+			Status:            models.PaymentStatusSettled,
+			ProviderReference: "pay_123",
+			AmountCents:       2500,
+			CreatedAt:         time.Now().UTC(),
+			UpdatedAt:         time.Now().UTC(),
+		},
+	}
 	app := newTestApplication(t, store)
 	token := issueHandlerTestToken(t, app.Tokens, auth.Identity{
 		UserID:   42,
@@ -499,17 +512,17 @@ func TestCreatePaymentReturnsConflictForDuplicateProviderReference(t *testing.T)
 
 	app.Routes().ServeHTTP(res, req)
 
-	if res.Code != http.StatusConflict {
-		t.Fatalf("status = %d, want %d", res.Code, http.StatusConflict)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
 	}
 
-	var payload map[string]map[string]string
+	var payload models.Payment
 	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
 
-	if payload["error"]["code"] != "duplicate_provider_reference" {
-		t.Fatalf("error code = %q, want duplicate_provider_reference", payload["error"]["code"])
+	if payload.ID != 501 {
+		t.Fatalf("payment id = %d, want existing payment 501", payload.ID)
 	}
 }
 
@@ -564,10 +577,12 @@ func newHandlerTestTokenManager(t *testing.T) *auth.TokenManager {
 func newTestApplication(t *testing.T, store Store) *Application {
 	t.Helper()
 
+	orders := services.NewOrderService(store, services.NewNoopInventoryCoordinator())
 	return &Application{
 		Logger:      slog.Default(),
 		Store:       store,
-		Orders:      services.NewOrderService(store, services.NewNoopInventoryCoordinator()),
+		Orders:      orders,
+		Payments:    services.NewPaymentService(store, store, orders, paymentflow.NewSimulatedGateway(), services.PaymentServiceOptions{GatewayTimeout: time.Second, MaxAttempts: 1}),
 		Tokens:      newHandlerTestTokenManager(t),
 		ServiceName: "opslane",
 		Environment: "test",
@@ -586,24 +601,28 @@ func issueHandlerTestToken(t *testing.T, tokens *auth.TokenManager, identity aut
 }
 
 type fakeStore struct {
-	createdTenant         models.Tenant
-	createTenantErr       error
-	createdUser           models.User
-	createUserErr         error
-	userByEmail           models.User
-	orderByID             models.Order
-	orderByIDErr          error
-	orderByIdempotencyKey models.Order
-	orderByIdempotencyErr error
-	createdOrder          models.Order
-	createOrderCalls      int
-	createOrderErr        error
-	updatedOrder          models.Order
-	updateOrderStatusErr  error
-	createdPayment        models.Payment
-	createPaymentErr      error
-	listPaymentsTenantID  int64
-	listPaymentsOrderID   int64
+	createdTenant          models.Tenant
+	createTenantErr        error
+	createdUser            models.User
+	createUserErr          error
+	userByEmail            models.User
+	orderByID              models.Order
+	orderByIDErr           error
+	orderByIdempotencyKey  models.Order
+	orderByIdempotencyErr  error
+	createdOrder           models.Order
+	createOrderCalls       int
+	createOrderErr         error
+	updatedOrder           models.Order
+	updateOrderStatusErr   error
+	createdPayment         models.Payment
+	createPaymentErr       error
+	paymentByReference     models.Payment
+	paymentByReferenceErr  error
+	updatedPayment         models.Payment
+	updatePaymentStatusErr error
+	listPaymentsTenantID   int64
+	listPaymentsOrderID    int64
 }
 
 func (s *fakeStore) Ping(context.Context) error {
@@ -679,6 +698,7 @@ func (s *fakeStore) UpdateOrderStatus(_ context.Context, _ int64, _ int64, statu
 	s.updatedOrder = s.orderByID
 	s.updatedOrder.Status = status
 	s.updatedOrder.UpdatedAt = time.Now().UTC()
+	s.orderByID = s.updatedOrder
 	return s.updatedOrder, nil
 }
 
@@ -698,8 +718,55 @@ func (s *fakeStore) CreatePayment(_ context.Context, payment *models.Payment) er
 	return nil
 }
 
+func (s *fakeStore) GetPaymentByProviderReference(context.Context, int64, string) (models.Payment, error) {
+	if s.paymentByReferenceErr != nil {
+		return models.Payment{}, s.paymentByReferenceErr
+	}
+	if s.paymentByReference.ID == 0 {
+		return models.Payment{}, sql.ErrNoRows
+	}
+
+	return s.paymentByReference, nil
+}
+
+func (s *fakeStore) UpdatePaymentStatus(_ context.Context, tenantID int64, providerReference string, status models.PaymentStatus, failureReason string) (models.Payment, error) {
+	if s.updatePaymentStatusErr != nil {
+		return models.Payment{}, s.updatePaymentStatusErr
+	}
+
+	payment := s.createdPayment
+	if payment.ID == 0 || payment.TenantID != tenantID || payment.ProviderReference != providerReference {
+		payment = s.paymentByReference
+	}
+	if payment.ID == 0 {
+		return models.Payment{}, sql.ErrNoRows
+	}
+
+	payment.Status = status
+	payment.FailureReason = failureReason
+	payment.UpdatedAt = time.Now().UTC()
+	s.updatedPayment = payment
+	s.paymentByReference = payment
+	return payment, nil
+}
+
 func (s *fakeStore) ListPaymentsByOrder(_ context.Context, tenantID, orderID int64) ([]models.Payment, error) {
 	s.listPaymentsTenantID = tenantID
 	s.listPaymentsOrderID = orderID
 	return []models.Payment{s.createdPayment}, nil
+}
+
+func paymentTestOrder() models.Order {
+	now := time.Now().UTC()
+	return models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusPending,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
 }

--- a/11-flagship/01-opslane/internal/payment/gateway.go
+++ b/11-flagship/01-opslane/internal/payment/gateway.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package payment
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+)
+
+var (
+	ErrGatewayTimeout     = errors.New("payment gateway timeout")
+	ErrGatewayUnavailable = errors.New("payment gateway unavailable")
+)
+
+// Job is the tenant-scoped payment work item used by services and workers.
+type Job struct {
+	TenantID          int64
+	OrderID           int64
+	ProviderReference string
+	AmountCents       int64
+}
+
+type GatewayRequest struct {
+	TenantID          int64
+	OrderID           int64
+	ProviderReference string
+	AmountCents       int64
+}
+
+type GatewayResult struct {
+	Status        models.PaymentStatus
+	FailureReason string
+}
+
+type Gateway interface {
+	Charge(ctx context.Context, req GatewayRequest) (GatewayResult, error)
+}
+
+// SimulatedGateway gives the flagship a deterministic gateway boundary before real providers exist.
+type SimulatedGateway struct {
+	Delay         time.Duration
+	Status        models.PaymentStatus
+	FailureReason string
+	Err           error
+}
+
+func NewSimulatedGateway() SimulatedGateway {
+	return SimulatedGateway{
+		Status: models.PaymentStatusSettled,
+	}
+}
+
+func (g SimulatedGateway) Charge(ctx context.Context, _ GatewayRequest) (GatewayResult, error) {
+	if g.Delay > 0 {
+		timer := time.NewTimer(g.Delay)
+		defer timer.Stop()
+
+		select {
+		case <-ctx.Done():
+			return GatewayResult{}, ErrGatewayTimeout
+		case <-timer.C:
+		}
+	}
+
+	if g.Err != nil {
+		return GatewayResult{}, g.Err
+	}
+
+	status := g.Status
+	if status == "" {
+		status = models.PaymentStatusSettled
+	}
+
+	return GatewayResult{
+		Status:        status,
+		FailureReason: g.FailureReason,
+	}, nil
+}

--- a/11-flagship/01-opslane/internal/payment/gateway_test.go
+++ b/11-flagship/01-opslane/internal/payment/gateway_test.go
@@ -1,0 +1,47 @@
+package payment
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+)
+
+func TestSimulatedGatewaySettlesByDefault(t *testing.T) {
+	t.Parallel()
+
+	gateway := NewSimulatedGateway()
+	result, err := gateway.Charge(context.Background(), GatewayRequest{
+		TenantID:          7,
+		OrderID:           101,
+		ProviderReference: "pay_123",
+		AmountCents:       2500,
+	})
+	if err != nil {
+		t.Fatalf("Charge returned error: %v", err)
+	}
+
+	if result.Status != models.PaymentStatusSettled {
+		t.Fatalf("status = %q, want settled", result.Status)
+	}
+}
+
+func TestSimulatedGatewayHonorsContextTimeout(t *testing.T) {
+	t.Parallel()
+
+	gateway := SimulatedGateway{Delay: 50 * time.Millisecond}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	_, err := gateway.Charge(ctx, GatewayRequest{
+		TenantID:          7,
+		OrderID:           101,
+		ProviderReference: "pay_timeout",
+		AmountCents:       2500,
+	})
+	if !errors.Is(err, ErrGatewayTimeout) {
+		t.Fatalf("Charge error = %v, want ErrGatewayTimeout", err)
+	}
+}

--- a/11-flagship/01-opslane/internal/payment/worker.go
+++ b/11-flagship/01-opslane/internal/payment/worker.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package payment
+
+import (
+	"context"
+	"fmt"
+)
+
+// Handler processes one payment job.
+type Handler func(context.Context, Job) error
+
+// Worker consumes tenant-scoped payment jobs until the queue closes or context stops.
+type Worker struct {
+	handler Handler
+	jobs    <-chan Job
+}
+
+func NewWorker(jobs <-chan Job, handler Handler) Worker {
+	return Worker{
+		jobs:    jobs,
+		handler: handler,
+	}
+}
+
+func (w Worker) Run(ctx context.Context) error {
+	if w.handler == nil {
+		return fmt.Errorf("payment worker handler is not configured")
+	}
+	if w.jobs == nil {
+		return fmt.Errorf("payment worker queue is not configured")
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case job, ok := <-w.jobs:
+			if !ok {
+				return nil
+			}
+			if err := w.handler(ctx, job); err != nil {
+				return fmt.Errorf("process payment job: %w", err)
+			}
+		}
+	}
+}

--- a/11-flagship/01-opslane/internal/payment/worker_test.go
+++ b/11-flagship/01-opslane/internal/payment/worker_test.go
@@ -1,0 +1,47 @@
+package payment
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestWorkerProcessesJobsUntilQueueCloses(t *testing.T) {
+	t.Parallel()
+
+	jobs := make(chan Job, 2)
+	jobs <- Job{TenantID: 7, OrderID: 101, ProviderReference: "pay_1", AmountCents: 2500}
+	jobs <- Job{TenantID: 7, OrderID: 102, ProviderReference: "pay_2", AmountCents: 4000}
+	close(jobs)
+
+	processed := 0
+	worker := NewWorker(jobs, func(context.Context, Job) error {
+		processed++
+		return nil
+	})
+
+	if err := worker.Run(context.Background()); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if processed != 2 {
+		t.Fatalf("processed = %d, want 2", processed)
+	}
+}
+
+func TestWorkerReturnsHandlerError(t *testing.T) {
+	t.Parallel()
+
+	handlerErr := errors.New("gateway down")
+	jobs := make(chan Job, 1)
+	jobs <- Job{TenantID: 7, OrderID: 101, ProviderReference: "pay_1", AmountCents: 2500}
+	close(jobs)
+
+	worker := NewWorker(jobs, func(context.Context, Job) error {
+		return handlerErr
+	})
+
+	err := worker.Run(context.Background())
+	if !errors.Is(err, handlerErr) {
+		t.Fatalf("Run error = %v, want handlerErr", err)
+	}
+}

--- a/11-flagship/01-opslane/internal/services/payment.go
+++ b/11-flagship/01-opslane/internal/services/payment.go
@@ -184,6 +184,10 @@ func (s *PaymentService) ReconcilePayment(ctx context.Context, input ReconcilePa
 		return models.Payment{}, fmt.Errorf("cannot downgrade payment from %s to %s", currentPayment.Status, input.Status)
 	}
 
+	if isFinalPaymentStatus(currentPayment.Status) && isFinalPaymentStatus(input.Status) && currentPayment.Status != input.Status {
+		return models.Payment{}, fmt.Errorf("cannot change payment from %s to %s; payment is already in final state", currentPayment.Status, input.Status)
+	}
+
 	updated, err := s.payments.UpdatePaymentStatus(ctx, input.TenantID, input.ProviderReference, input.Status, input.FailureReason)
 	if err != nil {
 		return models.Payment{}, fmt.Errorf("update payment status: %w", err)

--- a/11-flagship/01-opslane/internal/services/payment.go
+++ b/11-flagship/01-opslane/internal/services/payment.go
@@ -117,12 +117,13 @@ func (s *PaymentService) ProcessPayment(ctx context.Context, job paymentflow.Job
 		if !samePaymentTarget(existing, normalized) {
 			return ProcessPaymentResult{}, ErrInvalidPayment
 		}
-		if existing.Status != models.PaymentStatusPending {
-			return ProcessPaymentResult{Payment: existing, Created: false}, nil
-		}
-		return s.chargeGateway(ctx, existing, false)
+		return ProcessPaymentResult{Payment: existing, Created: false}, nil
 	case !errors.Is(err, sql.ErrNoRows):
 		return ProcessPaymentResult{}, fmt.Errorf("lookup payment by provider reference: %w", err)
+	}
+
+	if order.Status != models.OrderStatusPending {
+		return ProcessPaymentResult{}, fmt.Errorf("order is not in a state that accepts new payments: current status %s", order.Status)
 	}
 
 	payment := models.Payment{
@@ -145,10 +146,7 @@ func (s *PaymentService) ProcessPayment(ctx context.Context, job paymentflow.Job
 			if !samePaymentTarget(existing, normalized) {
 				return ProcessPaymentResult{}, ErrInvalidPayment
 			}
-			if existing.Status != models.PaymentStatusPending {
-				return ProcessPaymentResult{Payment: existing, Created: false}, nil
-			}
-			return s.chargeGateway(ctx, existing, false)
+			return ProcessPaymentResult{Payment: existing, Created: false}, nil
 		}
 		return ProcessPaymentResult{}, fmt.Errorf("create payment: %w", err)
 	}

--- a/11-flagship/01-opslane/internal/services/payment.go
+++ b/11-flagship/01-opslane/internal/services/payment.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	ErrInvalidPayment  = errors.New("invalid payment")
-	ErrPaymentNotFound = errors.New("payment not found")
+	ErrInvalidPayment    = errors.New("invalid payment")
+	ErrPaymentNotFound   = errors.New("payment not found")
+	ErrOrderNotPayable   = errors.New("order not in a payable state")
 )
 
 const defaultPaymentGatewayTimeout = 2 * time.Second
@@ -126,7 +127,7 @@ func (s *PaymentService) ProcessPayment(ctx context.Context, job paymentflow.Job
 	}
 
 	if order.Status != models.OrderStatusPending && order.Status != models.OrderStatusFailed {
-		return ProcessPaymentResult{}, fmt.Errorf("order is not in a state that accepts new payments: current status %s", order.Status)
+		return ProcessPaymentResult{}, fmt.Errorf("%w: current status %s", ErrOrderNotPayable, order.Status)
 	}
 
 	payment := models.Payment{
@@ -148,6 +149,9 @@ func (s *PaymentService) ProcessPayment(ctx context.Context, job paymentflow.Job
 			}
 			if !samePaymentTarget(existing, normalized) {
 				return ProcessPaymentResult{}, ErrInvalidPayment
+			}
+			if err := s.syncPaymentToOrder(ctx, existing, order); err != nil {
+				return ProcessPaymentResult{Payment: existing, Created: false}, err
 			}
 			return ProcessPaymentResult{Payment: existing, Created: false}, nil
 		}

--- a/11-flagship/01-opslane/internal/services/payment.go
+++ b/11-flagship/01-opslane/internal/services/payment.go
@@ -117,12 +117,15 @@ func (s *PaymentService) ProcessPayment(ctx context.Context, job paymentflow.Job
 		if !samePaymentTarget(existing, normalized) {
 			return ProcessPaymentResult{}, ErrInvalidPayment
 		}
+		if err := s.syncPaymentToOrder(ctx, existing, order); err != nil {
+			return ProcessPaymentResult{Payment: existing, Created: false}, err
+		}
 		return ProcessPaymentResult{Payment: existing, Created: false}, nil
 	case !errors.Is(err, sql.ErrNoRows):
 		return ProcessPaymentResult{}, fmt.Errorf("lookup payment by provider reference: %w", err)
 	}
 
-	if order.Status != models.OrderStatusPending {
+	if order.Status != models.OrderStatusPending && order.Status != models.OrderStatusFailed {
 		return ProcessPaymentResult{}, fmt.Errorf("order is not in a state that accepts new payments: current status %s", order.Status)
 	}
 
@@ -256,6 +259,46 @@ func (s *PaymentService) applyPaymentStatusToOrder(ctx context.Context, payment 
 	})
 	if err != nil {
 		return fmt.Errorf("apply payment status to order: %w", err)
+	}
+
+	return nil
+}
+
+func (s *PaymentService) syncPaymentToOrder(ctx context.Context, payment models.Payment, order models.Order) error {
+	if payment.Status == models.PaymentStatusPending {
+		return nil
+	}
+
+	desiredOrderStatus := func() models.OrderStatus {
+		switch payment.Status {
+		case models.PaymentStatusSettled:
+			return models.OrderStatusPaid
+		case models.PaymentStatusFailed:
+			return models.OrderStatusFailed
+		default:
+			return ""
+		}
+	}()
+
+	if desiredOrderStatus == "" {
+		return nil
+	}
+
+	if order.Status == desiredOrderStatus {
+		return nil
+	}
+
+	if order.Status != models.OrderStatusProcessing {
+		return nil
+	}
+
+	_, err := s.orderWorkflow.TransitionOrder(ctx, TransitionOrderRequest{
+		TenantID: payment.TenantID,
+		OrderID:  payment.OrderID,
+		Status:   desiredOrderStatus,
+	})
+	if err != nil {
+		return fmt.Errorf("sync payment to order: %w", err)
 	}
 
 	return nil

--- a/11-flagship/01-opslane/internal/services/payment.go
+++ b/11-flagship/01-opslane/internal/services/payment.go
@@ -172,12 +172,16 @@ func (s *PaymentService) ReconcilePayment(ctx context.Context, input ReconcilePa
 		return models.Payment{}, ErrInvalidPayment
 	}
 
-	_, err := s.payments.GetPaymentByProviderReference(ctx, input.TenantID, input.ProviderReference)
+	currentPayment, err := s.payments.GetPaymentByProviderReference(ctx, input.TenantID, input.ProviderReference)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return models.Payment{}, ErrPaymentNotFound
 		}
 		return models.Payment{}, fmt.Errorf("lookup payment by provider reference: %w", err)
+	}
+
+	if isFinalPaymentStatus(currentPayment.Status) && !isFinalPaymentStatus(input.Status) {
+		return models.Payment{}, fmt.Errorf("cannot downgrade payment from %s to %s", currentPayment.Status, input.Status)
 	}
 
 	updated, err := s.payments.UpdatePaymentStatus(ctx, input.TenantID, input.ProviderReference, input.Status, input.FailureReason)
@@ -273,6 +277,11 @@ func (s *PaymentService) syncPaymentToOrder(ctx context.Context, payment models.
 		return nil
 	}
 
+	currentOrder, err := s.orders.GetOrderByID(ctx, payment.TenantID, payment.OrderID)
+	if err != nil {
+		return fmt.Errorf("refresh order for sync: %w", err)
+	}
+
 	desiredOrderStatus := func() models.OrderStatus {
 		switch payment.Status {
 		case models.PaymentStatusSettled:
@@ -288,15 +297,15 @@ func (s *PaymentService) syncPaymentToOrder(ctx context.Context, payment models.
 		return nil
 	}
 
-	if order.Status == desiredOrderStatus {
+	if currentOrder.Status == desiredOrderStatus {
 		return nil
 	}
 
-	if order.Status != models.OrderStatusProcessing {
+	if currentOrder.Status != models.OrderStatusProcessing {
 		return nil
 	}
 
-	_, err := s.orderWorkflow.TransitionOrder(ctx, TransitionOrderRequest{
+	_, err = s.orderWorkflow.TransitionOrder(ctx, TransitionOrderRequest{
 		TenantID: payment.TenantID,
 		OrderID:  payment.OrderID,
 		Status:   desiredOrderStatus,
@@ -349,4 +358,13 @@ func normalizeGatewayError(err error) error {
 		return paymentflow.ErrGatewayUnavailable
 	}
 	return err
+}
+
+func isFinalPaymentStatus(status models.PaymentStatus) bool {
+	switch status {
+	case models.PaymentStatusSettled, models.PaymentStatusFailed, models.PaymentStatusRefunded:
+		return true
+	default:
+		return false
+	}
 }

--- a/11-flagship/01-opslane/internal/services/payment.go
+++ b/11-flagship/01-opslane/internal/services/payment.go
@@ -17,9 +17,9 @@ import (
 )
 
 var (
-	ErrInvalidPayment    = errors.New("invalid payment")
-	ErrPaymentNotFound   = errors.New("payment not found")
-	ErrOrderNotPayable   = errors.New("order not in a payable state")
+	ErrInvalidPayment  = errors.New("invalid payment")
+	ErrPaymentNotFound = errors.New("payment not found")
+	ErrOrderNotPayable = errors.New("order not in a payable state")
 )
 
 const defaultPaymentGatewayTimeout = 2 * time.Second

--- a/11-flagship/01-opslane/internal/services/payment.go
+++ b/11-flagship/01-opslane/internal/services/payment.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
+)
+
+var (
+	ErrInvalidPayment  = errors.New("invalid payment")
+	ErrPaymentNotFound = errors.New("payment not found")
+)
+
+const defaultPaymentGatewayTimeout = 2 * time.Second
+const defaultPaymentAttempts = 2
+
+// PaymentRepository is the persistence surface the payment workflow needs.
+type PaymentRepository interface {
+	CreatePayment(ctx context.Context, payment *models.Payment) error
+	GetPaymentByProviderReference(ctx context.Context, tenantID int64, providerReference string) (models.Payment, error)
+	UpdatePaymentStatus(ctx context.Context, tenantID int64, providerReference string, status models.PaymentStatus, failureReason string) (models.Payment, error)
+}
+
+// PaymentOrderReader lets the payment service validate tenant-scoped order facts.
+type PaymentOrderReader interface {
+	GetOrderByID(ctx context.Context, tenantID, orderID int64) (models.Order, error)
+}
+
+// PaymentOrderWorkflow is the order state machine seam used by payments.
+type PaymentOrderWorkflow interface {
+	TransitionOrder(ctx context.Context, req TransitionOrderRequest) (models.Order, error)
+}
+
+type PaymentServiceOptions struct {
+	GatewayTimeout time.Duration
+	MaxAttempts    int
+}
+
+type ProcessPaymentResult struct {
+	Payment models.Payment
+	Created bool
+}
+
+type ReconcilePaymentInput struct {
+	TenantID          int64
+	ProviderReference string
+	Status            models.PaymentStatus
+	FailureReason     string
+}
+
+// PaymentService owns duplicate protection, gateway calls, and payment-driven order transitions.
+type PaymentService struct {
+	payments      PaymentRepository
+	orders        PaymentOrderReader
+	orderWorkflow PaymentOrderWorkflow
+	gateway       paymentflow.Gateway
+	options       PaymentServiceOptions
+}
+
+func NewPaymentService(
+	payments PaymentRepository,
+	orders PaymentOrderReader,
+	orderWorkflow PaymentOrderWorkflow,
+	gateway paymentflow.Gateway,
+	options PaymentServiceOptions,
+) *PaymentService {
+	if options.GatewayTimeout <= 0 {
+		options.GatewayTimeout = defaultPaymentGatewayTimeout
+	}
+	if options.MaxAttempts <= 0 {
+		options.MaxAttempts = defaultPaymentAttempts
+	}
+
+	return &PaymentService{
+		payments:      payments,
+		orders:        orders,
+		orderWorkflow: orderWorkflow,
+		gateway:       gateway,
+		options:       options,
+	}
+}
+
+func (s *PaymentService) ProcessPayment(ctx context.Context, job paymentflow.Job) (ProcessPaymentResult, error) {
+	if s == nil || s.payments == nil || s.orders == nil || s.orderWorkflow == nil || s.gateway == nil {
+		return ProcessPaymentResult{}, fmt.Errorf("payment service is not configured")
+	}
+
+	normalized, err := normalizePaymentJob(job)
+	if err != nil {
+		return ProcessPaymentResult{}, err
+	}
+
+	order, err := s.orders.GetOrderByID(ctx, normalized.TenantID, normalized.OrderID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ProcessPaymentResult{}, ErrOrderNotFound
+		}
+		return ProcessPaymentResult{}, fmt.Errorf("get payment order: %w", err)
+	}
+	if order.TotalCents != normalized.AmountCents {
+		return ProcessPaymentResult{}, ErrInvalidPayment
+	}
+
+	existing, err := s.payments.GetPaymentByProviderReference(ctx, normalized.TenantID, normalized.ProviderReference)
+	switch {
+	case err == nil:
+		if !samePaymentTarget(existing, normalized) {
+			return ProcessPaymentResult{}, ErrInvalidPayment
+		}
+		if existing.Status != models.PaymentStatusPending {
+			return ProcessPaymentResult{Payment: existing, Created: false}, nil
+		}
+		return s.chargeGateway(ctx, existing, false)
+	case !errors.Is(err, sql.ErrNoRows):
+		return ProcessPaymentResult{}, fmt.Errorf("lookup payment by provider reference: %w", err)
+	}
+
+	payment := models.Payment{
+		TenantID:          normalized.TenantID,
+		OrderID:           normalized.OrderID,
+		Status:            models.PaymentStatusPending,
+		ProviderReference: normalized.ProviderReference,
+		AmountCents:       normalized.AmountCents,
+	}
+
+	if err := s.payments.CreatePayment(ctx, &payment); err != nil {
+		if errors.Is(err, db.ErrInvalidReference) {
+			return ProcessPaymentResult{}, ErrOrderNotFound
+		}
+		if errors.Is(err, db.ErrDuplicateValue) {
+			existing, lookupErr := s.payments.GetPaymentByProviderReference(ctx, normalized.TenantID, normalized.ProviderReference)
+			if lookupErr != nil {
+				return ProcessPaymentResult{}, fmt.Errorf("load duplicate payment by provider reference: %w", lookupErr)
+			}
+			if !samePaymentTarget(existing, normalized) {
+				return ProcessPaymentResult{}, ErrInvalidPayment
+			}
+			if existing.Status != models.PaymentStatusPending {
+				return ProcessPaymentResult{Payment: existing, Created: false}, nil
+			}
+			return s.chargeGateway(ctx, existing, false)
+		}
+		return ProcessPaymentResult{}, fmt.Errorf("create payment: %w", err)
+	}
+
+	return s.chargeGateway(ctx, payment, true)
+}
+
+func (s *PaymentService) ReconcilePayment(ctx context.Context, input ReconcilePaymentInput) (models.Payment, error) {
+	if s == nil || s.payments == nil || s.orderWorkflow == nil {
+		return models.Payment{}, fmt.Errorf("payment service is not configured")
+	}
+
+	input.ProviderReference = strings.TrimSpace(input.ProviderReference)
+	input.FailureReason = strings.TrimSpace(input.FailureReason)
+	if input.TenantID <= 0 || input.ProviderReference == "" || !isKnownPaymentStatus(input.Status) {
+		return models.Payment{}, ErrInvalidPayment
+	}
+
+	_, err := s.payments.GetPaymentByProviderReference(ctx, input.TenantID, input.ProviderReference)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return models.Payment{}, ErrPaymentNotFound
+		}
+		return models.Payment{}, fmt.Errorf("lookup payment by provider reference: %w", err)
+	}
+
+	updated, err := s.payments.UpdatePaymentStatus(ctx, input.TenantID, input.ProviderReference, input.Status, input.FailureReason)
+	if err != nil {
+		return models.Payment{}, fmt.Errorf("update payment status: %w", err)
+	}
+
+	if err := s.applyPaymentStatusToOrder(ctx, updated); err != nil {
+		return updated, err
+	}
+
+	return updated, nil
+}
+
+func (s *PaymentService) chargeGateway(ctx context.Context, current models.Payment, created bool) (ProcessPaymentResult, error) {
+	if err := s.moveOrderToProcessing(ctx, current); err != nil {
+		return ProcessPaymentResult{}, err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < s.options.MaxAttempts; attempt++ {
+		callCtx, cancel := context.WithTimeout(ctx, s.options.GatewayTimeout)
+		result, err := s.gateway.Charge(callCtx, paymentflow.GatewayRequest{
+			TenantID:          current.TenantID,
+			OrderID:           current.OrderID,
+			ProviderReference: current.ProviderReference,
+			AmountCents:       current.AmountCents,
+		})
+		cancel()
+
+		if err == nil {
+			if result.Status == "" {
+				result.Status = models.PaymentStatusSettled
+			}
+			if !isKnownPaymentStatus(result.Status) {
+				return ProcessPaymentResult{}, ErrInvalidPayment
+			}
+
+			updated, err := s.payments.UpdatePaymentStatus(ctx, current.TenantID, current.ProviderReference, result.Status, strings.TrimSpace(result.FailureReason))
+			if err != nil {
+				return ProcessPaymentResult{}, fmt.Errorf("update payment after gateway result: %w", err)
+			}
+			if err := s.applyPaymentStatusToOrder(ctx, updated); err != nil {
+				return ProcessPaymentResult{Payment: updated, Created: created}, err
+			}
+			return ProcessPaymentResult{Payment: updated, Created: created}, nil
+		}
+
+		lastErr = normalizeGatewayError(err)
+	}
+
+	return ProcessPaymentResult{Payment: current, Created: created}, fmt.Errorf("charge payment: %w", lastErr)
+}
+
+func (s *PaymentService) moveOrderToProcessing(ctx context.Context, payment models.Payment) error {
+	_, err := s.orderWorkflow.TransitionOrder(ctx, TransitionOrderRequest{
+		TenantID: payment.TenantID,
+		OrderID:  payment.OrderID,
+		Status:   models.OrderStatusProcessing,
+	})
+	if err != nil {
+		return fmt.Errorf("move order to processing: %w", err)
+	}
+
+	return nil
+}
+
+func (s *PaymentService) applyPaymentStatusToOrder(ctx context.Context, payment models.Payment) error {
+	var target models.OrderStatus
+	switch payment.Status {
+	case models.PaymentStatusSettled:
+		target = models.OrderStatusPaid
+	case models.PaymentStatusFailed:
+		target = models.OrderStatusFailed
+	default:
+		return nil
+	}
+
+	_, err := s.orderWorkflow.TransitionOrder(ctx, TransitionOrderRequest{
+		TenantID: payment.TenantID,
+		OrderID:  payment.OrderID,
+		Status:   target,
+	})
+	if err != nil {
+		return fmt.Errorf("apply payment status to order: %w", err)
+	}
+
+	return nil
+}
+
+func normalizePaymentJob(job paymentflow.Job) (paymentflow.Job, error) {
+	job.ProviderReference = strings.TrimSpace(job.ProviderReference)
+
+	if job.TenantID <= 0 || job.OrderID <= 0 || job.AmountCents <= 0 || job.ProviderReference == "" {
+		return paymentflow.Job{}, ErrInvalidPayment
+	}
+
+	return job, nil
+}
+
+func samePaymentTarget(payment models.Payment, job paymentflow.Job) bool {
+	return payment.TenantID == job.TenantID &&
+		payment.OrderID == job.OrderID &&
+		payment.ProviderReference == job.ProviderReference &&
+		payment.AmountCents == job.AmountCents
+}
+
+func isKnownPaymentStatus(status models.PaymentStatus) bool {
+	switch status {
+	case models.PaymentStatusPending,
+		models.PaymentStatusAuthorized,
+		models.PaymentStatusSettled,
+		models.PaymentStatusFailed,
+		models.PaymentStatusRefunded:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeGatewayError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, paymentflow.ErrGatewayTimeout) {
+		return paymentflow.ErrGatewayTimeout
+	}
+	if errors.Is(err, paymentflow.ErrGatewayUnavailable) {
+		return paymentflow.ErrGatewayUnavailable
+	}
+	return err
+}

--- a/11-flagship/01-opslane/internal/services/payment_test.go
+++ b/11-flagship/01-opslane/internal/services/payment_test.go
@@ -1,0 +1,321 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
+)
+
+func TestPaymentServiceSettlesPaymentAndMarksOrderPaid(t *testing.T) {
+	t.Parallel()
+
+	orders := newStubOrderRepository()
+	orders.seedOrder(models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusPending,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+	payments := newStubPaymentRepository()
+	service := NewPaymentService(payments, orders, NewOrderService(orders, &stubInventoryCoordinator{}), &stubPaymentGateway{
+		results: []paymentflow.GatewayResult{{Status: models.PaymentStatusSettled}},
+	}, PaymentServiceOptions{GatewayTimeout: time.Second, MaxAttempts: 1})
+
+	result, err := service.ProcessPayment(context.Background(), paymentflow.Job{
+		TenantID:          7,
+		OrderID:           101,
+		ProviderReference: "pay_123",
+		AmountCents:       2500,
+	})
+	if err != nil {
+		t.Fatalf("ProcessPayment returned error: %v", err)
+	}
+
+	if !result.Created {
+		t.Fatal("Created = false, want true")
+	}
+	if result.Payment.Status != models.PaymentStatusSettled {
+		t.Fatalf("payment status = %q, want settled", result.Payment.Status)
+	}
+	order, err := orders.GetOrderByID(context.Background(), 7, 101)
+	if err != nil {
+		t.Fatalf("GetOrderByID returned error: %v", err)
+	}
+	if order.Status != models.OrderStatusPaid {
+		t.Fatalf("order status = %q, want paid", order.Status)
+	}
+}
+
+func TestPaymentServiceReturnsExistingPaymentForDuplicateProviderReference(t *testing.T) {
+	t.Parallel()
+
+	orders := newStubOrderRepository()
+	orders.seedOrder(models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusPaid,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+	payments := newStubPaymentRepository()
+	payments.seedPayment(models.Payment{
+		ID:                501,
+		TenantID:          7,
+		OrderID:           101,
+		Status:            models.PaymentStatusSettled,
+		ProviderReference: "pay_123",
+		AmountCents:       2500,
+	})
+	gateway := &stubPaymentGateway{}
+	service := NewPaymentService(payments, orders, NewOrderService(orders, &stubInventoryCoordinator{}), gateway, PaymentServiceOptions{})
+
+	result, err := service.ProcessPayment(context.Background(), paymentflow.Job{
+		TenantID:          7,
+		OrderID:           101,
+		ProviderReference: "pay_123",
+		AmountCents:       2500,
+	})
+	if err != nil {
+		t.Fatalf("ProcessPayment returned error: %v", err)
+	}
+
+	if result.Created {
+		t.Fatal("Created = true, want false")
+	}
+	if result.Payment.ID != 501 {
+		t.Fatalf("payment id = %d, want 501", result.Payment.ID)
+	}
+	if gateway.calls != 0 {
+		t.Fatalf("gateway calls = %d, want 0", gateway.calls)
+	}
+}
+
+func TestPaymentServiceKeepsPendingPaymentWhenGatewayTimesOut(t *testing.T) {
+	t.Parallel()
+
+	orders := newStubOrderRepository()
+	orders.seedOrder(models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusPending,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+	payments := newStubPaymentRepository()
+	service := NewPaymentService(payments, orders, NewOrderService(orders, &stubInventoryCoordinator{}), &stubPaymentGateway{
+		err: paymentflow.ErrGatewayTimeout,
+	}, PaymentServiceOptions{GatewayTimeout: time.Second, MaxAttempts: 1})
+
+	result, err := service.ProcessPayment(context.Background(), paymentflow.Job{
+		TenantID:          7,
+		OrderID:           101,
+		ProviderReference: "pay_timeout",
+		AmountCents:       2500,
+	})
+	if !errors.Is(err, paymentflow.ErrGatewayTimeout) {
+		t.Fatalf("ProcessPayment error = %v, want ErrGatewayTimeout", err)
+	}
+	if result.Payment.Status != models.PaymentStatusPending {
+		t.Fatalf("payment status = %q, want pending", result.Payment.Status)
+	}
+
+	order, err := orders.GetOrderByID(context.Background(), 7, 101)
+	if err != nil {
+		t.Fatalf("GetOrderByID returned error: %v", err)
+	}
+	if order.Status != models.OrderStatusProcessing {
+		t.Fatalf("order status = %q, want processing", order.Status)
+	}
+}
+
+func TestPaymentServiceReconcilePaymentSettlesTimedOutPayment(t *testing.T) {
+	t.Parallel()
+
+	orders := newStubOrderRepository()
+	orders.seedOrder(models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusProcessing,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+	payments := newStubPaymentRepository()
+	payments.seedPayment(models.Payment{
+		ID:                501,
+		TenantID:          7,
+		OrderID:           101,
+		Status:            models.PaymentStatusPending,
+		ProviderReference: "pay_timeout",
+		AmountCents:       2500,
+	})
+	service := NewPaymentService(payments, orders, NewOrderService(orders, &stubInventoryCoordinator{}), &stubPaymentGateway{}, PaymentServiceOptions{})
+
+	updated, err := service.ReconcilePayment(context.Background(), ReconcilePaymentInput{
+		TenantID:          7,
+		ProviderReference: "pay_timeout",
+		Status:            models.PaymentStatusSettled,
+	})
+	if err != nil {
+		t.Fatalf("ReconcilePayment returned error: %v", err)
+	}
+	if updated.Status != models.PaymentStatusSettled {
+		t.Fatalf("payment status = %q, want settled", updated.Status)
+	}
+
+	order, err := orders.GetOrderByID(context.Background(), 7, 101)
+	if err != nil {
+		t.Fatalf("GetOrderByID returned error: %v", err)
+	}
+	if order.Status != models.OrderStatusPaid {
+		t.Fatalf("order status = %q, want paid", order.Status)
+	}
+}
+
+func TestPaymentServiceRejectsProviderReferenceReusedForDifferentOrder(t *testing.T) {
+	t.Parallel()
+
+	orders := newStubOrderRepository()
+	orders.seedOrder(models.Order{
+		ID:             101,
+		TenantID:       7,
+		UserID:         42,
+		Status:         models.OrderStatusPending,
+		TotalCents:     2500,
+		Currency:       "USD",
+		IdempotencyKey: "checkout-123",
+	})
+	payments := newStubPaymentRepository()
+	payments.seedPayment(models.Payment{
+		ID:                501,
+		TenantID:          7,
+		OrderID:           202,
+		Status:            models.PaymentStatusSettled,
+		ProviderReference: "pay_123",
+		AmountCents:       2500,
+	})
+	service := NewPaymentService(payments, orders, NewOrderService(orders, &stubInventoryCoordinator{}), &stubPaymentGateway{}, PaymentServiceOptions{})
+
+	_, err := service.ProcessPayment(context.Background(), paymentflow.Job{
+		TenantID:          7,
+		OrderID:           101,
+		ProviderReference: "pay_123",
+		AmountCents:       2500,
+	})
+	if !errors.Is(err, ErrInvalidPayment) {
+		t.Fatalf("ProcessPayment error = %v, want ErrInvalidPayment", err)
+	}
+}
+
+type stubPaymentGateway struct {
+	results []paymentflow.GatewayResult
+	err     error
+	calls   int
+}
+
+func (g *stubPaymentGateway) Charge(context.Context, paymentflow.GatewayRequest) (paymentflow.GatewayResult, error) {
+	g.calls++
+	if g.err != nil {
+		return paymentflow.GatewayResult{}, g.err
+	}
+	if len(g.results) == 0 {
+		return paymentflow.GatewayResult{Status: models.PaymentStatusSettled}, nil
+	}
+
+	result := g.results[0]
+	g.results = g.results[1:]
+	return result, nil
+}
+
+type stubPaymentRepository struct {
+	payments    map[string]models.Payment
+	nextID      int64
+	createErr   error
+	updateErr   error
+	createCalls int
+	updateCalls int
+}
+
+func newStubPaymentRepository() *stubPaymentRepository {
+	return &stubPaymentRepository{
+		payments: make(map[string]models.Payment),
+		nextID:   501,
+	}
+}
+
+func (r *stubPaymentRepository) CreatePayment(_ context.Context, payment *models.Payment) error {
+	r.createCalls++
+	if r.createErr != nil {
+		return r.createErr
+	}
+
+	key := r.makeKey(payment.TenantID, payment.ProviderReference)
+	if _, ok := r.payments[key]; ok {
+		return db.ErrDuplicateValue
+	}
+
+	payment.ID = r.nextID
+	r.nextID++
+	now := time.Now().UTC()
+	payment.CreatedAt = now
+	payment.UpdatedAt = now
+	r.seedPayment(*payment)
+	return nil
+}
+
+func (r *stubPaymentRepository) GetPaymentByProviderReference(_ context.Context, tenantID int64, providerReference string) (models.Payment, error) {
+	payment, ok := r.payments[r.makeKey(tenantID, providerReference)]
+	if !ok {
+		return models.Payment{}, sql.ErrNoRows
+	}
+
+	return payment, nil
+}
+
+func (r *stubPaymentRepository) UpdatePaymentStatus(_ context.Context, tenantID int64, providerReference string, status models.PaymentStatus, failureReason string) (models.Payment, error) {
+	r.updateCalls++
+	if r.updateErr != nil {
+		return models.Payment{}, r.updateErr
+	}
+
+	key := r.makeKey(tenantID, providerReference)
+	payment, ok := r.payments[key]
+	if !ok {
+		return models.Payment{}, sql.ErrNoRows
+	}
+
+	payment.Status = status
+	payment.FailureReason = failureReason
+	payment.UpdatedAt = time.Now().UTC()
+	r.seedPayment(payment)
+	return payment, nil
+}
+
+func (r *stubPaymentRepository) seedPayment(payment models.Payment) {
+	if payment.CreatedAt.IsZero() {
+		payment.CreatedAt = time.Now().UTC()
+	}
+	if payment.UpdatedAt.IsZero() {
+		payment.UpdatedAt = payment.CreatedAt
+	}
+	r.payments[r.makeKey(payment.TenantID, payment.ProviderReference)] = payment
+}
+
+func (r *stubPaymentRepository) makeKey(tenantID int64, providerReference string) string {
+	return fmt.Sprintf("%d::%s", tenantID, providerReference)
+}

--- a/11-flagship/01-opslane/modules/06-payment-pipeline/README.md
+++ b/11-flagship/01-opslane/modules/06-payment-pipeline/README.md
@@ -19,24 +19,96 @@ Model payment work as a reliability problem, not just another insert statement.
 
 ## Proof Surface
 
-This module is not implemented in the current tree yet.
+This module is implemented in the current tree.
 
-When it is complete:
+Run:
 
-- `go test` must pass for the future `internal/payment` package
-- payment workflow tests must prove retries and duplicate protection
-- reconciliation tests must cover missing callback and timeout scenarios
+```bash
+go test ./11-flagship/01-opslane/internal/payment/...
+go test ./11-flagship/01-opslane/internal/services/...
+go test ./11-flagship/01-opslane/internal/handlers/...
+go run ./11-flagship/01-opslane/scripts/progress.go
+```
 
-Expected new files:
+The proof surface now covers:
+
+- gateway timeout behavior
+- worker job processing boundaries
+- provider-reference duplicate protection
+- payment reconciliation after a pending/timeout case
+- HTTP handler integration through the payment service
+
+Implemented files:
 
 - `internal/payment/gateway.go`
 - `internal/payment/worker.go`
 - `internal/services/payment.go`
 
+Implementation map: [SURFACE.md](./SURFACE.md)
+
 ## Required Files and Boundaries
 
 Keep gateway behavior behind an explicit boundary.
 Do not scatter payment retry logic across handlers and repositories.
+
+## Machine View
+
+The learner-facing request is small:
+
+```text
+POST /api/v1/payments
+```
+
+Behind that request the machine now does more work:
+
+```text
+handler
+  -> reads trusted tenant identity from auth middleware
+  -> builds payment.Job
+  -> calls PaymentService
+
+PaymentService
+  -> checks tenant-scoped order exists
+  -> creates one pending payment row
+  -> moves order to processing
+  -> calls gateway through a timeout context
+  -> updates payment status
+  -> moves order to paid or failed when gateway result is final
+```
+
+The important idea is that the handler does not decide gateway, retry, or order-state rules.
+It only translates HTTP into a workflow request.
+
+## Diagram
+
+```text
+Client request
+    |
+    v
+HTTP handler
+    |
+    v
+PaymentService
+    |
+    +--> payments table: pending row
+    |
+    +--> OrderService: pending -> processing
+    |
+    +--> Gateway: charge with timeout
+    |
+    +--> payments table: settled/failed
+    |
+    +--> OrderService: processing -> paid/failed
+```
+
+## Try It
+
+Change the simulated gateway in a test from `settled` to `failed`.
+Observe that the payment status changes to `failed` and the order transitions to `failed`.
+
+Then change the gateway to return `ErrGatewayTimeout`.
+Observe that the payment stays `pending` and the order stays `processing`, because the system does
+not know whether the external provider eventually charged the customer.
 
 ## Engineering Questions
 

--- a/11-flagship/01-opslane/modules/06-payment-pipeline/SURFACE.md
+++ b/11-flagship/01-opslane/modules/06-payment-pipeline/SURFACE.md
@@ -1,0 +1,33 @@
+# OPSL.6 Implemented Code Surface
+
+This module is now implemented in the current tree.
+
+## Primary Code Files
+
+- [`internal/payment/gateway.go`](../../internal/payment/gateway.go)
+- [`internal/payment/worker.go`](../../internal/payment/worker.go)
+- [`internal/services/payment.go`](../../internal/services/payment.go)
+- [`internal/handlers/api.go`](../../internal/handlers/api.go)
+- [`internal/handlers/handlers.go`](../../internal/handlers/handlers.go)
+- [`internal/db/repository.go`](../../internal/db/repository.go)
+
+## Proof Commands
+
+```bash
+go test ./11-flagship/01-opslane/internal/payment/...
+go test ./11-flagship/01-opslane/internal/services/...
+go test ./11-flagship/01-opslane/internal/handlers/...
+go run ./11-flagship/01-opslane/scripts/progress.go
+```
+
+## What This Proves
+
+- payment gateway behavior is behind an explicit interface
+- worker processing has a bounded queue boundary
+- duplicate `provider_reference` values do not double-charge
+- timeout outcomes stay pending for reconciliation
+- settled and failed payments move the order workflow intentionally
+
+## What To Read Next
+
+If you want the current learner map, go back to [MODULES.md](../../MODULES.md).

--- a/11-flagship/01-opslane/scripts/progress.go
+++ b/11-flagship/01-opslane/scripts/progress.go
@@ -109,6 +109,8 @@ var modules = []moduleSpec{
 		title: "Payment Pipeline",
 		testPkgs: []string{
 			"./internal/payment/...",
+			"./internal/services/...",
+			"./internal/handlers/...",
 		},
 		requiredFiles: []string{
 			"internal/payment/gateway.go",
@@ -116,7 +118,7 @@ var modules = []moduleSpec{
 			"internal/services/payment.go",
 		},
 		readmeDir: "modules/06-payment-pipeline",
-		nextStep:  "Add payment workflow boundaries after OPSL.5 is provable.",
+		nextStep:  "Continue into OPSL.7 after payment retries and reconciliation are provable.",
 	},
 	{
 		id:    "OPSL.7",

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -4702,14 +4702,14 @@
       "type": "checkpoint",
       "subtype": "",
       "level": "production",
-      "status": "placeholder",
+      "status": "implemented",
       "verification_mode": "test",
       "path": "11-flagship/01-opslane/modules/06-payment-pipeline",
       "prerequisites": [
         "OPSL.5"
       ],
       "run_command": "",
-      "test_command": "go test ./11-flagship/01-opslane/internal/payment/...",
+      "test_command": "go test ./11-flagship/01-opslane/internal/payment/... ./11-flagship/01-opslane/internal/services/... ./11-flagship/01-opslane/internal/handlers/...",
       "starter_path": "",
       "next_items": [
         "OPSL.7"


### PR DESCRIPTION
## Summary

Implements Opslane `OPSL.6` as the payment pipeline module.

- Adds `internal/payment` gateway and worker boundaries.
- Adds `PaymentService` for duplicate provider-reference protection, bounded gateway timeout/retry behavior, and reconciliation.
- Wires payment creation through the service layer instead of direct handler-to-store writes.
- Extends repository lookup/update methods for tenant-scoped payment status updates.
- Updates Opslane module docs, progress checker, and `curriculum.v2.json` so `OPSL.6` is implemented and `OPSL.7` becomes current.

Closes #384

## Verification

- `go test ./11-flagship/01-opslane/internal/payment/...`
- `go test ./11-flagship/01-opslane/internal/services/...`
- `go test ./11-flagship/01-opslane/internal/handlers/...`
- `go test ./11-flagship/01-opslane/...`
- `go run ./11-flagship/01-opslane/scripts/progress.go`
- `go run ./scripts/validate_curriculum.go`
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `git diff --check`

Note: local `go build ./...` exited successfully but printed a Windows module-cache stat warning for `C:\Users\Rasel\go\pkg\mod\cache`; CI should use a clean runner cache.