### PR TITLE
feat: implement Opslane OPSL.7 event workers

### DIFF
--- a/11-flagship/01-opslane/MODULES.md
+++ b/11-flagship/01-opslane/MODULES.md
@@ -28,8 +28,8 @@ This file explains what each module means, what proof looks like, and what comes
 | `OPSL.4` | HTTP API Layer | complete |
 | `OPSL.5` | Order Processing | complete |
 | `OPSL.6` | Payment Pipeline | complete |
-| `OPSL.7` | Event Bus and Worker Pools | next |
-| `OPSL.8` | Caching Layer | locked |
+| `OPSL.7` | Event Bus and Worker Pools | complete |
+| `OPSL.8` | Caching Layer | next |
 | `OPSL.9` | Observability | locked |
 | `OPSL.10` | Graceful Shutdown and Deployment | locked |
 
@@ -182,11 +182,18 @@ Read this module:
 
 What you build: bounded asynchronous work, observable worker lifecycle, and queue-pressure handling.
 
-Target proof surface once this module is implemented:
+Proof surface:
 
-- `go test` passes for the future `internal/events` and `internal/workers` packages
-- pool saturation tests prove backpressure behavior
-- shutdown tests prove workers drain or stop intentionally
+```bash
+go test ./11-flagship/01-opslane/internal/events/...
+go test ./11-flagship/01-opslane/internal/workers/...
+```
+
+Behavior proof:
+
+- event bus tests prove bounded publish behavior and closed-bus handling
+- worker pool tests prove queue saturation, drain behavior, and handler error reporting
+- processor tests prove order, payment, and notification adapters call explicit workflow seams
 
 Required files:
 
@@ -197,9 +204,10 @@ Required files:
 - `internal/workers/payment_processor.go`
 - `internal/workers/notification_worker.go`
 
-Read this before starting:
+Read this module:
 
 - [modules/07-event-workers/README.md](./modules/07-event-workers/README.md)
+- [modules/07-event-workers/SURFACE.md](./modules/07-event-workers/SURFACE.md)
 
 ## OPSL.8 Caching Layer
 

--- a/11-flagship/01-opslane/README.md
+++ b/11-flagship/01-opslane/README.md
@@ -46,7 +46,8 @@ The current repository state is:
 - `OPSL.4` complete: HTTP API layer
 - `OPSL.5` complete: order processing
 - `OPSL.6` complete: payment pipeline
-- `OPSL.7` next: event bus and worker pools
+- `OPSL.7` complete: event bus and worker pools
+- `OPSL.8` next: caching layer
 
 Use the progress surface instead of guessing:
 
@@ -63,6 +64,7 @@ Then use the learner map:
 - [OPSL.4 module spec](./modules/04-http-api/README.md)
 - [OPSL.5 module spec](./modules/05-order-processing/README.md)
 - [OPSL.6 module spec](./modules/06-payment-pipeline/README.md)
+- [OPSL.7 module spec](./modules/07-event-workers/README.md)
 
 ## Module 5 Snapshot
 
@@ -90,6 +92,19 @@ order service instead of writing straight through to persistence.
 This slice turns payment creation into reliability-focused workflow code.
 The HTTP handler now creates a tenant-scoped payment job and lets the payment service decide how the
 database, gateway, and order state machine should cooperate.
+
+## Module 7 Snapshot
+
+`OPSL.7` establishes:
+
+- a bounded event bus with explicit queue-full behavior
+- a fixed-size worker pool that drains submitted work
+- order, payment, and notification processors behind workflow interfaces
+- error callbacks so background failures do not disappear
+
+This slice introduces asynchronous building blocks without hiding goroutines inside handlers.
+The system can now talk about queue capacity, backpressure, and safe draining before later modules
+wire those primitives into caching, observability, and shutdown behavior.
 
 ## Run the Project
 
@@ -177,5 +192,5 @@ curl http://localhost:8080/api/v1/orders/1/payments \
 
 ## Next Step
 
-After `OPSL.6`, continue to [OPSL.7](./modules/07-event-workers/README.md).
-That module moves the payment and order workflow work into bounded asynchronous processing.
+After `OPSL.7`, continue to [OPSL.8](./modules/08-caching/README.md).
+That module introduces bounded cache behavior on top of the now-explicit event and worker seams.

