### PR TITLE
[CHORE] Migrate repository URLs to swe-labs org

### DIFF
--- a/05-packages-io/01-modules-and-packages/1-module-basics/main.go
+++ b/05-packages-io/01-modules-and-packages/1-module-basics/main.go
@@ -46,7 +46,7 @@ import "fmt"
 //
 // File: go.mod
 //
-//	module github.com/rasel9t6/the-go-engineer <- Module path: the root import path for all packages
+//	module github.com/swe-labs/the-go-engineer <- Module path: the root import path for all packages
 //	go 1.24                                    <- Minimum Go version required to build
 //
 //	require (
@@ -83,10 +83,10 @@ func main() {
 	fmt.Println("=== Go Module Basics ===")
 	fmt.Println()
 
-	fmt.Println("Module path: github.com/rasel9t6/the-go-engineer")
+	fmt.Println("Module path: github.com/swe-labs/the-go-engineer")
 	fmt.Println("This means packages in this repo are importable as:")
-	fmt.Println("  github.com/rasel9t6/the-go-engineer/06-backend-db/01-web-and-database/databases/6-repository/models")
-	fmt.Println("  github.com/rasel9t6/the-go-engineer/06-backend-db/01-web-and-database/databases/6-repository/repository")
+	fmt.Println("  github.com/swe-labs/the-go-engineer/06-backend-db/01-web-and-database/databases/6-repository/models")
+	fmt.Println("  github.com/swe-labs/the-go-engineer/06-backend-db/01-web-and-database/databases/6-repository/repository")
 	fmt.Println()
 
 	commands := []struct {

--- a/06-backend-db/01-web-and-database/databases/6-repository/main.go
+++ b/06-backend-db/01-web-and-database/databases/6-repository/main.go
@@ -35,7 +35,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
-	"github.com/rasel9t6/the-go-engineer/06-backend-db/01-web-and-database/databases/6-repository/repository"
+	"github.com/swe-labs/the-go-engineer/06-backend-db/01-web-and-database/databases/6-repository/repository"
 )
 
 // Stage 06: Databases - Repository Pattern

--- a/06-backend-db/01-web-and-database/databases/6-repository/main_test.go
+++ b/06-backend-db/01-web-and-database/databases/6-repository/main_test.go
@@ -12,7 +12,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
-	"github.com/rasel9t6/the-go-engineer/06-backend-db/01-web-and-database/databases/6-repository/repository"
+	"github.com/swe-labs/the-go-engineer/06-backend-db/01-web-and-database/databases/6-repository/repository"
 )
 
 const repositorySchema = `

--- a/06-backend-db/01-web-and-database/databases/6-repository/repository/user.go
+++ b/06-backend-db/01-web-and-database/databases/6-repository/repository/user.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/rasel9t6/the-go-engineer/06-backend-db/01-web-and-database/databases/6-repository/models"
+	"github.com/swe-labs/the-go-engineer/06-backend-db/01-web-and-database/databases/6-repository/models"
 )
 
 // UserRepository defines the contract for user data access.

--- a/09-architecture/02-grpc/1-unary/client/main.go
+++ b/09-architecture/02-grpc/1-unary/client/main.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	pb "github.com/rasel9t6/the-go-engineer/09-architecture/02-grpc/gen"
+	pb "github.com/swe-labs/the-go-engineer/09-architecture/02-grpc/gen"
 )
 
 // ============================================================================

--- a/09-architecture/02-grpc/1-unary/server/main.go
+++ b/09-architecture/02-grpc/1-unary/server/main.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	pb "github.com/rasel9t6/the-go-engineer/09-architecture/02-grpc/gen"
+	pb "github.com/swe-labs/the-go-engineer/09-architecture/02-grpc/gen"
 )
 
 // ============================================================================

--- a/09-architecture/02-grpc/2-streaming/client/main.go
+++ b/09-architecture/02-grpc/2-streaming/client/main.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	pb "github.com/rasel9t6/the-go-engineer/09-architecture/02-grpc/gen"
+	pb "github.com/swe-labs/the-go-engineer/09-architecture/02-grpc/gen"
 )
 
 // ============================================================================

--- a/09-architecture/02-grpc/2-streaming/server/main.go
+++ b/09-architecture/02-grpc/2-streaming/server/main.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	pb "github.com/rasel9t6/the-go-engineer/09-architecture/02-grpc/gen"
+	pb "github.com/swe-labs/the-go-engineer/09-architecture/02-grpc/gen"
 )
 
 // ============================================================================

--- a/09-architecture/02-grpc/gen/order.pb.go
+++ b/09-architecture/02-grpc/gen/order.pb.go
@@ -541,7 +541,7 @@ const file_proto_order_proto_rawDesc = "" +
 	"\vCreateOrder\x12\x1c.order.v1.CreateOrderRequest\x1a\x1d.order.v1.CreateOrderResponse\x12A\n" +
 	"\bGetOrder\x12\x19.order.v1.GetOrderRequest\x1a\x1a.order.v1.GetOrderResponse\x12T\n" +
 	"\x10WatchOrderStatus\x12!.order.v1.WatchOrderStatusRequest\x1a\x1b.order.v1.OrderStatusUpdate0\x01\x12F\n" +
-	"\x12ProcessOrderStream\x12\x13.order.v1.OrderItem\x1a\x17.order.v1.ProcessResult(\x010\x01B1Z/github.com/rasel9t6/the-go-engineer/09-architecture/02-grpc/genb\x06proto3"
+	"\x12ProcessOrderStream\x12\x13.order.v1.OrderItem\x1a\x17.order.v1.ProcessResult(\x010\x01B1Z/github.com/swe-labs/the-go-engineer/09-architecture/02-grpc/genb\x06proto3"
 
 var (
 	file_proto_order_proto_rawDescOnce sync.Once

--- a/09-architecture/02-grpc/proto/order.proto
+++ b/09-architecture/02-grpc/proto/order.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package order.v1;
-option go_package = "github.com/rasel9t6/the-go-engineer/09-architecture/02-grpc/gen";
+option go_package = "github.com/swe-labs/the-go-engineer/09-architecture/02-grpc/gen";
 
 // ============================================================================
 // Section 26: gRPC - Service Definition

--- a/10-production/06-code-generation/2-mockery/main.go
+++ b/10-production/06-code-generation/2-mockery/main.go
@@ -29,7 +29,7 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/rasel9t6/the-go-engineer/10-production/06-code-generation/2-mockery/internal/storage"
+	"github.com/swe-labs/the-go-engineer/10-production/06-code-generation/2-mockery/internal/storage"
 )
 
 // Stage 10: Code Generation - Mockery Workflow

--- a/11-flagship/01-opslane/cmd/server/main.go
+++ b/11-flagship/01-opslane/cmd/server/main.go
@@ -12,14 +12,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/config"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/handlers"
-	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/workers"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/auth"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/config"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/db"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/events"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/handlers"
+	paymentflow "github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/payment"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/services"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/workers"
 )
 
 const startupDatabaseTimeout = 10 * time.Second

--- a/11-flagship/01-opslane/cmd/server/shutdown.go
+++ b/11-flagship/01-opslane/cmd/server/shutdown.go
@@ -13,8 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/workers"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/events"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/workers"
 )
 
 // setupGracefulShutdown configures a background goroutine that listens for

--- a/11-flagship/01-opslane/internal/auth/context_test.go
+++ b/11-flagship/01-opslane/internal/auth/context_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 func TestRequireIdentityReturnsContextIdentity(t *testing.T) {

--- a/11-flagship/01-opslane/internal/auth/middleware_test.go
+++ b/11-flagship/01-opslane/internal/auth/middleware_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 func TestRequireAuthAddsIdentityToRequestContext(t *testing.T) {

--- a/11-flagship/01-opslane/internal/auth/service.go
+++ b/11-flagship/01-opslane/internal/auth/service.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 // UserLookup is the minimum repository behavior auth needs to verify credentials.

--- a/11-flagship/01-opslane/internal/auth/service_test.go
+++ b/11-flagship/01-opslane/internal/auth/service_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 func TestServiceLoginIssuesTokenForValidCredentials(t *testing.T) {

--- a/11-flagship/01-opslane/internal/auth/token.go
+++ b/11-flagship/01-opslane/internal/auth/token.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 var (

--- a/11-flagship/01-opslane/internal/auth/token_test.go
+++ b/11-flagship/01-opslane/internal/auth/token_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 const testTokenSecret = "test-secret-with-at-least-thirty-two-characters"

--- a/11-flagship/01-opslane/internal/db/repository.go
+++ b/11-flagship/01-opslane/internal/db/repository.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/lib/pq"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/config"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/config"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 // ErrInvalidReference means a tenant-scoped row points at a parent row that does not exist.

--- a/11-flagship/01-opslane/internal/db/repository_integration_test.go
+++ b/11-flagship/01-opslane/internal/db/repository_integration_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/config"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/config"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"

--- a/11-flagship/01-opslane/internal/events/types.go
+++ b/11-flagship/01-opslane/internal/events/types.go
@@ -6,7 +6,7 @@ package events
 import (
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 // Type represents the routing key for a specific business event.

--- a/11-flagship/01-opslane/internal/handlers/api.go
+++ b/11-flagship/01-opslane/internal/handlers/api.go
@@ -12,11 +12,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
-	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/auth"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/db"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
+	paymentflow "github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/payment"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
 const maxJSONBodySize = 1 << 20

--- a/11-flagship/01-opslane/internal/handlers/handlers.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers.go
@@ -12,11 +12,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/middleware"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
-	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/auth"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/middleware"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
+	paymentflow "github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/payment"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
 const healthDatabaseTimeout = 2 * time.Second

--- a/11-flagship/01-opslane/internal/handlers/handlers_test.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/auth"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
-	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/auth"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/db"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
+	paymentflow "github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/payment"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
 func TestProtectedMeRouteReturnsAuthenticatedTenantIdentity(t *testing.T) {

--- a/11-flagship/01-opslane/internal/payment/gateway.go
+++ b/11-flagship/01-opslane/internal/payment/gateway.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 var (

--- a/11-flagship/01-opslane/internal/payment/gateway_test.go
+++ b/11-flagship/01-opslane/internal/payment/gateway_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 func TestSimulatedGatewaySettlesByDefault(t *testing.T) {

--- a/11-flagship/01-opslane/internal/services/order.go
+++ b/11-flagship/01-opslane/internal/services/order.go
@@ -9,8 +9,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/db"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 // OrderRepository is the minimum persistence surface the order workflow needs.

--- a/11-flagship/01-opslane/internal/services/order_test.go
+++ b/11-flagship/01-opslane/internal/services/order_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/db"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 func TestOrderServiceCreateOrderCreatesPendingOrderAndReservesInventory(t *testing.T) {

--- a/11-flagship/01-opslane/internal/services/payment.go
+++ b/11-flagship/01-opslane/internal/services/payment.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
-	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/db"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
+	paymentflow "github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/payment"
 )
 
 var (

--- a/11-flagship/01-opslane/internal/services/payment_test.go
+++ b/11-flagship/01-opslane/internal/services/payment_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/db"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
-	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/db"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
+	paymentflow "github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/payment"
 )
 
 func TestPaymentServiceSettlesPaymentAndMarksOrderPaid(t *testing.T) {

--- a/11-flagship/01-opslane/internal/services/validation.go
+++ b/11-flagship/01-opslane/internal/services/validation.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
 var (

--- a/11-flagship/01-opslane/internal/tracing/tracing.go
+++ b/11-flagship/01-opslane/internal/tracing/tracing.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/logging"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/logging"
 )
 
 // SpanContext holds timing and identity data for a named operation.

--- a/11-flagship/01-opslane/internal/tracing/tracing_test.go
+++ b/11-flagship/01-opslane/internal/tracing/tracing_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/logging"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/logging"
 )
 
 func TestStartSpanRecordsNameAndCorrelation(t *testing.T) {

--- a/11-flagship/01-opslane/internal/workers/notification_worker.go
+++ b/11-flagship/01-opslane/internal/workers/notification_worker.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/events"
 )
 
 type Notification struct {

--- a/11-flagship/01-opslane/internal/workers/order_processor.go
+++ b/11-flagship/01-opslane/internal/workers/order_processor.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/events"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
 type OrderWorkflow interface {

--- a/11-flagship/01-opslane/internal/workers/payment_processor.go
+++ b/11-flagship/01-opslane/internal/workers/payment_processor.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
-	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/events"
+	paymentflow "github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/payment"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
 type PaymentWorkflow interface {

--- a/11-flagship/01-opslane/internal/workers/pool.go
+++ b/11-flagship/01-opslane/internal/workers/pool.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/events"
 )
 
 var (

--- a/11-flagship/01-opslane/internal/workers/pool_test.go
+++ b/11-flagship/01-opslane/internal/workers/pool_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/events"
 )
 
 func TestPoolRejectsWhenQueueIsFull(t *testing.T) {

--- a/11-flagship/01-opslane/internal/workers/processors_test.go
+++ b/11-flagship/01-opslane/internal/workers/processors_test.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/events"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/models"
-	paymentflow "github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/payment"
-	"github.com/rasel9t6/the-go-engineer/11-flagship/01-opslane/internal/services"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/events"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
+	paymentflow "github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/payment"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
 func TestOrderProcessorTransitionsOrderStatus(t *testing.T) {

--- a/CODE-STANDARDS.md
+++ b/CODE-STANDARDS.md
@@ -93,7 +93,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	// Internal
-	"github.com/rasel9t6/the-go-engineer/internal/auth"
+	"github.com/swe-labs/the-go-engineer/internal/auth"
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Go Engineer
 
-[![CI](https://github.com/rasel9t6/the-go-engineer/actions/workflows/ci.yml/badge.svg)](https://github.com/rasel9t6/the-go-engineer/actions)
+[![CI](https://github.com/swe-labs/the-go-engineer/actions/workflows/ci.yml/badge.svg)](https://github.com/swe-labs/the-go-engineer/actions)
 [![License: TGE License v1.0](https://img.shields.io/badge/License-TGE_v1.0-red.svg)](#license)
 
 The Go Engineer is a repository-first Go software engineering curriculum. It teaches Go by combining runnable lessons, production-shaped examples, tests, validation, and a final integrated backend project.
@@ -31,7 +31,7 @@ Requirements:
 - CGO-capable C compiler for `go test -race ./...` and SQLite-backed paths
 
 ```bash
