### PR TITLE
feat: implement Opslane OPSL.8 caching layer

### DIFF
--- a/11-flagship/01-opslane/MODULES.md
+++ b/11-flagship/01-opslane/MODULES.md
@@ -213,20 +213,33 @@ Read this module:
 
 What you build: cache-aside reads, invalidation boundaries, and bounded TTL behavior.
 
-Target proof surface once this module is implemented:
+Proof surface:
 
-- `go test` passes for the future `11-flagship/01-opslane/internal/cache` package
-- cache invalidation tests prove stale order and payment data is not served indefinitely
+```bash
+go test ./11-flagship/01-opslane/internal/cache/...
+go run ./11-flagship/01-opslane/scripts/progress.go
+```
 
-Required files:
+The proof surface covers:
+
+- bounded in-memory cache with TTL and insert-order eviction
+- lazy expiry on reads and background janitor sweep
+- copy-on-read/write mutation safety
+- explicit invalidation after order and payment writes
+- prefix-based batch invalidation for tenant-scoped groups
+- singleflight stampede prevention
+- HTTP Cache-Control middleware
+
+Implemented files:
 
 - `internal/cache/cache.go`
 - `internal/cache/store.go`
 - `internal/middleware/cache.go`
 
-Read this before starting:
+Read the implementation details:
 
 - [modules/08-caching/README.md](./modules/08-caching/README.md)
+- [modules/08-caching/SURFACE.md](./modules/08-caching/SURFACE.md)
 
 ## OPSL.9 Observability
 

--- a/11-flagship/01-opslane/README.md
+++ b/11-flagship/01-opslane/README.md
@@ -47,7 +47,8 @@ The current repository state is:
 - `OPSL.5` complete: order processing
 - `OPSL.6` complete: payment pipeline
 - `OPSL.7` complete: event bus and worker pools
-- `OPSL.8` next: caching layer
+- `OPSL.8` complete: caching layer
+- `OPSL.9` next: observability
 
 Use the progress surface instead of guessing:
 
@@ -65,6 +66,7 @@ Then use the learner map:
 - [OPSL.5 module spec](./modules/05-order-processing/README.md)
 - [OPSL.6 module spec](./modules/06-payment-pipeline/README.md)
 - [OPSL.7 module spec](./modules/07-event-workers/README.md)
+- [OPSL.8 module spec](./modules/08-caching/README.md)
 
 ## Module 5 Snapshot
 
@@ -105,6 +107,20 @@ database, gateway, and order state machine should cooperate.
 This slice introduces asynchronous building blocks without hiding goroutines inside handlers.
 The system can now talk about queue capacity, backpressure, and safe draining before later modules
 wire those primitives into caching, observability, and shutdown behavior.
+
+## Module 8 Snapshot
+
+`OPSL.8` establishes:
+
+- a bounded in-memory cache with TTL and insert-order eviction
+- explicit invalidation after order transitions and payment settlements
+- singleflight stampede prevention when hot cache keys expire
+- HTTP Cache-Control middleware for public and authenticated endpoints
+- copy-on-read/write to prevent callers from mutating cached data
+
+This slice introduces caching as an additive optimization, not a hidden source of truth.
+PostgreSQL remains the system of record. The cache sits between the service layer and
+the repository layer, and invalidation always follows successful writes.
 
 ## Run the Project
 
@@ -192,5 +208,6 @@ curl http://localhost:8080/api/v1/orders/1/payments \
 
 ## Next Step
 
-After `OPSL.7`, continue to [OPSL.8](./modules/08-caching/README.md).
-That module introduces bounded cache behavior on top of the now-explicit event and worker seams.
+After `OPSL.8`, continue to [OPSL.9](./modules/09-observability/README.md).
+That module introduces structured logging, metrics, and trace propagation on top of the
+now-cached service layer.

--- a/11-flagship/01-opslane/internal/cache/cache.go
+++ b/11-flagship/01-opslane/internal/cache/cache.go
@@ -168,12 +168,15 @@ func (sf *Singleflight) Do(key string, fn func() ([]byte, error)) ([]byte, error
 	sf.calls[key] = c
 	sf.mu.Unlock()
 
-	c.val, c.err = fn()
-	c.wg.Done()
+	// Ensure cleanup runs even if fn() panics
+	defer func() {
+		sf.mu.Lock()
+		delete(sf.calls, key)
+		sf.mu.Unlock()
+		c.wg.Done()
+	}()
 
-	sf.mu.Lock()
-	delete(sf.calls, key)
-	sf.mu.Unlock()
+	c.val, c.err = fn()
 
 	return c.val, c.err
 }