--- a/11-flagship/01-opslane/internal/events/bus.go
+++ b/11-flagship/01-opslane/internal/events/bus.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+var (
+	ErrInvalidEvent = errors.New("invalid event")
+	ErrQueueFull    = errors.New("event queue full")
+	ErrBusClosed    = errors.New("event bus closed")
+)
+
+type Bus struct {
+	mu     sync.RWMutex
+	events chan Event
+	closed bool
+	now    func() time.Time
+}
+
+func NewBus(capacity int) *Bus {
+	if capacity <= 0 {
+		capacity = 1
+	}
+
+	return &Bus{
+		events: make(chan Event, capacity),
+		now:    time.Now,
+	}
+}
+
+func (b *Bus) Subscribe() <-chan Event {
+	if b == nil {
+		return nil
+	}
+
+	return b.events
+}
+
+func (b *Bus) TryPublish(event Event) error {
+	if b == nil {
+		return fmt.Errorf("event bus is not configured")
+	}
+
+	event, err := b.prepare(event)
+	if err != nil {
+		return err
+	}
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if b.closed {
+		return ErrBusClosed
+	}
+
+	select {
+	case b.events <- event:
+		return nil
+	default:
+		return ErrQueueFull
+	}
+}
+
+func (b *Bus) Publish(ctx context.Context, event Event) error {
+	if b == nil {
+		return fmt.Errorf("event bus is not configured")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	event, err := b.prepare(event)
+	if err != nil {
+		return err
+	}
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if b.closed {
+		return ErrBusClosed
+	}
+
+	select {
+	case b.events <- event:
+		return nil
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return ErrQueueFull
+	}
+}
+
+func (b *Bus) Close() {
+	if b == nil {
+		return
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return
+	}
+
+	b.closed = true
+	close(b.events)
+}
+
+func (b *Bus) prepare(event Event) (Event, error) {
+	if event.Type == "" || event.TenantID <= 0 {
+		return Event{}, ErrInvalidEvent
+	}
+
+	return event.WithOccurredAt(b.now().UTC()), nil
+}

--- a/11-flagship/01-opslane/internal/events/bus.go
+++ b/11-flagship/01-opslane/internal/events/bus.go
@@ -59,6 +59,13 @@ func (b *Bus) TryPublish(event Event) error {
 	}
 	b.mu.RUnlock()
 
+	// Check closed signal before attempting send
+	select {
+	case <-b.closed:
+		return ErrBusClosed
+	default:
+	}
+
 	prepared, err := b.prepare(event)
 	if err != nil {
 		return err
@@ -140,6 +147,14 @@ func (b *Bus) Close() {
 func (b *Bus) prepare(event Event) (Event, error) {
 	if event.Type == "" || event.TenantID <= 0 {
 		return Event{}, ErrInvalidEvent
+	}
+
+	if event.Metadata != nil {
+		metadataCopy := make(map[string]string, len(event.Metadata))
+		for k, v := range event.Metadata {
+			metadataCopy[k] = v
+		}
+		event.Metadata = metadataCopy
 	}
 
 	return event.WithOccurredAt(b.now().UTC()), nil

--- a/11-flagship/01-opslane/internal/events/bus.go
+++ b/11-flagship/01-opslane/internal/events/bus.go
@@ -106,15 +106,19 @@ func (b *Bus) Publish(ctx context.Context, event Event) error {
 	select {
 	case <-b.closed:
 		return ErrBusClosed
+	case <-ctx.Done():
+		return ctx.Err()
 	default:
 		// Proceed to try sending with context
 	}
 
-	// Try to send the event with context, prioritizing closed signal
+	// Try to send the event with context, prioritizing closed signal and context cancellation
 	for {
 		select {
 		case <-b.closed:
 			return ErrBusClosed
+		case <-ctx.Done():
+			return ctx.Err()
 		default:
 		}
 

--- a/11-flagship/01-opslane/internal/events/bus.go
+++ b/11-flagship/01-opslane/internal/events/bus.go
@@ -91,14 +91,16 @@ func (b *Bus) Publish(ctx context.Context, event Event) error {
 	select {
 	case b.events <- event:
 		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	default:
 	}
 
 	select {
+	case b.events <- event:
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
-	default:
-		return ErrQueueFull
 	}
 }
 

--- a/11-flagship/01-opslane/internal/events/bus.go
+++ b/11-flagship/01-opslane/internal/events/bus.go
@@ -82,19 +82,18 @@ func (b *Bus) Publish(ctx context.Context, event Event) error {
 	}
 
 	b.mu.RLock()
-	defer b.mu.RUnlock()
-
 	if b.closed {
+		b.mu.RUnlock()
 		return ErrBusClosed
 	}
 
 	select {
 	case b.events <- event:
+		b.mu.RUnlock()
 		return nil
-	case <-ctx.Done():
-		return ctx.Err()
 	default:
 	}
+	b.mu.RUnlock()
 
 	select {
 	case b.events <- event:

--- a/11-flagship/01-opslane/internal/events/bus.go
+++ b/11-flagship/01-opslane/internal/events/bus.go
@@ -18,10 +18,12 @@ var (
 )
 
 type Bus struct {
-	mu     sync.RWMutex
-	events chan Event
-	closed bool
-	now    func() time.Time
+	events     chan Event
+	closed     chan struct{}
+	once       sync.Once
+	now        func() time.Time
+	mu         sync.RWMutex
+	closedFlag bool
 }
 
 func NewBus(capacity int) *Bus {
@@ -31,6 +33,7 @@ func NewBus(capacity int) *Bus {
 
 	return &Bus{
 		events: make(chan Event, capacity),
+		closed: make(chan struct{}),
 		now:    time.Now,
 	}
 }
@@ -48,21 +51,24 @@ func (b *Bus) TryPublish(event Event) error {
 		return fmt.Errorf("event bus is not configured")
 	}
 
-	event, err := b.prepare(event)
+	// Fast-path: if the bus is already closed, reject immediately
+	b.mu.RLock()
+	if b.closedFlag {
+		b.mu.RUnlock()
+		return ErrBusClosed
+	}
+	b.mu.RUnlock()
+
+	prepared, err := b.prepare(event)
 	if err != nil {
 		return err
 	}
 
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-
-	if b.closed {
-		return ErrBusClosed
-	}
-
 	select {
-	case b.events <- event:
+	case b.events <- prepared:
 		return nil
+	case <-b.closed:
+		return ErrBusClosed
 	default:
 		return ErrQueueFull
 	}
@@ -76,28 +82,33 @@ func (b *Bus) Publish(ctx context.Context, event Event) error {
 		ctx = context.Background()
 	}
 
-	event, err := b.prepare(event)
+	// Fast-path: reject if bus is already closed
+	b.mu.RLock()
+	if b.closedFlag {
+		b.mu.RUnlock()
+		return ErrBusClosed
+	}
+	b.mu.RUnlock()
+
+	prepared, err := b.prepare(event)
 	if err != nil {
 		return err
 	}
 
-	b.mu.RLock()
-	if b.closed {
-		b.mu.RUnlock()
+	// Check if bus is closed first to avoid race with Close
+	select {
+	case <-b.closed:
 		return ErrBusClosed
-	}
-
-	select {
-	case b.events <- event:
-		b.mu.RUnlock()
-		return nil
 	default:
+		// Proceed to try sending with context
 	}
-	b.mu.RUnlock()
 
+	// Try to send the event with context
 	select {
-	case b.events <- event:
+	case b.events <- prepared:
 		return nil
+	case <-b.closed:
+		return ErrBusClosed
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -107,16 +118,15 @@ func (b *Bus) Close() {
 	if b == nil {
 		return
 	}
-
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if b.closed {
-		return
-	}
-
-	b.closed = true
-	close(b.events)
+	b.once.Do(func() {
+		// Mark closed in a thread-safe way and signal close to waiters
+		b.mu.Lock()
+		if !b.closedFlag {
+			b.closedFlag = true
+			close(b.closed)
+		}
+		b.mu.Unlock()
+	})
 }
 
 func (b *Bus) prepare(event Event) (Event, error) {

--- a/11-flagship/01-opslane/internal/events/bus.go
+++ b/11-flagship/01-opslane/internal/events/bus.go
@@ -103,14 +103,22 @@ func (b *Bus) Publish(ctx context.Context, event Event) error {
 		// Proceed to try sending with context
 	}
 
-	// Try to send the event with context
-	select {
-	case b.events <- prepared:
-		return nil
-	case <-b.closed:
-		return ErrBusClosed
-	case <-ctx.Done():
-		return ctx.Err()
+	// Try to send the event with context, prioritizing closed signal
+	for {
+		select {
+		case <-b.closed:
+			return ErrBusClosed
+		default:
+		}
+
+		select {
+		case b.events <- prepared:
+			return nil
+		case <-b.closed:
+			return ErrBusClosed
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 }
 

--- a/11-flagship/01-opslane/internal/events/bus.go
+++ b/11-flagship/01-opslane/internal/events/bus.go
@@ -17,13 +17,20 @@ var (
 	ErrBusClosed    = errors.New("event bus closed")
 )
 
+// Bus is a single-channel event bus. Publish/TryPublish write events into a
+// buffered channel; subscribers read from that same channel via Subscribe.
+//
+// Thread-safety: all exported methods are safe for concurrent use.
+// Close is idempotent — calling it multiple times is safe.
+//
+// Design note: the closed signal is carried solely by the `closed` channel.
+// A non-blocking select on a closed channel is O(1) and allocation-free, so
+// a separate boolean flag + mutex fast-path is unnecessary overhead.
 type Bus struct {
-	events     chan Event
-	closed     chan struct{}
-	once       sync.Once
-	now        func() time.Time
-	mu         sync.RWMutex
-	closedFlag bool
+	events chan Event
+	closed chan struct{}
+	once   sync.Once
+	now    func() time.Time
 }
 
 func NewBus(capacity int) *Bus {
@@ -38,6 +45,9 @@ func NewBus(capacity int) *Bus {
 	}
 }
 
+// Subscribe returns the read-only event channel. All published events are
+// delivered in order. The channel is never closed by the bus; callers should
+// also select on a done/context signal to know when to stop reading.
 func (b *Bus) Subscribe() <-chan Event {
 	if b == nil {
 		return nil
@@ -46,20 +56,15 @@ func (b *Bus) Subscribe() <-chan Event {
 	return b.events
 }
 
+// TryPublish attempts a non-blocking publish. Returns ErrQueueFull immediately
+// if the buffer is at capacity, or ErrBusClosed if Close has been called.
 func (b *Bus) TryPublish(event Event) error {
 	if b == nil {
 		return fmt.Errorf("event bus is not configured")
 	}
 
-	// Fast-path: if the bus is already closed, reject immediately
-	b.mu.RLock()
-	if b.closedFlag {
-		b.mu.RUnlock()
-		return ErrBusClosed
-	}
-	b.mu.RUnlock()
-
-	// Check closed signal before attempting send
+	// Fast closed check — a receive on a closed channel is non-blocking and
+	// allocation-free, so no mutex is needed.
 	select {
 	case <-b.closed:
 		return ErrBusClosed
@@ -81,6 +86,8 @@ func (b *Bus) TryPublish(event Event) error {
 	}
 }
 
+// Publish enqueues an event, blocking until it is accepted, the bus is
+// closed, or the context is cancelled.
 func (b *Bus) Publish(ctx context.Context, event Event) error {
 	if b == nil {
 		return fmt.Errorf("event bus is not configured")
@@ -89,62 +96,45 @@ func (b *Bus) Publish(ctx context.Context, event Event) error {
 		ctx = context.Background()
 	}
 
-	// Fast-path: reject if bus is already closed
-	b.mu.RLock()
-	if b.closedFlag {
-		b.mu.RUnlock()
+	// Fast closed check before the more expensive prepare call.
+	select {
+	case <-b.closed:
 		return ErrBusClosed
+	default:
 	}
-	b.mu.RUnlock()
 
 	prepared, err := b.prepare(event)
 	if err != nil {
 		return err
 	}
 
-	// Check if bus is closed first to avoid race with Close
 	select {
+	case b.events <- prepared:
+		return nil
 	case <-b.closed:
 		return ErrBusClosed
 	case <-ctx.Done():
 		return ctx.Err()
-	default:
-		// Proceed to try sending with context
-	}
-
-	// Try to send the event with context, prioritizing closed signal and context cancellation
-	for {
-		select {
-		case <-b.closed:
-			return ErrBusClosed
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		select {
-		case b.events <- prepared:
-			return nil
-		case <-b.closed:
-			return ErrBusClosed
-		case <-ctx.Done():
-			return ctx.Err()
-		}
 	}
 }
 
+// Close permanently shuts the bus. After Close returns, all subsequent
+// Publish and TryPublish calls will return ErrBusClosed immediately.
+// Close is idempotent; calling it more than once is safe.
+//
+// Note: b.events is intentionally NOT closed here. The bus does not own the
+// consumer side of the channel, so closing it would risk a panic in any
+// subscriber that attempts a receive after a hypothetical re-open, and would
+// also race with in-flight sends from Publish. Subscribers should stop reading
+// by watching their own done/context signal alongside the Subscribe channel.
 func (b *Bus) Close() {
 	if b == nil {
 		return
 	}
+	// sync.Once guarantees close(b.closed) is called exactly once, making
+	// Close safe to call concurrently from multiple goroutines.
 	b.once.Do(func() {
-		// Mark closed in a thread-safe way and signal close to waiters
-		b.mu.Lock()
-		if !b.closedFlag {
-			b.closedFlag = true
-			close(b.closed)
-		}
-		b.mu.Unlock()
+		close(b.closed)
 	})
 }
 

--- a/11-flagship/01-opslane/internal/events/bus_test.go
+++ b/11-flagship/01-opslane/internal/events/bus_test.go
@@ -1,0 +1,75 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestBusPublishesEventWithTimestamp(t *testing.T) {
+	t.Parallel()
+
+	bus := NewBus(1)
+	bus.now = func() time.Time {
+		return time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+	}
+
+	if err := bus.TryPublish(Event{Type: TypeOrderCreated, TenantID: 7, OrderID: 101}); err != nil {
+		t.Fatalf("TryPublish returned error: %v", err)
+	}
+
+	event := <-bus.Subscribe()
+	if event.OccurredAt.IsZero() {
+		t.Fatal("OccurredAt should be set")
+	}
+	if event.OrderID != 101 {
+		t.Fatalf("OrderID = %d, want 101", event.OrderID)
+	}
+}
+
+func TestBusRejectsWhenQueueIsFull(t *testing.T) {
+	t.Parallel()
+
+	bus := NewBus(1)
+	first := Event{Type: TypeOrderCreated, TenantID: 7, OrderID: 101}
+	second := Event{Type: TypePaymentRequested, TenantID: 7, OrderID: 101}
+
+	if err := bus.TryPublish(first); err != nil {
+		t.Fatalf("first TryPublish returned error: %v", err)
+	}
+
+	err := bus.TryPublish(second)
+	if !errors.Is(err, ErrQueueFull) {
+		t.Fatalf("second TryPublish error = %v, want ErrQueueFull", err)
+	}
+}
+
+func TestBusPublishHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	bus := NewBus(1)
+	if err := bus.TryPublish(Event{Type: TypeOrderCreated, TenantID: 7}); err != nil {
+		t.Fatalf("TryPublish returned error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := bus.Publish(ctx, Event{Type: TypePaymentRequested, TenantID: 7})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Publish error = %v, want context.Canceled", err)
+	}
+}
+
+func TestBusRejectsPublishAfterClose(t *testing.T) {
+	t.Parallel()
+
+	bus := NewBus(1)
+	bus.Close()
+
+	err := bus.TryPublish(Event{Type: TypeOrderCreated, TenantID: 7})
+	if !errors.Is(err, ErrBusClosed) {
+		t.Fatalf("TryPublish error = %v, want ErrBusClosed", err)
+	}
+}

--- a/11-flagship/01-opslane/internal/events/types.go
+++ b/11-flagship/01-opslane/internal/events/types.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package events
+
+import (
+	"time"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+)
+
+type Type string
+
+const (
+	TypeOrderCreated          Type = "order.created"
+	TypeOrderStatusChanged    Type = "order.status_changed"
+	TypePaymentRequested      Type = "payment.requested"
+	TypePaymentSettled        Type = "payment.settled"
+	TypePaymentFailed         Type = "payment.failed"
+	TypeNotificationRequested Type = "notification.requested"
+)
+
+// Event is the small, explicit message that crosses the async boundary.
+type Event struct {
+	ID                string
+	Type              Type
+	TenantID          int64
+	UserID            int64
+	OrderID           int64
+	PaymentID         int64
+	OrderStatus       models.OrderStatus
+	PaymentStatus     models.PaymentStatus
+	ProviderReference string
+	AmountCents       int64
+	OccurredAt        time.Time
+	Metadata          map[string]string
+}
+
+func (e Event) WithOccurredAt(now time.Time) Event {
+	if e.OccurredAt.IsZero() {
+		e.OccurredAt = now
+	}
+
+	return e
+}

--- a/11-flagship/01-opslane/internal/workers/notification_worker.go
+++ b/11-flagship/01-opslane/internal/workers/notification_worker.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package workers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
+)
+
+type Notification struct {
+	TenantID int64
+	EventID  string
+	Channel  string
+	Subject  string
+	Body     string
+}
+
+type NotificationSink interface {
+	Send(ctx context.Context, notification Notification) error
+}
+
+type NotificationWorker struct {
+	Sink NotificationSink
+}
+
+func (w NotificationWorker) Handle(ctx context.Context, event events.Event) error {
+	if event.Type != events.TypeNotificationRequested {
+		return nil
+	}
+	if w.Sink == nil {
+		return fmt.Errorf("notification sink is not configured")
+	}
+	if event.TenantID <= 0 {
+		return events.ErrInvalidEvent
+	}
+
+	notification := Notification{
+		TenantID: event.TenantID,
+		EventID:  event.ID,
+		Channel:  event.Metadata["channel"],
+		Subject:  event.Metadata["subject"],
+		Body:     event.Metadata["body"],
+	}
+	if notification.Channel == "" || notification.Subject == "" {
+		return events.ErrInvalidEvent
+	}
+
+	if err := w.Sink.Send(ctx, notification); err != nil {
+		return fmt.Errorf("send notification: %w", err)
+	}
+
+	return nil
+}

--- a/11-flagship/01-opslane/internal/workers/order_processor.go
+++ b/11-flagship/01-opslane/internal/workers/order_processor.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package workers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
+)
+
+type OrderWorkflow interface {
+	TransitionOrder(ctx context.Context, req services.TransitionOrderRequest) (models.Order, error)
+}
+
+type OrderProcessor struct {
+	Workflow OrderWorkflow
+}
+
+func (p OrderProcessor) Handle(ctx context.Context, event events.Event) error {
+	if event.Type != events.TypeOrderStatusChanged {
+		return nil
+	}
+	if p.Workflow == nil {
+		return fmt.Errorf("order processor workflow is not configured")
+	}
+	if event.TenantID <= 0 || event.OrderID <= 0 || event.OrderStatus == "" {
+		return events.ErrInvalidEvent
+	}
+
+	_, err := p.Workflow.TransitionOrder(ctx, services.TransitionOrderRequest{
+		TenantID: event.TenantID,
+		OrderID:  event.OrderID,
+		Status:   event.OrderStatus,
+	})
+	if err != nil {
+		return fmt.Errorf("process order status event: %w", err)
+	}
+
+	return nil
+}

--- a/11-flagship/01-opslane/internal/workers/payment_processor.go
+++ b/11-flagship/01-opslane/internal/workers/payment_processor.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package workers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
+	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
+)
+
+type PaymentWorkflow interface {
+	ProcessPayment(ctx context.Context, job paymentflow.Job) (services.ProcessPaymentResult, error)
+}
+
+type PaymentProcessor struct {
+	Workflow PaymentWorkflow
+}
+
+func (p PaymentProcessor) Handle(ctx context.Context, event events.Event) error {
+	if event.Type != events.TypePaymentRequested {
+		return nil
+	}
+	if p.Workflow == nil {
+		return fmt.Errorf("payment processor workflow is not configured")
+	}
+
+	_, err := p.Workflow.ProcessPayment(ctx, paymentflow.Job{
+		TenantID:          event.TenantID,
+		OrderID:           event.OrderID,
+		ProviderReference: event.ProviderReference,
+		AmountCents:       event.AmountCents,
+	})
+	if err != nil {
+		return fmt.Errorf("process payment event: %w", err)
+	}
+
+	return nil
+}

--- a/11-flagship/01-opslane/internal/workers/pool.go
+++ b/11-flagship/01-opslane/internal/workers/pool.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package workers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
+)
+
+var (
+	ErrInvalidPoolConfig = errors.New("invalid worker pool config")
+	ErrPoolStopped       = errors.New("worker pool stopped")
+	ErrQueueFull         = errors.New("worker queue full")
+)
+
+type Handler func(context.Context, events.Event) error
+type ErrorHandler func(events.Event, error)
+
+type PoolConfig struct {
+	Name      string
+	Workers   int
+	QueueSize int
+	Handler   Handler
+	OnError   ErrorHandler
+}
+
+type Pool struct {
+	name    string
+	workers int
+	jobs    chan events.Event
+	handler Handler
+	onError ErrorHandler
+
+	mu      sync.RWMutex
+	started bool
+	stopped bool
+	wg      sync.WaitGroup
+}
+
+func NewPool(config PoolConfig) (*Pool, error) {
+	if config.Workers <= 0 || config.QueueSize <= 0 || config.Handler == nil {
+		return nil, ErrInvalidPoolConfig
+	}
+	if config.Name == "" {
+		config.Name = "worker-pool"
+	}
+
+	return &Pool{
+		name:    config.Name,
+		workers: config.Workers,
+		jobs:    make(chan events.Event, config.QueueSize),
+		handler: config.Handler,
+		onError: config.OnError,
+	}, nil
+}
+
+func (p *Pool) Start(ctx context.Context) error {
+	if p == nil {
+		return fmt.Errorf("worker pool is not configured")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	p.mu.Lock()
+	if p.stopped {
+		p.mu.Unlock()
+		return ErrPoolStopped
+	}
+	if p.started {
+		p.mu.Unlock()
+		return nil
+	}
+	p.started = true
+	p.mu.Unlock()
+
+	for i := 0; i < p.workers; i++ {
+		p.wg.Add(1)
+		go p.runWorker(ctx)
+	}
+
+	return nil
+}
+
+func (p *Pool) Submit(ctx context.Context, event events.Event) error {
+	if p == nil {
+		return fmt.Errorf("worker pool is not configured")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.stopped {
+		return ErrPoolStopped
+	}
+
+	select {
+	case p.jobs <- event:
+		return nil
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return ErrQueueFull
+	}
+}
+
+func (p *Pool) TrySubmit(event events.Event) error {
+	if p == nil {
+		return fmt.Errorf("worker pool is not configured")
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.stopped {
+		return ErrPoolStopped
+	}
+
+	select {
+	case p.jobs <- event:
+		return nil
+	default:
+		return ErrQueueFull
+	}
+}
+
+func (p *Pool) Stop() {
+	if p == nil {
+		return
+	}
+
+	p.mu.Lock()
+	if p.stopped {
+		p.mu.Unlock()
+		return
+	}
+	p.stopped = true
+	close(p.jobs)
+	p.mu.Unlock()
+
+	p.wg.Wait()
+}
+
+func (p *Pool) QueueLength() int {
+	if p == nil {
+		return 0
+	}
+
+	return len(p.jobs)
+}
+
+func (p *Pool) Name() string {
+	if p == nil {
+		return ""
+	}
+
+	return p.name
+}
+
+func (p *Pool) runWorker(ctx context.Context) {
+	defer p.wg.Done()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-p.jobs:
+			if !ok {
+				return
+			}
+			if err := p.handler(ctx, event); err != nil && p.onError != nil {
+				p.onError(event, err)
+			}
+		}
+	}
+}

--- a/11-flagship/01-opslane/internal/workers/pool.go
+++ b/11-flagship/01-opslane/internal/workers/pool.go
@@ -105,14 +105,22 @@ func (p *Pool) Submit(ctx context.Context, event events.Event) error {
 		// Proceed to try submitting with context
 	}
 
-	// Try to submit the event with context
-	select {
-	case p.jobs <- event:
-		return nil
-	case <-p.stopCh:
-		return ErrPoolStopped
-	case <-ctx.Done():
-		return ctx.Err()
+	// Try to submit the event with context, prioritizing stop signal
+	for {
+		select {
+		case <-p.stopCh:
+			return ErrPoolStopped
+		default:
+		}
+
+		select {
+		case p.jobs <- event:
+			return nil
+		case <-p.stopCh:
+			return ErrPoolStopped
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 }
 

--- a/11-flagship/01-opslane/internal/workers/pool.go
+++ b/11-flagship/01-opslane/internal/workers/pool.go
@@ -105,14 +105,16 @@ func (p *Pool) Submit(ctx context.Context, event events.Event) error {
 	select {
 	case p.jobs <- event:
 		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	default:
 	}
 
 	select {
+	case p.jobs <- event:
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
-	default:
-		return ErrQueueFull
 	}
 }
 
@@ -175,13 +177,27 @@ func (p *Pool) runWorker(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			return
 		case event, ok := <-p.jobs:
 			if !ok {
 				return
 			}
 			if err := p.handler(ctx, event); err != nil && p.onError != nil {
 				p.onError(event, err)
+			}
+			continue
+		}
+
+		for {
+			select {
+			case event, ok := <-p.jobs:
+				if !ok {
+					return
+				}
+				if err := p.handler(ctx, event); err != nil && p.onError != nil {
+					p.onError(event, err)
+				}
+			default:
+				return
 			}
 		}
 	}

--- a/11-flagship/01-opslane/internal/workers/pool.go
+++ b/11-flagship/01-opslane/internal/workers/pool.go
@@ -101,15 +101,19 @@ func (p *Pool) Submit(ctx context.Context, event events.Event) error {
 	select {
 	case <-p.stopCh:
 		return ErrPoolStopped
+	case <-ctx.Done():
+		return ctx.Err()
 	default:
 		// Proceed to try submitting with context
 	}
 
-	// Try to submit the event with context, prioritizing stop signal
+	// Try to submit the event with context, prioritizing stop signal and context cancellation
 	for {
 		select {
 		case <-p.stopCh:
 			return ErrPoolStopped
+		case <-ctx.Done():
+			return ctx.Err()
 		default:
 		}
 

--- a/11-flagship/01-opslane/internal/workers/pool.go
+++ b/11-flagship/01-opslane/internal/workers/pool.go
@@ -40,6 +40,7 @@ type Pool struct {
 	started bool
 	stopped bool
 	wg      sync.WaitGroup
+	stopCh  chan struct{}
 }
 
 func NewPool(config PoolConfig) (*Pool, error) {
@@ -56,6 +57,7 @@ func NewPool(config PoolConfig) (*Pool, error) {
 		jobs:    make(chan events.Event, config.QueueSize),
 		handler: config.Handler,
 		onError: config.OnError,
+		stopCh:  make(chan struct{}),
 	}, nil
 }
 
@@ -95,23 +97,20 @@ func (p *Pool) Submit(ctx context.Context, event events.Event) error {
 		ctx = context.Background()
 	}
 
-	p.mu.RLock()
-	if p.stopped {
-		p.mu.RUnlock()
+	// Check if pool is stopped first to avoid race with Stop
+	select {
+	case <-p.stopCh:
 		return ErrPoolStopped
-	}
-
-	select {
-	case p.jobs <- event:
-		p.mu.RUnlock()
-		return nil
 	default:
+		// Proceed to try submitting with context
 	}
-	p.mu.RUnlock()
 
+	// Try to submit the event with context
 	select {
 	case p.jobs <- event:
 		return nil
+	case <-p.stopCh:
+		return ErrPoolStopped
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -148,6 +147,7 @@ func (p *Pool) Stop() {
 		return
 	}
 	p.stopped = true
+	close(p.stopCh)
 	close(p.jobs)
 	p.mu.Unlock()
 

--- a/11-flagship/01-opslane/internal/workers/pool.go
+++ b/11-flagship/01-opslane/internal/workers/pool.go
@@ -79,10 +79,13 @@ func (p *Pool) Start(ctx context.Context) error {
 		return nil
 	}
 	p.started = true
-	p.mu.Unlock()
 
 	for i := 0; i < p.workers; i++ {
 		p.wg.Add(1)
+	}
+	p.mu.Unlock()
+
+	for i := 0; i < p.workers; i++ {
 		go p.runWorker(ctx)
 	}
 
@@ -192,9 +195,7 @@ func (p *Pool) runWorker(ctx context.Context) {
 			if !ok {
 				return
 			}
-			if err := p.handler(ctx, event); err != nil && p.onError != nil {
-				p.onError(event, err)
-			}
+			p.doHandle(ctx, event)
 			continue
 		}
 
@@ -204,12 +205,28 @@ func (p *Pool) runWorker(ctx context.Context) {
 				if !ok {
 					return
 				}
-				if err := p.handler(ctx, event); err != nil && p.onError != nil {
-					p.onError(event, err)
-				}
+				p.doHandle(ctx, event)
 			default:
 				return
 			}
 		}
+	}
+}
+
+func (p *Pool) doHandle(ctx context.Context, event events.Event) {
+	defer func() {
+		if r := recover(); r != nil {
+			err, ok := r.(error)
+			if !ok {
+				err = fmt.Errorf("panic: %v", r)
+			}
+			if p.onError != nil {
+				p.onError(event, err)
+			}
+		}
+	}()
+
+	if err := p.handler(ctx, event); err != nil && p.onError != nil {
+		p.onError(event, err)
 	}
 }

--- a/11-flagship/01-opslane/internal/workers/pool.go
+++ b/11-flagship/01-opslane/internal/workers/pool.go
@@ -96,19 +96,18 @@ func (p *Pool) Submit(ctx context.Context, event events.Event) error {
 	}
 
 	p.mu.RLock()
-	defer p.mu.RUnlock()
-
 	if p.stopped {
+		p.mu.RUnlock()
 		return ErrPoolStopped
 	}
 
 	select {
 	case p.jobs <- event:
+		p.mu.RUnlock()
 		return nil
-	case <-ctx.Done():
-		return ctx.Err()
 	default:
 	}
+	p.mu.RUnlock()
 
 	select {
 	case p.jobs <- event:

--- a/11-flagship/01-opslane/internal/workers/pool.go
+++ b/11-flagship/01-opslane/internal/workers/pool.go
@@ -92,6 +92,12 @@ func (p *Pool) Start(ctx context.Context) error {
 	return nil
 }
 
+// Submit enqueues an event for processing. It blocks until the event is
+// accepted, the pool is stopped, or the context is cancelled.
+//
+// Note: p.jobs is never closed while the pool is running, so there is no
+// risk of a "send on closed channel" panic here. Workers exit by watching
+// stopCh, not by channel closure.
 func (p *Pool) Submit(ctx context.Context, event events.Event) error {
 	if p == nil {
 		return fmt.Errorf("worker pool is not configured")
@@ -100,37 +106,34 @@ func (p *Pool) Submit(ctx context.Context, event events.Event) error {
 		ctx = context.Background()
 	}
 
-	// Check if pool is stopped first to avoid race with Stop
+	// Fast-path: reject if pool is already stopped. Without this check, a
+	// stopped pool with remaining buffer capacity would non-deterministically
+	// accept the send in the select below (Go selects randomly among ready
+	// cases). The pre-check makes rejection deterministic.
 	select {
+	case <-p.stopCh:
+		return ErrPoolStopped
+	default:
+	}
+
+	select {
+	case p.jobs <- event:
+		return nil
 	case <-p.stopCh:
 		return ErrPoolStopped
 	case <-ctx.Done():
 		return ctx.Err()
-	default:
-		// Proceed to try submitting with context
-	}
-
-	// Try to submit the event with context, prioritizing stop signal and context cancellation
-	for {
-		select {
-		case <-p.stopCh:
-			return ErrPoolStopped
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		select {
-		case p.jobs <- event:
-			return nil
-		case <-p.stopCh:
-			return ErrPoolStopped
-		case <-ctx.Done():
-			return ctx.Err()
-		}
 	}
 }
 
+// TrySubmit attempts a non-blocking enqueue. Returns ErrQueueFull immediately
+// if the job channel has no capacity, or ErrPoolStopped if the pool has been
+// shut down.
+//
+// The stopped check and the channel send are both guarded by the read-lock so
+// that Stop (which holds the write-lock when it sets p.stopped) cannot sneak
+// in between the two operations. Because p.jobs is never closed while the pool
+// is running, the non-blocking send is safe.
 func (p *Pool) TrySubmit(event events.Event) error {
 	if p == nil {
 		return fmt.Errorf("worker pool is not configured")
@@ -151,6 +154,11 @@ func (p *Pool) TrySubmit(event events.Event) error {
 	}
 }
 
+// Stop signals all workers to exit and waits for them to finish.
+//
+// Crucially, p.jobs is NOT closed here. Closing a channel that other
+// goroutines may still be sending to causes a panic. Instead workers
+// watch stopCh and drain any remaining buffered events before returning.
 func (p *Pool) Stop() {
 	if p == nil {
 		return
@@ -163,7 +171,6 @@ func (p *Pool) Stop() {
 	}
 	p.stopped = true
 	close(p.stopCh)
-	close(p.jobs)
 	p.mu.Unlock()
 
 	p.wg.Wait()
@@ -185,30 +192,43 @@ func (p *Pool) Name() string {
 	return p.name
 }
 
+// runWorker is the per-goroutine event loop. It exits when either:
+//   - stopCh is closed (graceful shutdown): remaining buffered events are drained
+//     so that no accepted work is silently dropped.
+//   - ctx is cancelled: the worker stops immediately without draining, because
+//     the caller's context signals an abort, not a graceful stop.
 func (p *Pool) runWorker(ctx context.Context) {
 	defer p.wg.Done()
 
 	for {
 		select {
 		case <-ctx.Done():
+			// Caller context cancelled — stop immediately, do not drain.
+			return
+
+		case <-p.stopCh:
+			// Graceful shutdown: drain any already-buffered events before exiting
+			// so that work that was accepted prior to Stop() was not lost.
+			// A fresh background context is used because the original ctx may
+			// already be cancelled, which would make every handler call fail.
+			drainCtx := context.Background()
+			for {
+				select {
+				case event, ok := <-p.jobs:
+					if !ok {
+						return
+					}
+					p.doHandle(drainCtx, event)
+				default:
+					return
+				}
+			}
+
 		case event, ok := <-p.jobs:
 			if !ok {
 				return
 			}
 			p.doHandle(ctx, event)
-			continue
-		}
-
-		for {
-			select {
-			case event, ok := <-p.jobs:
-				if !ok {
-					return
-				}
-				p.doHandle(ctx, event)
-			default:
-				return
-			}
 		}
 	}
 }

--- a/11-flagship/01-opslane/internal/workers/pool_test.go
+++ b/11-flagship/01-opslane/internal/workers/pool_test.go
@@ -133,3 +133,88 @@ func TestPoolRejectsSubmitAfterStop(t *testing.T) {
 		t.Fatalf("TrySubmit error = %v, want ErrPoolStopped", err)
 	}
 }
+
+// TestSubmitToStoppedPool verifies that Submit returns ErrPoolStopped when trying to submit to a stopped pool
+func TestSubmitToStoppedPool(t *testing.T) {
+	t.Parallel()
+
+	pool, err := NewPool(PoolConfig{
+		Name:      "submit-stopped",
+		Workers:   1,
+		QueueSize: 1,
+		Handler:   func(context.Context, events.Event) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("NewPool returned error: %v", err)
+	}
+
+	// Stop the pool
+	pool.Stop()
+
+	// Try to submit to the stopped pool
+	err = pool.Submit(context.Background(), events.Event{Type: events.TypeOrderCreated, TenantID: 7})
+	if !errors.Is(err, ErrPoolStopped) {
+		t.Fatalf("Submit error = %v, want ErrPoolStopped", err)
+	}
+}
+
+// TestSubmitToStoppedPoolWithContext verifies that Submit respects context cancellation even when pool is stopped
+func TestSubmitToStoppedPoolWithContext(t *testing.T) {
+	t.Parallel()
+
+	pool, err := NewPool(PoolConfig{
+		Name:      "submit-stopped-context",
+		Workers:   1,
+		QueueSize: 1,
+		Handler:   func(context.Context, events.Event) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("NewPool returned error: %v", err)
+	}
+
+	// Stop the pool
+	pool.Stop()
+
+	// Create a context that gets cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Try to submit to the stopped pool with a cancellable context
+	err = pool.Submit(ctx, events.Event{Type: events.TypeOrderCreated, TenantID: 7})
+	// Should return ErrPoolStopped because the pool is stopped, not context.Canceled
+	if !errors.Is(err, ErrPoolStopped) {
+		t.Fatalf("Submit error = %v, want ErrPoolStopped", err)
+	}
+}
+
+// TestPublishToClosedBus verifies that Publish returns ErrBusClosed when trying to publish to a closed bus
+func TestPublishToClosedBus(t *testing.T) {
+	t.Parallel()
+
+	bus := events.NewBus(1)
+	bus.Close()
+
+	err := bus.Publish(context.Background(), events.Event{Type: events.TypeOrderCreated, TenantID: 7})
+	if !errors.Is(err, events.ErrBusClosed) {
+		t.Fatalf("Publish error = %v, want ErrBusClosed", err)
+	}
+}
+
+// TestPublishToClosedBusWithContext verifies that Publish respects context cancellation even when bus is closed
+func TestPublishToClosedBusWithContext(t *testing.T) {
+	t.Parallel()
+
+	bus := events.NewBus(1)
+	bus.Close()
+
+	// Create a context that gets cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Try to publish to the closed bus with a cancellable context
+	err := bus.Publish(ctx, events.Event{Type: events.TypeOrderCreated, TenantID: 7})
+	// Should return ErrBusClosed because the bus is closed, not context.Canceled
+	if !errors.Is(err, events.ErrBusClosed) {
+		t.Fatalf("Publish error = %v, want ErrBusClosed", err)
+	}
+}

--- a/11-flagship/01-opslane/internal/workers/pool_test.go
+++ b/11-flagship/01-opslane/internal/workers/pool_test.go
@@ -1,0 +1,135 @@
+package workers
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
+)
+
+func TestPoolRejectsWhenQueueIsFull(t *testing.T) {
+	t.Parallel()
+
+	pool, err := NewPool(PoolConfig{
+		Name:      "test",
+		Workers:   1,
+		QueueSize: 1,
+		Handler:   func(context.Context, events.Event) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("NewPool returned error: %v", err)
+	}
+
+	if err := pool.TrySubmit(events.Event{Type: events.TypeOrderCreated, TenantID: 7}); err != nil {
+		t.Fatalf("first TrySubmit returned error: %v", err)
+	}
+
+	err = pool.TrySubmit(events.Event{Type: events.TypePaymentRequested, TenantID: 7})
+	if !errors.Is(err, ErrQueueFull) {
+		t.Fatalf("second TrySubmit error = %v, want ErrQueueFull", err)
+	}
+
+	pool.Stop()
+}
+
+func TestPoolDrainsQueuedWorkOnStop(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	processed := 0
+
+	pool, err := NewPool(PoolConfig{
+		Name:      "drain",
+		Workers:   2,
+		QueueSize: 4,
+		Handler: func(context.Context, events.Event) error {
+			mu.Lock()
+			processed++
+			mu.Unlock()
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewPool returned error: %v", err)
+	}
+	if err := pool.Start(context.Background()); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	for i := 0; i < 4; i++ {
+		if err := pool.Submit(context.Background(), events.Event{Type: events.TypeOrderCreated, TenantID: 7}); err != nil {
+			t.Fatalf("Submit returned error: %v", err)
+		}
+	}
+
+	pool.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if processed != 4 {
+		t.Fatalf("processed = %d, want 4", processed)
+	}
+}
+
+func TestPoolReportsHandlerErrors(t *testing.T) {
+	t.Parallel()
+
+	handlerErr := errors.New("worker failed")
+	errs := make(chan error, 1)
+
+	pool, err := NewPool(PoolConfig{
+		Name:      "errors",
+		Workers:   1,
+		QueueSize: 1,
+		Handler: func(context.Context, events.Event) error {
+			return handlerErr
+		},
+		OnError: func(_ events.Event, err error) {
+			errs <- err
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewPool returned error: %v", err)
+	}
+	if err := pool.Start(context.Background()); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	if err := pool.Submit(context.Background(), events.Event{Type: events.TypeOrderCreated, TenantID: 7}); err != nil {
+		t.Fatalf("Submit returned error: %v", err)
+	}
+
+	select {
+	case err := <-errs:
+		if !errors.Is(err, handlerErr) {
+			t.Fatalf("reported error = %v, want handlerErr", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for worker error")
+	}
+
+	pool.Stop()
+}
+
+func TestPoolRejectsSubmitAfterStop(t *testing.T) {
+	t.Parallel()
+
+	pool, err := NewPool(PoolConfig{
+		Name:      "stopped",
+		Workers:   1,
+		QueueSize: 1,
+		Handler:   func(context.Context, events.Event) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("NewPool returned error: %v", err)
+	}
+
+	pool.Stop()
+
+	err = pool.TrySubmit(events.Event{Type: events.TypeOrderCreated, TenantID: 7})
+	if !errors.Is(err, ErrPoolStopped) {
+		t.Fatalf("TrySubmit error = %v, want ErrPoolStopped", err)
+	}
+}

--- a/11-flagship/01-opslane/internal/workers/processors_test.go
+++ b/11-flagship/01-opslane/internal/workers/processors_test.go
@@ -1,0 +1,130 @@
+package workers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
+	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
+)
+
+func TestOrderProcessorTransitionsOrderStatus(t *testing.T) {
+	t.Parallel()
+
+	workflow := &stubOrderWorkflow{}
+	processor := OrderProcessor{Workflow: workflow}
+
+	err := processor.Handle(context.Background(), events.Event{
+		Type:        events.TypeOrderStatusChanged,
+		TenantID:    7,
+		OrderID:     101,
+		OrderStatus: models.OrderStatusPaid,
+	})
+	if err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+
+	if workflow.last.TenantID != 7 || workflow.last.OrderID != 101 || workflow.last.Status != models.OrderStatusPaid {
+		t.Fatalf("transition = %+v, want tenant 7 order 101 paid", workflow.last)
+	}
+}
+
+func TestPaymentProcessorStartsPaymentWorkflow(t *testing.T) {
+	t.Parallel()
+
+	workflow := &stubPaymentWorkflow{}
+	processor := PaymentProcessor{Workflow: workflow}
+
+	err := processor.Handle(context.Background(), events.Event{
+		Type:              events.TypePaymentRequested,
+		TenantID:          7,
+		OrderID:           101,
+		ProviderReference: "pay_123",
+		AmountCents:       2500,
+	})
+	if err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+
+	if workflow.last.TenantID != 7 || workflow.last.OrderID != 101 || workflow.last.ProviderReference != "pay_123" {
+		t.Fatalf("payment job = %+v, want tenant 7 order 101 pay_123", workflow.last)
+	}
+}
+
+func TestNotificationWorkerSendsNotification(t *testing.T) {
+	t.Parallel()
+
+	sink := &stubNotificationSink{}
+	worker := NotificationWorker{Sink: sink}
+
+	err := worker.Handle(context.Background(), events.Event{
+		ID:       "evt_1",
+		Type:     events.TypeNotificationRequested,
+		TenantID: 7,
+		Metadata: map[string]string{
+			"channel": "email",
+			"subject": "Payment settled",
+			"body":    "Your payment succeeded.",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+
+	if sink.last.TenantID != 7 || sink.last.Channel != "email" || sink.last.Subject != "Payment settled" {
+		t.Fatalf("notification = %+v, want tenant 7 email subject", sink.last)
+	}
+}
+
+func TestNotificationWorkerSurfacesSinkError(t *testing.T) {
+	t.Parallel()
+
+	sinkErr := errors.New("smtp down")
+	worker := NotificationWorker{Sink: &stubNotificationSink{err: sinkErr}}
+
+	err := worker.Handle(context.Background(), events.Event{
+		ID:       "evt_1",
+		Type:     events.TypeNotificationRequested,
+		TenantID: 7,
+		Metadata: map[string]string{
+			"channel": "email",
+			"subject": "Payment settled",
+		},
+	})
+	if !errors.Is(err, sinkErr) {
+		t.Fatalf("Handle error = %v, want sinkErr", err)
+	}
+}
+
+type stubOrderWorkflow struct {
+	last services.TransitionOrderRequest
+	err  error
+}
+
+func (s *stubOrderWorkflow) TransitionOrder(_ context.Context, req services.TransitionOrderRequest) (models.Order, error) {
+	s.last = req
+	return models.Order{ID: req.OrderID, TenantID: req.TenantID, Status: req.Status}, s.err
+}
+
+type stubPaymentWorkflow struct {
+	last paymentflow.Job
+	err  error
+}
+
+func (s *stubPaymentWorkflow) ProcessPayment(_ context.Context, job paymentflow.Job) (services.ProcessPaymentResult, error) {
+	s.last = job
+	return services.ProcessPaymentResult{}, s.err
+}
+
+type stubNotificationSink struct {
+	last Notification
+	err  error
+}
+
+func (s *stubNotificationSink) Send(_ context.Context, notification Notification) error {
+	s.last = notification
+	return s.err
+}

--- a/11-flagship/01-opslane/modules/07-event-workers/README.md
+++ b/11-flagship/01-opslane/modules/07-event-workers/README.md
@@ -19,15 +19,26 @@ Add bounded asynchronous work without turning background processing into invisib
 
 ## Proof Surface
 
-This module is not implemented in the current tree yet.
+This module is implemented in the current tree.
 
-When it is complete:
+Run:
 
-- `go test` must pass for the future `internal/events` package
-- `go test` must pass for the future `internal/workers` package
-- saturation and drain tests must prove bounded behavior
+```bash
+go test ./11-flagship/01-opslane/internal/events/...
+go test ./11-flagship/01-opslane/internal/workers/...
+go run ./11-flagship/01-opslane/scripts/progress.go
+```
 
-Expected new files:
+The proof surface now covers:
+
+- bounded event publishing
+- queue-full backpressure
+- context-aware publishing and submission
+- worker pool drain behavior
+- handler error reporting
+- order, payment, and notification worker adapters
+
+Implemented files:
 
 - `internal/events/bus.go`
 - `internal/events/types.go`
@@ -36,10 +47,86 @@ Expected new files:
 - `internal/workers/payment_processor.go`
 - `internal/workers/notification_worker.go`
 
+Implementation map: [SURFACE.md](./SURFACE.md)
+
 ## Required Files and Boundaries
 
 Worker coordination should stay explicit and bounded.
 Avoid untracked goroutine spawning inside handlers or repositories.
+
+## Mental Model
+
+Async work is not "fire and forget".
+
+It is:
+
+```text
+event -> bounded queue -> fixed workers -> explicit handler -> observable error path
+```
+
+If the queue is full, the system must decide what to do.
+OPSL.7 keeps that decision visible by returning `ErrQueueFull` instead of hiding unlimited buffering.
+
+## Machine View
+
+When code publishes an event, the machine does not create infinite work.
+It tries to put one small event into one bounded channel.
+
+```text
+Publisher
+    |
+    v
+Event Bus channel with capacity N
+    |
+    v
+Worker Pool channel with capacity M
+    |
+    v
+Fixed number of worker goroutines
+    |
+    v
+OrderProcessor / PaymentProcessor / NotificationWorker
+```
+
+The important constraint:
+
+```text
+queue capacity + worker count = the upper bound of in-memory async pressure
+```
+
+That is what prevents "one request creates unlimited goroutines" from becoming a production outage.
+
+## Diagram
+
+```text
+HTTP/service code
+      |
+      v
+ events.Bus.TryPublish
+      |
+      | queue full -> ErrQueueFull
+      v
+ events.Event
+      |
+      v
+ workers.Pool.TrySubmit
+      |
+      | queue full -> ErrQueueFull
+      v
+ fixed worker goroutine
+      |
+      +--> OrderProcessor
+      +--> PaymentProcessor
+      +--> NotificationWorker
+```
+
+## Try It
+
+Change a worker pool test from `QueueSize: 1` to `QueueSize: 2`.
+Then observe that the second `TrySubmit` no longer returns `ErrQueueFull` until the queue reaches the new capacity.
+
+Next, change `Workers: 2` to `Workers: 1` in the drain test.
+The test should still pass, but work drains with less parallel capacity.
 
 ## Engineering Questions
 

--- a/11-flagship/01-opslane/modules/07-event-workers/SURFACE.md
+++ b/11-flagship/01-opslane/modules/07-event-workers/SURFACE.md
@@ -1,0 +1,32 @@
+# OPSL.7 Implemented Code Surface
+
+This module is now implemented in the current tree.
+
+## Primary Code Files
+
+- [`internal/events/types.go`](../../internal/events/types.go)
+- [`internal/events/bus.go`](../../internal/events/bus.go)
+- [`internal/workers/pool.go`](../../internal/workers/pool.go)
+- [`internal/workers/order_processor.go`](../../internal/workers/order_processor.go)
+- [`internal/workers/payment_processor.go`](../../internal/workers/payment_processor.go)
+- [`internal/workers/notification_worker.go`](../../internal/workers/notification_worker.go)
+
+## Proof Commands
+
+```bash
+go test ./11-flagship/01-opslane/internal/events/...
+go test ./11-flagship/01-opslane/internal/workers/...
+go run ./11-flagship/01-opslane/scripts/progress.go
+```
+
+## What This Proves
+
+- async work has bounded queue capacity
+- queue saturation returns explicit errors
+- worker pools drain submitted work on stop
+- processor adapters call order, payment, and notification seams
+- handler failures travel through an explicit error callback instead of disappearing
+
+## What To Read Next
+
+If you want the current learner map, go back to [MODULES.md](../../MODULES.md).

--- a/11-flagship/01-opslane/scripts/progress.go
+++ b/11-flagship/01-opslane/scripts/progress.go
@@ -136,7 +136,7 @@ var modules = []moduleSpec{
 			"internal/workers/notification_worker.go",
 		},
 		readmeDir: "modules/07-event-workers",
-		nextStep:  "Start bounded async processing after payment workflow logic exists.",
+		nextStep:  "Continue into OPSL.8 after queue limits, drain behavior, and worker adapters are provable.",
 	},
 	{
 		id:    "OPSL.8",

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -4723,7 +4723,7 @@
       "type": "checkpoint",
       "subtype": "",
       "level": "production",
-      "status": "placeholder",
+      "status": "implemented",
       "verification_mode": "test",
       "path": "11-flagship/01-opslane/modules/07-event-workers",
       "prerequisites": [


### PR DESCRIPTION
## Summary

Implements Opslane `OPSL.7` as the event bus and worker pool module.

- Adds `internal/events` with explicit event types and a bounded event bus.
- Adds `internal/workers` with a fixed-size worker pool, queue-full backpressure, drain behavior, and handler error reporting.
- Adds order, payment, and notification worker adapters behind explicit workflow/sink interfaces.
- Updates Opslane module docs, progress checker, and `curriculum.v2.json` so `OPSL.7` is implemented and `OPSL.8` becomes current.

Closes #385

## Verification

- `go test ./11-flagship/01-opslane/internal/events/...`
- `go test ./11-flagship/01-opslane/internal/workers/...`
- `go test ./11-flagship/01-opslane/...`
- `go run ./11-flagship/01-opslane/scripts/progress.go`
- `go run ./scripts/validate_curriculum.go`
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `git diff --check`

Notes:

- `go test -race ./11-flagship/01-opslane/internal/events/... ./11-flagship/01-opslane/internal/workers/...` was not runnable in this local Windows shell because `-race` requires CGO.
- Local `go build ./...` exited successfully but printed a Windows module-cache stat warning for `C:\Users\Rasel\go\pkg\mod\cache`; CI should use a clean runner cache.