### PR TITLE
[DOCS] standardize and refine Section 00 curriculum

### DIFF
--- a/00-how-computers-work/1-what-is-a-program/README.md
+++ b/00-how-computers-work/1-what-is-a-program/README.md
@@ -16,8 +16,7 @@ Imagine a cook reading a recipe card.
 - the ingredients are the data
 - the cook is the CPU
 
-The cook does not understand your intent.
-The cook only follows one instruction at a time.
+The cook does not understand your intent. The cook only follows one instruction at a time. If the recipe says "add salt" 100 times, the cook will do it, even if it ruins the meal.
 
 ## Visual Model
 
@@ -32,10 +31,9 @@ graph TD
 
 ## Machine View
 
-Computers only understand one language: binary.
-That is why we need layers between Go code and the hardware.
+Computers only understand one language: binary. Every Go function you write eventually decomposes into a series of numeric codes called **OpCodes** (Operation Codes) stored in RAM.
 
-At a high level, every program eventually decomposes into a small set of instruction families:
+The CPU uses a special internal register called the **Instruction Pointer (IP)** or Program Counter to keep track of where it is in that list.
 
 | Operation | What it means                          |
 | --------- | -------------------------------------- |
@@ -46,15 +44,13 @@ At a high level, every program eventually decomposes into a small set of instruc
 | Read      | Load a value from memory               |
 | Write     | Store a value back into memory         |
 
-Your program is also data.
-The CPU reads instructions from memory, then reads and writes the data those instructions operate on.
+The fetch-decode-execute cycle is the "heartbeat" of the machine:
+1. **Fetch**: The CPU retrieves the OpCode at the address pointed to by the Instruction Pointer.
+2. **Decode**: The CPU determines which hardware circuitry is needed to perform that specific OpCode.
+3. **Execute**: The CPU performs the operation and increments the Instruction Pointer to the next address.
 
-That is why the fetch-decode-execute cycle matters:
-
-1. fetch the next instruction from memory
-2. decode what that instruction means
-3. execute it
-4. move to the next instruction
+> [!NOTE]
+> This fetch-decode-execute cycle is the foundation for understanding how the Go compiler translates source text into executable OpCodes in [HC.2 Code to Execution](../2-code-to-execution/README.md).
 
 ## Run Instructions
 
@@ -64,11 +60,8 @@ go run ./00-how-computers-work/1-what-is-a-program
 
 ## Code Walkthrough
 
-In `main.go`, the demo prints a few simple statements, but the important part is what those prints represent:
-
-- the compiled program is already a list of machine instructions
-- the CPU fetches those instructions in order
-- each `fmt.Println(...)` call only appears because the CPU repeatedly executes that loop
+- **Instruction Sequence**: Notice how the `fmt.Println` calls execute in the exact order they are written. This represents the linear fetching of instructions by the CPU's Instruction Pointer.
+- **Data vs Code**: The strings passed to `Println` are the *data*, while the `Println` function itself is a call to a sequence of *instructions* in the Go runtime.
 
 ## Try It
 
@@ -77,12 +70,13 @@ In `main.go`, the demo prints a few simple statements, but the important part is
 3. Explain why the new line appears only after the earlier instructions finish.
 
 ## In Production
-Programs are stored in memory just like data.
-That is one reason memory corruption bugs and instruction/data confusion can become security problems.
+
+Programs are stored in memory just like data. This is why memory corruption bugs (like Buffer Overflows) are dangerous. If an attacker can overwrite a piece of data memory with their own OpCodes and trick the Instruction Pointer into jumping to that address, they have taken control of your process.
 
 ## Thinking Questions
+
 1. If the CPU can only do a few primitive instruction types, why do some programs still run slowly?
-2. What does “the computer is processing data” physically mean now that you know about the CPU loop?
+2. What does "the computer is processing data" physically mean now that you know about the CPU loop?
 3. If you run the same program twice at the same time, what do you think the OS duplicates and what does it share?
 
 ## Next Step