-git clone https://github.com/rasel9t6/the-go-engineer.git
+git clone https://github.com/swe-labs/the-go-engineer.git
 cd the-go-engineer
 go mod download
 go run ./00-how-computers-work/1-what-is-a-program

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rasel9t6/the-go-engineer
+module github.com/swe-labs/the-go-engineer
 
 go 1.26
 

--- a/scripts/validate_curriculum.go
+++ b/scripts/validate_curriculum.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/rasel9t6/the-go-engineer/scripts/internal/curriculumvalidator"
+	"github.com/swe-labs/the-go-engineer/scripts/internal/curriculumvalidator"
 )
 
 func main() {


### PR DESCRIPTION
Closes #419

## Scope
- Section: repository-wide maintenance
- Lesson IDs: none
- Files: module path, internal imports, repository badges/clone URLs, validation tooling, and teaching examples that print/import the module path

## Type
- [ ] [FEAT]
- [ ] [FIX]
- [ ] [DOCS]
- [ ] [TEST]
- [x] [CHORE]
- [ ] [REFACTOR]
- [ ] [SECURITY]
- [ ] [RELEASE]

## Validation
- [x] `go build ./...` *(passed; local Go emitted a non-fatal stat-cache warning from the user module cache)*
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `go mod tidy` *(only intended `go.mod` module path remained; no `go.sum` diff)*
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go test -coverprofile=.cache/coverage.out ./...`
- [x] `go run ./scripts/validate_curriculum.go`
- [x] `git diff --check`
- [x] `git grep -n github.com/rasel9t6/the-go-engineer` returned no tracked matches
- [x] `git grep -n rasel9t6/the-go-engineer` returned no tracked matches

## Review Loop
- [x] findings-first self-review complete
- [x] P0/P1/P2 findings fixed or documented
- [ ] review threads answered
- [ ] addressed threads resolved

## Tracking
- [x] issue created and assigned when appropriate
- [x] labels applied
- [ ] milestone attached when available
- [ ] project item added to `The Go Engineer v2`

## Risk
- This is a repository identity/module-path migration. Existing downstream clones using the old module path may need to update imports and remotes.
- One unrelated local working-tree edit remains intentionally uncommitted: `02-language-basics/04-data-structures/5-slices-2/main.go`.