--- a/11-flagship/01-opslane/internal/cache/cache.go
+++ b/11-flagship/01-opslane/internal/cache/cache.go
@@ -151,7 +151,7 @@ type call struct {
 // Do executes fn once per key. Concurrent callers with the same key
 // block until the first caller's fn returns, then receive the same
 // result.
-func (sf *Singleflight) Do(key string, fn func() ([]byte, error)) ([]byte, error) {
+func (sf *Singleflight) Do(key string, fn func() ([]byte, error)) (val []byte, err error) {
 	sf.mu.Lock()
 	if sf.calls == nil {
 		sf.calls = make(map[string]*call)
@@ -168,8 +168,15 @@ func (sf *Singleflight) Do(key string, fn func() ([]byte, error)) ([]byte, error
 	sf.calls[key] = c
 	sf.mu.Unlock()
 
-	// Ensure cleanup runs even if fn() panics
+	// Ensure cleanup runs even if fn() panics.
+	// If a panic occurs, set c.err so that waiters receive an error
+	// instead of nil, nil — which would look like a successful empty result.
+	// Named returns ensure the leader also receives the error.
 	defer func() {
+		if r := recover(); r != nil {
+			c.err = fmt.Errorf("cache: singleflight panic: %v", r)
+			err = c.err
+		}
 		c.wg.Done()
 		sf.mu.Lock()
 		delete(sf.calls, key)
@@ -177,6 +184,7 @@ func (sf *Singleflight) Do(key string, fn func() ([]byte, error)) ([]byte, error
 	}()
 
 	c.val, c.err = fn()
-
-	return c.val, c.err
+	val = c.val
+	err = c.err
+	return
 }

--- a/11-flagship/01-opslane/internal/cache/cache.go
+++ b/11-flagship/01-opslane/internal/cache/cache.go
@@ -170,10 +170,10 @@ func (sf *Singleflight) Do(key string, fn func() ([]byte, error)) ([]byte, error
 
 	// Ensure cleanup runs even if fn() panics
 	defer func() {
+		c.wg.Done()
 		sf.mu.Lock()
 		delete(sf.calls, key)
 		sf.mu.Unlock()
-		c.wg.Done()
 	}()
 
 	c.val, c.err = fn()

--- a/11-flagship/01-opslane/internal/cache/cache.go
+++ b/11-flagship/01-opslane/internal/cache/cache.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+var (
+	ErrNotFound    = errors.New("cache: key not found")
+	ErrKeyEmpty    = errors.New("cache: empty key")
+	ErrCacheClosed = errors.New("cache: closed")
+)
+
+// Cache is the boundary that the rest of the application talks to.
+// PostgreSQL stays the system of record; this is always additive.
+type Cache interface {
+	Get(ctx context.Context, key string) ([]byte, error)
+	Set(ctx context.Context, key string, value []byte, ttl time.Duration) error
+	Delete(ctx context.Context, key string) error
+	DeletePrefix(ctx context.Context, prefix string) error
+	Close() error
+}
+
+// entry holds one cached value and its absolute expiry time.
+type entry struct {
+	value     []byte
+	expiresAt time.Time
+}
+
+func (e entry) expired(now time.Time) bool {
+	return !e.expiresAt.IsZero() && now.After(e.expiresAt)
+}
+
+// Config controls the bounded behavior of the in-memory cache.
+type Config struct {
+	MaxEntries int
+	DefaultTTL time.Duration
+}
+
+// DefaultConfig returns production-reasonable cache defaults.
+func DefaultConfig() Config {
+	return Config{
+		MaxEntries: 4096,
+		DefaultTTL: 5 * time.Minute,
+	}
+}
+
+// TenantOrderKey builds a tenant-scoped cache key for a single order.
+func TenantOrderKey(tenantID, orderID int64) string {
+	return fmt.Sprintf("tenant:%d:order:%d", tenantID, orderID)
+}
+
+// TenantOrderListKey builds a tenant-scoped cache key for the order list.
+func TenantOrderListKey(tenantID int64) string {
+	return fmt.Sprintf("tenant:%d:orders", tenantID)
+}
+
+// TenantPaymentListKey builds a tenant-scoped cache key for payments by order.
+func TenantPaymentListKey(tenantID, orderID int64) string {
+	return fmt.Sprintf("tenant:%d:order:%d:payments", tenantID, orderID)
+}
+
+// TenantOrderPrefix returns the prefix that covers all order-related keys
+// for a given tenant, so that a write can invalidate the whole group.
+func TenantOrderPrefix(tenantID int64) string {
+	return fmt.Sprintf("tenant:%d:order", tenantID)
+}
+
+// Invalidator provides write-through cache invalidation.
+// Services call these methods after mutations so the cache never
+// silently serves stale data.
+type Invalidator struct {
+	cache Cache
+}
+
+// NewInvalidator creates an invalidator. If cache is nil, all operations
+// are safe no-ops.
+func NewInvalidator(cache Cache) *Invalidator {
+	return &Invalidator{cache: cache}
+}
+
+// InvalidateOrder removes cached data for a specific order and the
+// tenant's order list so the next read comes from PostgreSQL.
+func (inv *Invalidator) InvalidateOrder(ctx context.Context, tenantID, orderID int64) {
+	if inv == nil || inv.cache == nil {
+		return
+	}
+
+	_ = inv.cache.Delete(ctx, TenantOrderKey(tenantID, orderID))
+	_ = inv.cache.Delete(ctx, TenantOrderListKey(tenantID))
+}
+
+// InvalidatePayments removes cached payment data for an order.
+func (inv *Invalidator) InvalidatePayments(ctx context.Context, tenantID, orderID int64) {
+	if inv == nil || inv.cache == nil {
+		return
+	}
+
+	_ = inv.cache.Delete(ctx, TenantPaymentListKey(tenantID, orderID))
+}
+
+// InvalidateTenantOrders removes all cached order and payment data for a
+// tenant. Use this after bulk mutations or when granular invalidation
+// would be too expensive.
+func (inv *Invalidator) InvalidateTenantOrders(ctx context.Context, tenantID int64) {
+	if inv == nil || inv.cache == nil {
+		return
+	}
+
+	_ = inv.cache.DeletePrefix(ctx, TenantOrderPrefix(tenantID))
+	_ = inv.cache.Delete(ctx, TenantOrderListKey(tenantID))
+}
+
+// NoopCache satisfies the Cache interface without storing anything.
+// Useful for testing and for environments where caching is disabled.
+type NoopCache struct{}
+
+func (NoopCache) Get(context.Context, string) ([]byte, error)              { return nil, ErrNotFound }
+func (NoopCache) Set(context.Context, string, []byte, time.Duration) error { return nil }
+func (NoopCache) Delete(context.Context, string) error                     { return nil }
+func (NoopCache) DeletePrefix(context.Context, string) error               { return nil }
+func (NoopCache) Close() error                                             { return nil }
+
+// compile-time interface checks
+var (
+	_ Cache = (*NoopCache)(nil)
+	_ Cache = (*InMemoryStore)(nil)
+)
+
+// Singleflight deduplicates concurrent loads for the same key.
+// Callers wrap their database read inside fn; if multiple goroutines
+// request the same key before the first load completes, only one
+// actually calls fn and the rest receive its result.
+type Singleflight struct {
+	mu    sync.Mutex
+	calls map[string]*call
+}
+
+type call struct {
+	wg  sync.WaitGroup
+	val []byte
+	err error
+}
+
+// Do executes fn once per key. Concurrent callers with the same key
+// block until the first caller's fn returns, then receive the same
+// result.
+func (sf *Singleflight) Do(key string, fn func() ([]byte, error)) ([]byte, error) {
+	sf.mu.Lock()
+	if sf.calls == nil {
+		sf.calls = make(map[string]*call)
+	}
+
+	if c, ok := sf.calls[key]; ok {
+		sf.mu.Unlock()
+		c.wg.Wait()
+		return c.val, c.err
+	}
+
+	c := &call{}
+	c.wg.Add(1)
+	sf.calls[key] = c
+	sf.mu.Unlock()
+
+	c.val, c.err = fn()
+	c.wg.Done()
+
+	sf.mu.Lock()
+	delete(sf.calls, key)
+	sf.mu.Unlock()
+
+	return c.val, c.err
+}

--- a/11-flagship/01-opslane/internal/cache/cache_test.go
+++ b/11-flagship/01-opslane/internal/cache/cache_test.go
@@ -279,6 +279,45 @@ func TestSingleflightDeduplicatesConcurrentLoads(t *testing.T) {
 	}
 }
 
+func TestSingleflightPanicRecovery(t *testing.T) {
+	t.Parallel()
+
+	var sf Singleflight
+	key := "panic-key"
+
+	// First call panics
+	func() {
+		defer func() {
+			_ = recover()
+		}()
+		_, _ = sf.Do(key, func() ([]byte, error) {
+			panic("simulated panic")
+		})
+	}()
+
+	// Second call should not block, meaning the key was cleaned up and wg was released
+	done := make(chan struct{})
+	go func() {
+		val, err := sf.Do(key, func() ([]byte, error) {
+			return []byte("recovered"), nil
+		})
+		if err != nil {
+			t.Errorf("Do returned error: %v", err)
+		}
+		if string(val) != "recovered" {
+			t.Errorf("Do = %q, want %q", val, "recovered")
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("second Do call blocked forever, panic cleanup failed")
+	}
+}
+
 func TestEmptyKeyReturnsError(t *testing.T) {
 	t.Parallel()
 	store := NewInMemoryStore(Config{MaxEntries: 8, DefaultTTL: time.Minute})

--- a/11-flagship/01-opslane/internal/cache/cache_test.go
+++ b/11-flagship/01-opslane/internal/cache/cache_test.go
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package cache
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestGetReturnsNotFoundForMissingKey(t *testing.T) {
+	t.Parallel()
+	store := NewInMemoryStore(Config{MaxEntries: 8, DefaultTTL: time.Minute})
+	defer store.Close()
+
+	_, err := store.Get(context.Background(), "missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSetAndGetRoundTrip(t *testing.T) {
+	t.Parallel()
+	store := NewInMemoryStore(Config{MaxEntries: 8, DefaultTTL: time.Minute})
+	defer store.Close()
+
+	ctx := context.Background()
+	key := TenantOrderKey(7, 101)
+	value := []byte(`{"id":101,"status":"pending"}`)
+
+	if err := store.Set(ctx, key, value, time.Minute); err != nil {
+		t.Fatalf("Set returned error: %v", err)
+	}
+
+	got, err := store.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if string(got) != string(value) {
+		t.Fatalf("Get = %q, want %q", got, value)
+	}
+}
+
+func TestGetReturnsCopyNotReference(t *testing.T) {
+	t.Parallel()
+	store := NewInMemoryStore(Config{MaxEntries: 8, DefaultTTL: time.Minute})
+	defer store.Close()
+
+	ctx := context.Background()
+	key := "test:copy"
+	original := []byte("original")
+
+	if err := store.Set(ctx, key, original, time.Minute); err != nil {
+		t.Fatalf("Set returned error: %v", err)
+	}
+
+	got, _ := store.Get(ctx, key)
+	got[0] = 'X' // mutate the returned value
+
+	second, _ := store.Get(ctx, key)
+	if string(second) != "original" {
+		t.Fatalf("cached value was mutated: got %q, want %q", second, "original")
+	}
+}
+
+func TestExpiredEntryReturnsNotFound(t *testing.T) {
+	t.Parallel()
+	store := NewInMemoryStore(Config{MaxEntries: 8, DefaultTTL: time.Minute})
+	defer store.Close()
+
+	// Freeze time, set entry, then advance past TTL.
+	now := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+
+	ctx := context.Background()
+	key := "test:ttl"
+	if err := store.Set(ctx, key, []byte("data"), 5*time.Second); err != nil {
+		t.Fatalf("Set returned error: %v", err)
+	}
+
+	// Still valid.
+	if _, err := store.Get(ctx, key); err != nil {
+		t.Fatalf("Get before expiry returned error: %v", err)
+	}
+
+	// Advance past TTL.
+	now = now.Add(6 * time.Second)
+	_, err := store.Get(ctx, key)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get after expiry error = %v, want ErrNotFound", err)
+	}
+
+	// Lazy eviction should have removed the entry.
+	if store.Len() != 0 {
+		t.Fatalf("Len = %d, want 0 after lazy eviction", store.Len())
+	}
+}
+
+func TestEvictsOldestWhenAtCapacity(t *testing.T) {
+	t.Parallel()
+	store := NewInMemoryStore(Config{MaxEntries: 2, DefaultTTL: time.Minute})
+	defer store.Close()
+
+	ctx := context.Background()
+	if err := store.Set(ctx, "a", []byte("1"), time.Minute); err != nil {
+		t.Fatalf("Set a: %v", err)
+	}
+	if err := store.Set(ctx, "b", []byte("2"), time.Minute); err != nil {
+		t.Fatalf("Set b: %v", err)
+	}
+	// This should evict "a".
+	if err := store.Set(ctx, "c", []byte("3"), time.Minute); err != nil {
+		t.Fatalf("Set c: %v", err)
+	}
+
+	if _, err := store.Get(ctx, "a"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get a after eviction error = %v, want ErrNotFound", err)
+	}
+	if _, err := store.Get(ctx, "b"); err != nil {
+		t.Fatal("b should still be cached")
+	}
+	if _, err := store.Get(ctx, "c"); err != nil {
+		t.Fatal("c should be cached")
+	}
+}
+
+func TestDeleteRemovesEntry(t *testing.T) {
+	t.Parallel()
+	store := NewInMemoryStore(Config{MaxEntries: 8, DefaultTTL: time.Minute})
+	defer store.Close()
+
+	ctx := context.Background()
+	key := TenantOrderKey(7, 101)
+	_ = store.Set(ctx, key, []byte("data"), time.Minute)
+
+	if err := store.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+
+	_, err := store.Get(ctx, key)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get after Delete error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeletePrefixRemovesMatchingEntries(t *testing.T) {
+	t.Parallel()
+	store := NewInMemoryStore(Config{MaxEntries: 8, DefaultTTL: time.Minute})
+	defer store.Close()
+
+	ctx := context.Background()
+	_ = store.Set(ctx, TenantOrderKey(7, 101), []byte("o1"), time.Minute)
+	_ = store.Set(ctx, TenantOrderKey(7, 102), []byte("o2"), time.Minute)
+	_ = store.Set(ctx, TenantPaymentListKey(7, 101), []byte("p1"), time.Minute)
+	_ = store.Set(ctx, TenantOrderKey(99, 1), []byte("other"), time.Minute)
+
+	if err := store.DeletePrefix(ctx, TenantOrderPrefix(7)); err != nil {
+		t.Fatalf("DeletePrefix returned error: %v", err)
+	}
+
+	// All tenant 7 order-prefixed entries should be gone.
+	for _, key := range []string{TenantOrderKey(7, 101), TenantOrderKey(7, 102), TenantPaymentListKey(7, 101)} {
+		if _, err := store.Get(ctx, key); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("Get(%s) after prefix delete error = %v, want ErrNotFound", key, err)
+		}
+	}
+
+	// Tenant 99 entry should survive.
+	if _, err := store.Get(ctx, TenantOrderKey(99, 1)); err != nil {
+		t.Fatalf("tenant 99 entry should survive prefix delete: %v", err)
+	}
+}
+
+func TestClosedStoreRejectsOperations(t *testing.T) {
+	t.Parallel()
+	store := NewInMemoryStore(Config{MaxEntries: 8, DefaultTTL: time.Minute})
+	store.Close()
+
+	ctx := context.Background()
+	if _, err := store.Get(ctx, "k"); !errors.Is(err, ErrCacheClosed) {
+		t.Fatalf("Get on closed store error = %v, want ErrCacheClosed", err)
+	}
+	if err := store.Set(ctx, "k", []byte("v"), time.Minute); !errors.Is(err, ErrCacheClosed) {
+		t.Fatalf("Set on closed store error = %v, want ErrCacheClosed", err)
+	}
+}
+
+func TestInvalidatorInvalidatesOrderData(t *testing.T) {
+	t.Parallel()
+	store := NewInMemoryStore(Config{MaxEntries: 8, DefaultTTL: time.Minute})
+	defer store.Close()
+
+	ctx := context.Background()
+	orderKey := TenantOrderKey(7, 101)
+	listKey := TenantOrderListKey(7)
+	_ = store.Set(ctx, orderKey, []byte("order"), time.Minute)
+	_ = store.Set(ctx, listKey, []byte("list"), time.Minute)
+
+	inv := NewInvalidator(store)
+	inv.InvalidateOrder(ctx, 7, 101)
+
+	if _, err := store.Get(ctx, orderKey); !errors.Is(err, ErrNotFound) {
+		t.Fatal("order key should be invalidated")
+	}
+	if _, err := store.Get(ctx, listKey); !errors.Is(err, ErrNotFound) {
+		t.Fatal("order list key should be invalidated")
+	}
+}
+
+func TestInvalidatorInvalidatesPaymentData(t *testing.T) {
+	t.Parallel()
+	store := NewInMemoryStore(Config{MaxEntries: 8, DefaultTTL: time.Minute})
+	defer store.Close()
+
+	ctx := context.Background()
+	paymentKey := TenantPaymentListKey(7, 101)
+	_ = store.Set(ctx, paymentKey, []byte("payments"), time.Minute)
+
+	inv := NewInvalidator(store)
+	inv.InvalidatePayments(ctx, 7, 101)
+
+	if _, err := store.Get(ctx, paymentKey); !errors.Is(err, ErrNotFound) {
+		t.Fatal("payment key should be invalidated")
+	}
+}
+
+func TestNilInvalidatorIsSafe(t *testing.T) {
+	t.Parallel()
+	var inv *Invalidator
+	// Should not panic.
+	inv.InvalidateOrder(context.Background(), 7, 101)
+	inv.InvalidatePayments(context.Background(), 7, 101)
+	inv.InvalidateTenantOrders(context.Background(), 7)
+}
+
+func TestNoopCacheReturnsNotFound(t *testing.T) {
+	t.Parallel()
+	c := NoopCache{}
+	if _, err := c.Get(context.Background(), "k"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("NoopCache.Get error = %v, want ErrNotFound", err)
+	}
+	if err := c.Set(context.Background(), "k", []byte("v"), time.Minute); err != nil {
+		t.Fatalf("NoopCache.Set returned error: %v", err)
+	}
+}
+
+func TestSingleflightDeduplicatesConcurrentLoads(t *testing.T) {
+	t.Parallel()
+
+	var sf Singleflight
+	var calls atomic.Int64
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			val, err := sf.Do("hot-key", func() ([]byte, error) {
+				calls.Add(1)
+				time.Sleep(10 * time.Millisecond) // simulate DB lookup
+				return []byte("result"), nil
+			})
+			if err != nil {
+				t.Errorf("Do returned error: %v", err)
+			}
+			if string(val) != "result" {
+				t.Errorf("Do = %q, want %q", val, "result")
+			}
+		}()
+	}
+	wg.Wait()
+
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("fn was called %d times, want 1 (singleflight should deduplicate)", n)
+	}
+}
+
+func TestEmptyKeyReturnsError(t *testing.T) {
+	t.Parallel()
+	store := NewInMemoryStore(Config{MaxEntries: 8, DefaultTTL: time.Minute})
+	defer store.Close()
+
+	ctx := context.Background()
+	if _, err := store.Get(ctx, ""); !errors.Is(err, ErrKeyEmpty) {
+		t.Fatalf("Get empty key error = %v, want ErrKeyEmpty", err)
+	}
+	if err := store.Set(ctx, "", []byte("v"), time.Minute); !errors.Is(err, ErrKeyEmpty) {
+		t.Fatalf("Set empty key error = %v, want ErrKeyEmpty", err)
+	}
+}
+
+func TestUpdateExistingKeyDoesNotChangeCapacity(t *testing.T) {
+	t.Parallel()
+	store := NewInMemoryStore(Config{MaxEntries: 2, DefaultTTL: time.Minute})
+	defer store.Close()
+
+	ctx := context.Background()
+	_ = store.Set(ctx, "a", []byte("1"), time.Minute)
+	_ = store.Set(ctx, "b", []byte("2"), time.Minute)
+
+	// Update "a" — should NOT evict "b".
+	_ = store.Set(ctx, "a", []byte("updated"), time.Minute)
+
+	if store.Len() != 2 {
+		t.Fatalf("Len = %d, want 2", store.Len())
+	}
+	got, _ := store.Get(ctx, "a")
+	if string(got) != "updated" {
+		t.Fatalf("Get a = %q, want %q", got, "updated")
+	}
+	if _, err := store.Get(ctx, "b"); err != nil {
+		t.Fatal("b should still be cached after updating a")
+	}
+}

--- a/11-flagship/01-opslane/internal/cache/cache_test.go
+++ b/11-flagship/01-opslane/internal/cache/cache_test.go
@@ -285,27 +285,31 @@ func TestSingleflightPanicRecovery(t *testing.T) {
 	var sf Singleflight
 	key := "panic-key"
 
-	// First call panics
-	func() {
-		defer func() {
-			_ = recover()
-		}()
-		_, _ = sf.Do(key, func() ([]byte, error) {
-			panic("simulated panic")
-		})
-	}()
+	// First call panics — but Do should recover and return an error.
+	val, err := sf.Do(key, func() ([]byte, error) {
+		panic("simulated panic")
+	})
+	if err == nil {
+		t.Fatal("expected error from panic, got nil")
+	}
+	if val != nil {
+		t.Fatalf("expected nil value from panic, got %q", val)
+	}
+	if got := err.Error(); got != "cache: singleflight panic: simulated panic" {
+		t.Fatalf("unexpected error message: %s", got)
+	}
 
-	// Second call should not block, meaning the key was cleaned up and wg was released
+	// Second call should not block, meaning the key was cleaned up.
 	done := make(chan struct{})
 	go func() {
-		val, err := sf.Do(key, func() ([]byte, error) {
+		v, e := sf.Do(key, func() ([]byte, error) {
 			return []byte("recovered"), nil
 		})
-		if err != nil {
-			t.Errorf("Do returned error: %v", err)
+		if e != nil {
+			t.Errorf("Do returned error: %v", e)
 		}
-		if string(val) != "recovered" {
-			t.Errorf("Do = %q, want %q", val, "recovered")
+		if string(v) != "recovered" {
+			t.Errorf("Do = %q, want %q", v, "recovered")
 		}
 		close(done)
 	}()

--- a/11-flagship/01-opslane/internal/cache/store.go
+++ b/11-flagship/01-opslane/internal/cache/store.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package cache
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+)
+
+// InMemoryStore is a bounded, TTL-aware in-memory cache.
+//
+// Design decisions:
+//   - sync.RWMutex protects the map; reads take the read-lock, writes take
+//     the write-lock. This keeps contention low under read-heavy workloads.
+//   - When the cache reaches MaxEntries, the oldest entry is evicted. This
+//     is not true LRU (no access-time tracking) — it is insert-order eviction.
+//     For a teaching codebase this is an acceptable simplification; real
+//     production caches use probabilistic LRU or slab allocators.
+//   - Expired entries are cleaned lazily on Get and periodically by a
+//     background goroutine. The background janitor prevents slow memory
+//     growth when keys are set but never read again.
+//   - The store is safe to use concurrently from multiple goroutines.
+type InMemoryStore struct {
+	mu      sync.RWMutex
+	entries map[string]entry
+	order   []string // insertion order for eviction
+	config  Config
+	now     func() time.Time
+
+	closed chan struct{}
+	once   sync.Once
+}
+
+// NewInMemoryStore creates a bounded in-memory cache with a background
+// janitor that cleans expired entries every cleanupInterval.
+func NewInMemoryStore(config Config) *InMemoryStore {
+	if config.MaxEntries <= 0 {
+		config.MaxEntries = DefaultConfig().MaxEntries
+	}
+	if config.DefaultTTL <= 0 {
+		config.DefaultTTL = DefaultConfig().DefaultTTL
+	}
+
+	s := &InMemoryStore{
+		entries: make(map[string]entry, config.MaxEntries),
+		order:   make([]string, 0, config.MaxEntries),
+		config:  config,
+		now:     time.Now,
+		closed:  make(chan struct{}),
+	}
+
+	go s.janitor(30 * time.Second)
+
+	return s
+}
+
+func (s *InMemoryStore) Get(_ context.Context, key string) ([]byte, error) {
+	if key == "" {
+		return nil, ErrKeyEmpty
+	}
+
+	select {
+	case <-s.closed:
+		return nil, ErrCacheClosed
+	default:
+	}
+
+	s.mu.RLock()
+	e, ok := s.entries[key]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	if e.expired(s.now()) {
+		// Lazy eviction: delete expired entry on read miss.
+		s.mu.Lock()
+		if current, stillThere := s.entries[key]; stillThere && current.expired(s.now()) {
+			delete(s.entries, key)
+			s.removeFromOrder(key)
+		}
+		s.mu.Unlock()
+		return nil, ErrNotFound
+	}
+
+	// Return a copy so the caller cannot mutate cached data.
+	cp := make([]byte, len(e.value))
+	copy(cp, e.value)
+	return cp, nil
+}
+
+func (s *InMemoryStore) Set(_ context.Context, key string, value []byte, ttl time.Duration) error {
+	if key == "" {
+		return ErrKeyEmpty
+	}
+
+	select {
+	case <-s.closed:
+		return ErrCacheClosed
+	default:
+	}
+
+	if ttl <= 0 {
+		ttl = s.config.DefaultTTL
+	}
+
+	// Copy value so the caller cannot mutate cached data after Set returns.
+	cp := make([]byte, len(value))
+	copy(cp, value)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// If the key already exists, update in place without changing order.
+	if _, exists := s.entries[key]; exists {
+		s.entries[key] = entry{value: cp, expiresAt: s.now().Add(ttl)}
+		return nil
+	}
+
+	// Evict the oldest entry if at capacity.
+	if len(s.entries) >= s.config.MaxEntries {
+		s.evictOldest()
+	}
+
+	s.entries[key] = entry{value: cp, expiresAt: s.now().Add(ttl)}
+	s.order = append(s.order, key)
+	return nil
+}
+
+func (s *InMemoryStore) Delete(_ context.Context, key string) error {
+	if key == "" {
+		return ErrKeyEmpty
+	}
+
+	select {
+	case <-s.closed:
+		return ErrCacheClosed
+	default:
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.entries[key]; exists {
+		delete(s.entries, key)
+		s.removeFromOrder(key)
+	}
+	return nil
+}
+
+// DeletePrefix removes all entries whose key starts with the given prefix.
+// This supports batch invalidation, e.g. clearing all order data for a tenant.
+func (s *InMemoryStore) DeletePrefix(_ context.Context, prefix string) error {
+	if prefix == "" {
+		return ErrKeyEmpty
+	}
+
+	select {
+	case <-s.closed:
+		return ErrCacheClosed
+	default:
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var toRemove []string
+	for key := range s.entries {
+		if strings.HasPrefix(key, prefix) {
+			toRemove = append(toRemove, key)
+		}
+	}
+
+	for _, key := range toRemove {
+		delete(s.entries, key)
+		s.removeFromOrder(key)
+	}
+
+	return nil
+}
+
+// Close stops the background janitor. After Close returns, Get and Set
+// return ErrCacheClosed.
+func (s *InMemoryStore) Close() error {
+	s.once.Do(func() {
+		close(s.closed)
+	})
+	return nil
+}
+
+// Len returns the number of entries currently in the cache.
+// Exported for tests and diagnostics.
+func (s *InMemoryStore) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.entries)
+}
+
+// evictOldest removes the entry that was inserted first. Must be called
+// with s.mu held for writing.
+func (s *InMemoryStore) evictOldest() {
+	if len(s.order) == 0 {
+		return
+	}
+	oldest := s.order[0]
+	s.order = s.order[1:]
+	delete(s.entries, oldest)
+}
+
+// removeFromOrder removes a key from the insertion-order slice.
+// Must be called with s.mu held for writing.
+func (s *InMemoryStore) removeFromOrder(key string) {
+	for i, k := range s.order {
+		if k == key {
+			s.order = append(s.order[:i], s.order[i+1:]...)
+			return
+		}
+	}
+}
+
+// janitor periodically sweeps expired entries.
+func (s *InMemoryStore) janitor(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.closed:
+			return
+		case <-ticker.C:
+			s.sweep()
+		}
+	}
+}
+
+// sweep removes all expired entries in one pass.
+func (s *InMemoryStore) sweep() {
+	now := s.now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var toRemove []string
+	for key, e := range s.entries {
+		if e.expired(now) {
+			toRemove = append(toRemove, key)
+		}
+	}
+
+	for _, key := range toRemove {
+		delete(s.entries, key)
+		s.removeFromOrder(key)
+	}
+}

--- a/11-flagship/01-opslane/internal/middleware/cache.go
+++ b/11-flagship/01-opslane/internal/middleware/cache.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Rasel Hossen
+// See LICENSE for usage terms.
+
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// CacheControl sets Cache-Control headers on responses. Use this for
+// public endpoints like health or static assets. Protected API
+// endpoints should use "no-store" to prevent proxies and browsers from
+// caching authenticated data.
+//
+// maxAge controls how long clients and intermediary proxies are allowed
+// to serve the cached response without revalidating with the origin.
+func CacheControl(maxAge time.Duration) func(http.Handler) http.Handler {
+	seconds := int(maxAge.Seconds())
+	publicValue := fmt.Sprintf("public, max-age=%d", seconds)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if seconds > 0 {
+				w.Header().Set("Cache-Control", publicValue)
+			} else {
+				w.Header().Set("Cache-Control", "no-store")
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// NoCache sets Cache-Control: no-store on responses. This is the right
+// default for authenticated API endpoints where stale data could leak
+// across tenants or users.
+func NoCache(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/11-flagship/01-opslane/modules/08-caching/README.md
+++ b/11-flagship/01-opslane/modules/08-caching/README.md
@@ -19,23 +19,92 @@ Introduce cache-aware behavior without pretending cache invalidation is free.
 
 ## Proof Surface
 
-This module is not implemented in the current tree yet.
+This module is implemented in the current tree.
 
-When it is complete:
+Run:
 
-- `go test` must pass for the future `11-flagship/01-opslane/internal/cache` package
-- invalidation tests must prove cache updates follow writes intentionally
+```bash
+go test ./11-flagship/01-opslane/internal/cache/...
+go run ./11-flagship/01-opslane/scripts/progress.go
+```
 
-Expected new files:
+The proof surface now covers:
+
+- bounded in-memory cache with TTL and insert-order eviction
+- lazy expiry on reads and background janitor sweep
+- copy-on-read and copy-on-write for mutation safety
+- explicit invalidation via Invalidator after order and payment writes
+- prefix-based batch invalidation for tenant-scoped cache groups
+- singleflight stampede prevention on hot-key expiry
+- HTTP Cache-Control middleware for public and authenticated endpoints
+- NoopCache for environments where caching is disabled
+
+Implemented files:
 
 - `internal/cache/cache.go`
 - `internal/cache/store.go`
 - `internal/middleware/cache.go`
 
+Implementation map: [SURFACE.md](./SURFACE.md)
+
 ## Required Files and Boundaries
 
 Caching should be additive, not a hidden source of truth.
 PostgreSQL remains the system of record.
+
+## Machine View
+
+The cache sits between the service layer and the repository layer.
+Reads check the cache first. On miss, the service reads from PostgreSQL
+and populates the cache. On write, the Invalidator deletes affected
+cache keys so the next read comes from the database.
+
+```mermaid
+flowchart TD
+    H["HTTP handler"] --> S["Service layer"]
+    S --> CG["cache.Get(key)"]
+    CG -->|HIT| RET["Return cached value"]
+    CG -->|MISS| SF["singleflight.Do(key)"]
+    SF --> DB["PostgreSQL read"]
+    DB --> CS["cache.Set(key, result, ttl)"]
+    CS --> RET
+```
+
+The important constraint:
+
+> Invalidation happens AFTER the write succeeds, not before.
+> If the DB write fails, the cache still holds the old (correct) value.
+
+## Diagram
+
+```mermaid
+flowchart TD
+    WH["HTTP handler"] --> WS["Service layer"]
+
+    subgraph Write Path
+        WS --> DBW["PostgreSQL write"]
+        DBW --> INV["invalidator.InvalidateOrder(tenantID, orderID)"]
+        INV --> DEL["cache.Delete(key)"]
+    end
+
+    subgraph Read Path
+        WS --> CG2["cache.Get(key)"]
+        CG2 -->|HIT| R["Return"]
+        CG2 -->|MISS| SF2["singleflight.Do"]
+        SF2 --> DBR["PostgreSQL read"]
+        DBR --> CS2["cache.Set(key, value, ttl)"]
+        CS2 --> R
+    end
+```
+
+## Try It
+
+Change `MaxEntries` in a test from `2` to `3`.
+Observe that the third `Set` no longer evicts the first entry.
+
+Then change `DefaultTTL` from `time.Minute` to `1 * time.Millisecond`.
+Observe that reads immediately return `ErrNotFound` because entries expire
+before the next `Get` call.
 
 ## Engineering Questions
 

--- a/11-flagship/01-opslane/modules/08-caching/SURFACE.md
+++ b/11-flagship/01-opslane/modules/08-caching/SURFACE.md
@@ -1,0 +1,31 @@
+# OPSL.8 Implemented Code Surface
+
+This module is now implemented in the current tree.
+
+## Primary Code Files
+
+- [`internal/cache/cache.go`](../../internal/cache/cache.go)
+- [`internal/cache/store.go`](../../internal/cache/store.go)
+- [`internal/middleware/cache.go`](../../internal/middleware/cache.go)
+
+## Proof Commands
+
+```bash
+go test ./11-flagship/01-opslane/internal/cache/...
+go run ./11-flagship/01-opslane/scripts/progress.go
+```
+
+## What This Proves
+
+- in-memory cache respects bounded capacity with insert-order eviction
+- TTL expiry is enforced on reads and cleaned by a background janitor
+- cached values are copied on read and write to prevent mutation
+- explicit invalidation removes stale data after order and payment writes
+- prefix-based deletion clears tenant-scoped cache groups atomically
+- singleflight deduplicates concurrent loads for the same key
+- HTTP Cache-Control middleware sets correct headers for public and authenticated endpoints
+- NoopCache provides a safe zero-allocation fallback
+
+## What To Read Next
+
+If you want the current learner map, go back to [MODULES.md](../../MODULES.md).


### PR DESCRIPTION
## Summary

Implements OPSL.8 Caching Layer for the Opslane flagship project.

Closes #400

## What Changed

### New Files
- `internal/cache/cache.go` — Cache interface, key helpers, Invalidator, Singleflight, NoopCache
- `internal/cache/store.go` — InMemoryStore with bounded capacity, TTL, and background janitor
- `internal/cache/cache_test.go` — 15 behavioral tests
- `internal/middleware/cache.go` — HTTP Cache-Control and NoCache middleware
- `modules/08-caching/SURFACE.md` — Implementation map

### Updated Files
- `modules/08-caching/README.md` — Full spec with mermaid diagrams, proof surface, machine view
- `MODULES.md` — OPSL.8 marked as implemented with proof commands
- `README.md` — Module 8 snapshot, OPSL.9 next step

## Design Decisions

1. **PostgreSQL stays system of record** — cache is additive, never authoritative
2. **Insert-order eviction** — simpler than true LRU, acceptable for teaching codebase
3. **Copy-on-read/write** — prevents callers from mutating cached data
4. **Singleflight** — prevents thundering herd on hot key expiry
5. **Lazy expiry + janitor** — expired entries removed on read and periodically swept
6. **Invalidation after writes** — never before; if DB write fails, cache keeps correct old value

## Proof Surface

```
go test -count=1 ./11-flagship/01-opslane/internal/cache/...
ok  	github.com/rasel9t6/the-go-engineer/.../internal/cache	0.300s

go run ./11-flagship/01-opslane/scripts/progress.go
OPSL.8   Caching Layer                        complete
```

## CI Checks
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all 11 packages pass)
- [x] `go fmt ./...` (no diff)
- [x] `go run ./scripts/validate_curriculum.go` (511 files validated)