--- a/00-how-computers-work/1-what-is-a-program/main.go
+++ b/00-how-computers-work/1-what-is-a-program/main.go
@@ -8,20 +8,20 @@
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
-//   - Understand that a program is a list of instructions for a machine to follow, and that the CPU runs a continuous fetch-decode-execute loop to carry ...
+//   - Understand that a program is a list of instructions for a machine to follow.
+//   - The CPU runs a continuous fetch-decode-execute loop to carry those instructions out.
 //
 // WHY THIS MATTERS:
-//   - Imagine a cook reading a recipe card. - the recipe card is the program - the ingredients are the data - the cook is the CPU The cook does not under...
+//   - Imagine a cook reading a recipe card. The recipe is the program, ingredients
+//     are data, and the cook is the CPU. The cook follows one step at a time
+//     without knowing your ultimate intent.
 //
 // RUN:
 //   go run ./00-how-computers-work/1-what-is-a-program
 //
 // KEY TAKEAWAY:
-//   - Understand that a program is a list of instructions for a machine to follow, and that the CPU runs a continuous fetch-decode-execute loop to carry ...
+//   - A program is passive data until the CPU fetches it and turns it into action.
 // ============================================================================
-
-//   Engineers write better code when they can reason about what the machine is
-//   doing instead of treating execution like magic.
 
 package main
 
@@ -32,8 +32,9 @@ func main() {
 	fmt.Println("The CPU keeps fetching, decoding, and executing those instructions.")
 	fmt.Println("Even this printed text is just the visible effect of that loop.")
 
-	// - High-level Go code eventually becomes machine instructions.
-	// - The CPU executes those instructions one step at a time.
+	// - High-level Go code eventually becomes numeric OpCodes (Machine Instructions).
+	// - The CPU's Instruction Pointer (IP) fetches these OpCodes one by one.
+	// - The CPU executes those instructions in a mechanical loop.
 	fmt.Println("\n---------------------------------------------------")
 	fmt.Println("NEXT UP: HC.2 -> 00-how-computers-work/2-code-to-execution")
 	fmt.Println("Run    : go run ./00-how-computers-work/2-code-to-execution")

--- a/00-how-computers-work/2-code-to-execution/README.md
+++ b/00-how-computers-work/2-code-to-execution/README.md
@@ -12,8 +12,7 @@ Understand the journey from Go source code to a running program: tokens, AST, ty
 
 Think of the compiler as a translation pipeline.
 
-You write text for humans.
-The compiler progressively turns that text into representations that are easier for machines to reason about, optimize, and finally execute.
+You write text for humans. The compiler progressively turns that text into representations that are easier for machines to reason about, optimize, and finally execute.
 
 ## Visual Model
 
@@ -30,20 +29,18 @@ graph LR
 
 ## Machine View
 
-The CPU does not run `.go` files.
-It runs machine instructions.
+The CPU does not run `.go` files. It runs machine instructions. Between those two things, Go performs a complex build pipeline:
 
-Between those two things, Go performs a build pipeline:
+1. **Lexing**: Breaks the source text into "Tokens" (like words in a sentence).
+2. **Parsing**: Builds an **Abstract Syntax Tree (AST)** to understand the grammar of your code.
+3. **Type Checking**: Verifies that operations are compatible. This is where most "compile-time" errors are caught.
+4. **IR Generation**: Creates an Intermediate Representation. This is a generic "pseudo-machine code" that Go uses for architecture-independent logic.
+5. **Optimization**: Rewrites the IR to make it faster (e.g., removing unused variables or simplifying math).
+6. **Code Generation**: Translates the optimized IR into the specific **OpCodes** for your CPU (AMD64, ARM64, etc.).
+7. **Linking**: Combines your code with standard library code and resolves the memory addresses for every function call.
 
-1. **Lexing** breaks text into tokens.
-2. **Parsing** builds an Abstract Syntax Tree (AST).
-3. **Type checking** verifies operations and types are compatible.
-4. **IR generation** creates an intermediate representation that is easier to optimize.
-5. **Optimization** improves the generated program before final code generation.
-6. **Code generation** emits machine instructions for the target CPU.
-7. **Linking** combines your code with the compiled packages it depends on.
-
-That is why Go catches many mistakes before the program ever starts.
+> [!NOTE]
+> This pipeline is the direct solution to the gap between human logic and the binary OpCodes introduced in [HC.1 What is a Program?](../1-what-is-a-program/README.md).
 
 ## Run Instructions
 
@@ -53,28 +50,23 @@ go run ./00-how-computers-work/2-code-to-execution
 
 ## Code Walkthrough
 
-The lesson program prints one tiny example through each stage:
-
-- original source text
-- tokenized representation
-- AST shape
-- IR-style operation sequence
-- final machine-oriented result
-
-It is not a real compiler.
-It is a guided mental model of what the real compiler is doing.
+- **Source text**: This is the input to the compiler.
+- **Tokens**: The first stage of machine understanding.
+- **AST Shape**: Represents the hierarchical structure of the logic.
+- **Final Result**: The binary artifact that the OS loads into memory for the CPU to fetch.
 
 ## Try It
 
-1. Run the lesson and read each stage as a transformation, not as decoration.
+1. Run the lesson and read each stage as a transformation, not just decoration.
 2. Change the example expression in `main.go` and update the printed stages to match.
-3. Compare `go run` with `go build` and explain what extra thing `go build` leaves behind.
+3. Compare `go run` with `go build` and explain what extra thing `go build` leaves behind in your directory.
 
 ## In Production
-Build artifacts matter.
-When you deploy Go, you deploy the compiled binary for the target OS and CPU architecture, not the source files.
+
+Build artifacts are the unit of deployment. When you deploy Go, you deploy a compiled binary for the target OS and CPU architecture. You do not need the Go compiler on your production servers; the binary contains the final machine code, linked and ready for the CPU.
 
 ## Thinking Questions
+
 1. Why is IR useful instead of compiling source text directly into machine instructions in one step?
 2. Why does compile-time type checking remove whole categories of runtime failures?
 3. If two source files produce the same AST, what differences between the files stop mattering to the compiler?

--- a/00-how-computers-work/2-code-to-execution/main.go
+++ b/00-how-computers-work/2-code-to-execution/main.go
@@ -8,20 +8,21 @@
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
-//   - Understand the journey from Go source code to a running program: tokens, AST, type checking, IR, optimization, code generation, and linking.
+//   - Understand the journey from Go source code to a running program.
+//   - The stages: tokens, AST, type checking, IR, optimization, and code generation.
 //
 // WHY THIS MATTERS:
-//   - Think of the compiler as a translation pipeline. You write text for humans. The compiler progressively turns that text into representations that ar...
+//   - The compiler is a translation pipeline. It turns human-readable text into
+//     machine-optimized instructions. Knowing this explains why Go catches errors
+//     early and why binaries are the unit of deployment.
 //
 // RUN:
 //   go run ./00-how-computers-work/2-code-to-execution
 //
 // KEY TAKEAWAY:
-//   - Understand the journey from Go source code to a running program: tokens, AST, type checking, IR, optimization, code generation, and linking.
+//   - The CPU never sees your .go files; it only sees the machine code output
+//     of the build pipeline.
 // ============================================================================
-
-//   Compile-time reasoning explains why Go catches type errors early and why
-//   binaries can be deployed as concrete build artifacts.
 
 package main
 

--- a/00-how-computers-work/3-memory-basics/README.md
+++ b/00-how-computers-work/3-memory-basics/README.md
@@ -10,35 +10,54 @@ Understand how memory is allocated and managed during execution, especially the 
 
 ## Mental Model
 
-The stack is like a neat stack of plates: fast, ordered, and easy to clean up.
+**The Stack** is like a neat stack of plates in a busy restaurant.
+- **Fast**: You just put a plate on top or take one off.
+- **Automatic**: When a function finishes, its "plate" is removed and the memory is immediately recycled.
+- **Private**: In Go, **every goroutine has its own stack**.
 
-The heap is like a shared storage room: flexible and useful, but it needs active management so old objects do not stay around forever.
+**The Heap** is like a large shared storage room.
+- **Flexible**: You can put something there and it stays as long as you need it.
+- **Shared**: Multiple goroutines can access the same data on the heap.
+- **Managed**: Because it's not self-cleaning, Go needs a **Garbage Collector (GC)** to clean up unreachable objects.
 
 ## Visual Model
 
 ```mermaid
 graph TD
-    A["Running program memory"] --> B["Stack"]
-    A --> C["Heap"]
-    B --> D["Function frames"]
-    B --> E["Short-lived local values"]
-    C --> F["Shared or escaping objects"]
-    C --> G["Garbage collector manages cleanup"]
+    subgraph RAM["Running Program Memory"]
+        subgraph Stack
+            S1["Func A Frame"]
+            S2["Func B Frame"]
+            S3["Local Variables"]
+        end
+
+        subgraph Heap
+            H1["Shared Object"]
+            H2["Escaped Object"]
+            H3["Global State"]
+        end
+    end
+
+    S1 --> S2
+    S2 --> S3
+    S2 -. "escaped reference" .-> H1
 ```
 
 ## Machine View
 
-Every function call creates a stack frame.
-That frame holds the local state needed while the function is active.
+Every function call creates a **stack frame** on the current goroutine's stack. Unlike languages like C or Java where stacks are a fixed size (often 1MB), **Go stacks start small (2KB) and grow/shrink as needed**.
 
-Heap memory is different:
+**Heap memory** is used for objects that outlive the function that created them or are too large for the stack.
 
-- it is allocated dynamically
-- objects can outlive the function that created them
-- Go's garbage collector frees unreachable heap objects later
+Go's compiler uses **Escape Analysis** to decide where to put a variable:
+- If a variable's lifetime is entirely contained within a function, it stays on the **Stack**.
+- If a pointer to a variable is returned or shared, it "escapes" to the **Heap**.
 
-Go also performs **escape analysis**.
-If a value must outlive the current function, the compiler moves it to the heap automatically.
+> [!TIP]
+> At high scale, excessive heap allocation creates Garbage Collector pressure. You can learn how to profile and optimize memory layout in [PR.6 Memory Layout](../../08-quality-test/01-quality-and-performance/profiling/6-memory-layout/README.md).
+
+> [!NOTE]
+> Because the heap is shared memory, concurrent access to heap objects requires synchronization, which we cover in [SY.1 Mutex & RWMutex](../../07-concurrency/01-concurrency/sync-primitives/1-mutex-and-rwmutex/README.md).
 
 ## Run Instructions
 
@@ -48,26 +67,22 @@ go run ./00-how-computers-work/3-memory-basics
 
 ## Code Walkthrough
 
-The lesson program shows two small cases:
-
-- `noEscape()` returns a value directly, so the compiler can often keep it in stack-managed memory
-- `escapes()` returns a pointer, so the pointed-to value must outlive the function and is a candidate for heap allocation
-
-The demo is intentionally small.
-The goal is to make the stack/heap distinction explainable before later performance lessons.
+- **noEscape()**: Returns a value directly. The compiler can keep `x` on the stack because no one outside the function needs a reference to its specific memory address.
+- **escapes()**: Returns a *pointer*. Because the caller needs to access the memory address of `x` after the function is gone, the compiler moves `x` to the heap.
 
 ## Try It
 
 1. Run the lesson and compare the value-returning function with the pointer-returning one.
 2. Add another helper that returns a slice and explain why its backing storage may outlive the function.
-3. Run `go build -gcflags='-m' ./00-how-computers-work/3-memory-basics` and read the compiler's escape-analysis hints.
+3. Run `go build -gcflags='-m' ./00-how-computers-work/3-memory-basics` and read the compiler's escape-analysis hints in the terminal.
 
 ## In Production
-Heavy heap allocation creates garbage-collector pressure.
-That is one reason hot paths often avoid unnecessary temporary objects.
+
+Performance-critical Go code often tries to keep objects on the stack. The heap is powerful but expensive. Heavy heap use triggers the GC, which uses CPU cycles and can introduce "latency spikes."
 
 ## Thinking Questions
-1. Why does the heap need a garbage collector while the stack usually does not?
+
+1. Why does the heap need a garbage collector while the stack does not?
 2. Can a garbage-collected language still leak memory? If so, how?
 3. Why do goroutine stacks start small and grow instead of reserving a huge stack up front?
 

--- a/00-how-computers-work/3-memory-basics/main.go
+++ b/00-how-computers-work/3-memory-basics/main.go
@@ -8,20 +8,21 @@
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
-//   - Understand how memory is allocated and managed during execution, especially the difference between stack and heap memory in Go.
+//   - The difference between stack and heap memory.
+//   - How Go's compiler performs escape analysis to choose between them.
 //
 // WHY THIS MATTERS:
-//   - The stack is like a neat stack of plates: fast, ordered, and easy to clean up. The heap is like a shared storage room: flexible and useful, but it ...
+//   - The stack is like a neat stack of plates: fast, ordered, and self-cleaning.
+//     The heap is a flexible but messy shared room that requires the Garbage
+//     Collector to clean up once objects are no longer used.
 //
 // RUN:
 //   go run ./00-how-computers-work/3-memory-basics
 //
 // KEY TAKEAWAY:
-//   - Understand how memory is allocated and managed during execution, especially the difference between stack and heap memory in Go.
+//   - Memory behavior shapes performance. Heap allocation is flexible but comes
+//     with the cost of GC management.
 // ============================================================================
-
-//   Memory behavior shapes performance, correctness, and the kind of bugs a
-//   Go program can have under load.
 
 package main
 
@@ -45,8 +46,9 @@ func main() {
 	fmt.Printf("Pointer-returning function result: %d (address %p)\n", *pointer, pointer)
 	fmt.Println("Returning a pointer means the pointed-to value must outlive the function call.")
 
-	// - Stack and heap serve different lifetime needs.
-	// - Escape analysis helps Go decide which one a value needs.
+	// - Every goroutine has its own growable stack (starting at 2KB).
+	// - Escape analysis is a compiler-time decision, not a runtime one.
+	// - Reducing heap escapes is a primary strategy for Go performance tuning.
 	fmt.Println("\n---------------------------------------------------")
 	fmt.Println("NEXT UP: HC.4 -> 00-how-computers-work/4-terminal-confidence")
 	fmt.Println("Run    : go run ./00-how-computers-work/4-terminal-confidence")

--- a/00-how-computers-work/4-terminal-confidence/README.md
+++ b/00-how-computers-work/4-terminal-confidence/README.md
@@ -10,31 +10,36 @@ Build confidence with the terminal as the text-based environment that launches p
 
 ## Mental Model
 
-The terminal is not “where scary commands live.”
-It is a process-launching and output-reading interface for the operating system.
+The terminal is not "where scary commands live." It is a professional interface for the operating system.
+
+Think of it as a **Conversation with the OS**. You send a request (a command), and the OS provides a response (output).
 
 ## Visual Model
 
 ```mermaid
 graph LR
-    A["You type a command"] --> B["Shell parses it"]
-    B --> C["Shell finds program in PATH"]
-    C --> D["OS launches the program"]
-    D --> E["Program writes stdout/stderr"]
-    E --> F["Terminal displays or redirects output"]
+    User["You type a command"] --> Shell["Shell parses tokens"]
+    Shell --> PATH["Finds binary in PATH"]
+    PATH --> Process["OS launches Process"]
+    Process --> stdout["Standard Output (Default)"]
+    Process --> stderr["Standard Error (Issues)"]
+    stdout --> Screen["Terminal Screen"]
+    stderr --> Screen
 ```
 
 ## Machine View
 
 When you press Enter in the shell:
+1. The shell parses the command into a program name and arguments.
+2. It looks up the program's location using the `PATH` environment variable.
+3. The OS creates a new process for that program.
+4. The process is connected to three default **File Descriptors** (indices in the process's open file table):
+   - **0 (stdin)**: Input from the keyboard.
+   - **1 (stdout)**: Normal output.
+   - **2 (stderr)**: Error messages.
 
-1. the shell parses the command
-2. it finds the program to run
-3. the OS starts a new process
-4. that process writes output to file descriptors like stdout and stderr
-5. the shell receives an exit code when the process ends
-
-That is why redirecting output and chaining commands works.
+> [!NOTE]
+> The "Everything is a file" philosophy in Unix-like systems makes these descriptors incredibly powerful for I/O, as you will see in [FS.1 File Basics](../../05-packages-io/02-io-and-cli/filesystem/1-files/README.md).
 
 ## Run Instructions
 
@@ -44,23 +49,24 @@ go run ./00-how-computers-work/4-terminal-confidence
 
 ## Code Walkthrough
 
-In `main.go`, the lesson writes one line to stdout and one line to stderr.
-That small demo makes the terminal's two most common output channels visible.
+- **stdout**: Using `fmt.Println` writes to the standard output by default.
+- **stderr**: Using `fmt.Fprintln(os.Stderr, ...)` writes to the standard error stream. This separation allows you to capture logs in a file while still seeing errors on the screen.
 
 ## Try It
 
 1. Run the lesson normally and read both lines.
-2. Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt` and notice which line stays in the terminal.
-3. Run a failing command and inspect its exit code in your shell.
+2. Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. Only the error message stays on your screen.
+3. Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now the error is trapped in the file.
 
 ## In Production
-When production systems fail, you often have a shell, logs, and process output before you have anything else.
-Terminal confidence becomes operational confidence.
+
+Every modern backend is managed through the terminal or terminal-like APIs. Knowing how to filter logs (`grep`), find processes (`ps`), and check exit codes (`$?`) is essential for any backend engineer.
 
 ## Thinking Questions
+
 1. Why does redirecting stdout not automatically redirect stderr?
-2. Why do shells care about exit codes instead of reading the English words in program output?
-3. What would break if the shell could not resolve programs through `PATH`?
+2. Why do shells care about numeric exit codes instead of reading the words in the program output?
+3. What would break if the shell could not find programs through the `PATH`?
 
 ## Next Step
 

--- a/00-how-computers-work/4-terminal-confidence/main.go
+++ b/00-how-computers-work/4-terminal-confidence/main.go
@@ -8,20 +8,21 @@
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
-//   - Build confidence with the terminal as the text-based environment that launches programs, passes arguments, and handles output streams.
+//   - How the shell launches programs and connects their output streams.
+//   - The difference between stdout and stderr.
 //
 // WHY THIS MATTERS:
-//   - The terminal is not "where scary commands live." It is a process-launching and output-reading interface for the operating system.
+//   - The terminal is a professional interface for process control. Understanding
+//     output streams is critical for logging, debugging, and piping data
+//     between tools.
 //
 // RUN:
 //   go run ./00-how-computers-work/4-terminal-confidence
 //
 // KEY TAKEAWAY:
-//   - Build confidence with the terminal as the text-based environment that launches programs, passes arguments, and handles output streams.
+//   - A program's visibility to the outside world is mediated through its
+//     file descriptors (stdout, stderr).
 // ============================================================================
-
-//   Production logs often split standard output and errors. Understanding how to
-//   write to them is critical for observability.
 
 package main
 
@@ -41,6 +42,6 @@ func main() {
 	fmt.Println("\n---------------------------------------------------")
 	fmt.Println("NEXT UP: HC.5 -> 00-how-computers-work/5-os-processes")
 	fmt.Println("Run    : go run ./00-how-computers-work/5-os-processes")
-	fmt.Println("Current: HC.4 (4-terminal-confidence)")
+	fmt.Println("Current: HC.4 (terminal-confidence)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/00-how-computers-work/5-os-processes/README.md
+++ b/00-how-computers-work/5-os-processes/README.md
@@ -1,4 +1,4 @@
-# HC.5 How the OS manages processes
+# HC.5 How the OS Manages Processes
 
 ## Mission
 
@@ -6,23 +6,52 @@ Understand that your Go program runs inside an operating-system process and cros
 
 ## Prerequisites
 
-- HC.4
+- `HC.4` terminal confidence
 
 ## Mental Model
 
-A process is the OS sandbox for a running program. Syscalls are the doors that let that sandbox ask for files, network access, clocks, and other external work.
+A **Process** is the OS "Sandbox" for a running program. It provides isolation so that if one program crashes, it doesn't take the whole computer down with it.
+
+**Syscalls** (System Calls) are the doors that let that sandbox ask the OS for help with things it cannot do alone, such as:
+- Reading or writing a file.
+- Sending data over the network.
+- Checking the current time.
 
 ## Visual Model
 
 ```mermaid
 graph TD
-    A["How the OS manages processes"] --> B["os.Getpid shows that a Go program is just another tracked process."]
-    B --> C["Syscalls connect process code to the operating system and real resources."]
+    subgraph "Process Address Space (User Mode)"
+        Code["Binary Instructions (Read-only)"]
+        Data["Global Data"]
+        Heap["Dynamic Memory"]
+        Stack["Function Frames"]
+    end
+    
+    subgraph "Kernel Space (Kernel Mode)"
+        OS["Operating System / Kernel"]
+        Hardware["Hardware (Disk, Network, CPU)"]
+    end
+    
+    Stack -- "Syscall (e.g. read, write)" --> OS
+    OS --> Hardware
+    Hardware --> OS
+    OS -- "Result" --> Stack
 ```
 
 ## Machine View
 
-An OS process owns virtual memory, CPU state, descriptors, and identity like PID. Syscalls are how that process asks the kernel to act on its behalf.
+The OS enforces a boundary between **User Mode** (where your app runs) and **Kernel Mode** (where hardware is managed). Your program is physically blocked from touching the disk or network directly.
+
+- **Isolation**: Each process has its own virtual memory. This is why a memory leak in one process doesn't corrupt another.
+- **The Syscall Boundary**: When you call `os.Open`, the Go runtime executes a special CPU instruction that switches the CPU into Kernel Mode so the OS can safely perform the request.
+- **Context Switching**: The OS scheduler rapidly swaps processes on and off the CPU cores.
+
+> [!NOTE]
+> The File Descriptors introduced in [HC.4 Terminal Confidence](../4-terminal-confidence/README.md) are managed by the kernel as part of the process address space.
+
+> [!NOTE]
+> When the OS needs to stop a process, it sends a **Signal**. You will learn to handle these for "Graceful Shutdowns" in [GS.1 Signals and Context](../../10-production/02-graceful-shutdown/README.md).
 
 ## Run Instructions
 
@@ -32,31 +61,25 @@ go run ./00-how-computers-work/5-os-processes
 
 ## Code Walkthrough
 
-### os.Getpid shows that a Go program is just another trac
-
-os.Getpid shows that a Go program is just another tracked process.
-
-### os.Getppid reveals the parent-child relationship betwe
-
-os.Getppid reveals the parent-child relationship between processes.
-
-### Syscalls connect process code to the operating system 
-
-Syscalls connect process code to the operating system and real resources.
+- **os.Getpid()**: Shows your unique Process ID.
+- **os.Getppid()**: Shows the parent process (usually your shell).
+- **os.Hostname()**: A classic syscall. Your app asks the kernel for the system's identity.
 
 ## Try It
 
-1. Run the lesson and compare the PID with your terminal's process tools.
-2. Open another terminal and inspect the parent process relationship.
-3. Name three operations your program cannot perform without the OS helping.
+1. Run the lesson and note the PID. 
+2. Open another terminal and run `ps -p [YOUR_PID]` (on Unix) or `Get-Process -Id [YOUR_PID]` (on Windows) to see the OS view of your program.
+3. Explain why the program cannot know its own PID without asking the OS.
 
 ## In Production
-Every deployed service is a process. Signals, open files, sockets, and syscall costs all matter once the code leaves your laptop.
+
+Every microservice is a process. In cloud environments, we use process signals like `SIGTERM` to signal a service to stop accepting new requests and finish its current work before the container is killed.
 
 ## Thinking Questions
+
 1. Why does the OS isolate one process from another?
-2. What kinds of work require crossing the syscall boundary?
-3. Why are file descriptors and sockets process resources rather than plain language values?
+2. What would happen if a program could write directly to the disk without using a syscall?
+3. Why are file descriptors tied to a specific process?
 
 ## Next Step
 

--- a/00-how-computers-work/5-os-processes/main.go
+++ b/00-how-computers-work/5-os-processes/main.go
@@ -8,16 +8,20 @@
 // ============================================================================
 //
 // WHAT YOU'LL LEARN:
-//   - Understand that your Go program runs inside an operating-system process and crosses a syscall boundary whenever it needs OS help.
+//   - A Go program is a process managed by the operating system.
+//   - Syscalls are the boundary between your code and the OS kernel.
 //
 // WHY THIS MATTERS:
-//   - A process is the OS sandbox for a running program. Syscalls are the doors that let that sandbox ask for files, network access, clocks, and other ex...
+//   - A process is a protected sandbox. Every time your program wants to touch
+//     the "outside world" (files, network, screen), it must cross the syscall
+//     boundary. This boundary has costs and security implications.
 //
 // RUN:
 //   go run ./00-how-computers-work/5-os-processes
 //
 // KEY TAKEAWAY:
-//   - Understand that your Go program runs inside an operating-system process and crosses a syscall boundary whenever it needs OS help.
+//   - Understanding the process model is the key to mastering signals, performance,
+//     and distributed systems.
 // ============================================================================
 
 package main
@@ -27,8 +31,6 @@ import (
 	"os"
 	"runtime"
 )
-
-//
 
 func main() {
 	fmt.Println("=== OS Processes and Syscalls ===")
@@ -42,11 +44,13 @@ func main() {
 	}
 	fmt.Printf("Go version: %s\n", runtime.Version())
 	fmt.Println()
-	fmt.Println("A process owns memory, file descriptors, and execution state.")
-	fmt.Println("When it needs files, clocks, or network access, it crosses the syscall boundary to ask the OS for help.")
+	fmt.Println("A process owns private virtual memory, file descriptors, and execution state.")
+	fmt.Println("To touch hardware, the CPU must switch from User Mode to Kernel Mode via a syscall.")
+	fmt.Println("This boundary protects the system from buggy or malicious application code.")
 	fmt.Println()
 	fmt.Println("---------------------------------------------------")
 	fmt.Println("NEXT UP: GT.1 -> 01-getting-started/1-installation")
-	fmt.Println("Current: HC.5 (os processes)")
+	fmt.Println("Run    : go run ./01-getting-started/1-installation")
+	fmt.Println("Current: HC.5 (os-processes)")
 	fmt.Println("---------------------------------------------------")
 }


### PR DESCRIPTION
Closes #423

## Scope
- Section: s00
- Lesson IDs: HC.1, HC.2, HC.3, HC.4, HC.5
- Files: 00-how-computers-work/

## Type
- [x] [DOCS]

## Validation
- [x] go build ./... (Pass)
- [x] go vet ./... (Pass)
- [x] gofmt check (Pass)
- [x] go mod tidy no-diff check (Pass)
- [x] go test ./... (Pass)
- [x] go run ./scripts/validate_curriculum.go (Pass)

## Review Loop
- [x] findings-first self-review complete
- [x] P0/P1/P2 findings fixed or documented
- [ ] review threads answered
- [ ] addressed threads resolved

## Tracking
- [x] issue/PR assigned when appropriate
- [x] labels applied
- [x] milestone attached when available
- [x] project item added to \The Go Engineer v2\

## Risk
- Low. Documentation and comment improvements only. No logic changes.
