### PR TITLE
[CHORE] polish onboarding curriculum surfaces

### DIFF
--- a/00-how-computers-work/3-memory-basics/main.go
+++ b/00-how-computers-work/3-memory-basics/main.go
@@ -28,13 +28,13 @@ package main
 
 import "fmt"
 
-// noEscape (Function): runs the no escape step and keeps its inputs, outputs, or errors visible.
+// noEscape (Function): returns a plain value whose lifetime stays inside the caller boundary.
 func noEscape() int {
 	x := 42
 	return x
 }
 
-// escapes (Function): runs the escapes step and keeps its inputs, outputs, or errors visible.
+// escapes (Function): returns an address, forcing the local value to outlive its stack frame.
 func escapes() *int {
 	x := 99
 	return &x

--- a/01-getting-started/3-how-go-works/README.md
+++ b/01-getting-started/3-how-go-works/README.md
@@ -35,7 +35,7 @@ Go uses a strict visibility rule: **Capitalization**.
 The compiler enforces this. You cannot use a private function from another package.
 
 > [!NOTE]
-> This simple rule—Capitalization—is the foundation for package design in Go. You will see how this enables clear module boundaries in [MP.1 Module Basics](../../05-packages-io/01-modules-and-packages/1-module-basics/README.md).
+> This simple rule - capitalization - is the foundation for package design in Go. You will see how this enables clear module boundaries in [MP.1 Module Basics](../../05-packages-io/01-modules-and-packages/1-module-basics/README.md).
 
 > [!TIP]
 > While we use strings and numbers here, Go allows you to create your own complex types, which we dive into during [Section 04: Types and Design](../../04-types-design/README.md).

--- a/01-getting-started/4-dev-environment/README.md
+++ b/01-getting-started/4-dev-environment/README.md
@@ -10,7 +10,7 @@ Learn the small command loop that makes day-to-day Go work predictable.
 
 ## Mental Model
 
-The Go toolchain is a **workflow**, not a single command. 
+The Go toolchain is a **workflow**, not a single command.
 Think of it like a craft:
 1. **Write**: The act of typing code.
 2. **Format**: `go fmt` makes it professional and readable.
@@ -55,7 +55,7 @@ go run ./01-getting-started/4-dev-environment
 
 ## In Production
 
-In a professional environment, we use **CI (Continuous Integration)** to run these commands automatically. If a developer forgets to format their code or breaks a test, the CI system will reject their changes. This ensures the master codebase always stays healthy.
+In a professional environment, we use **CI (Continuous Integration)** to run these commands automatically. If a developer forgets to format their code or breaks a test, the CI system rejects the change before it reaches the main branch.
 
 ## Thinking Questions
 

--- a/01-getting-started/6-reading-compiler-errors/README.md
+++ b/01-getting-started/6-reading-compiler-errors/README.md
@@ -11,7 +11,7 @@ Learn to treat the compiler as a helpful partner instead of an obstacle by decod
 ## Mental Model
 
 Think of the compiler as a **Spell Checker for Logic**.
-It doesn't care about your feelings; it only cares about the rules of the language. If you break a rule, it stops you *before* you ship broken code to a user.
+It applies the rules of the language consistently. If you break a rule, it stops you *before* broken code reaches a user.
 
 ## Visual Model
 
@@ -55,7 +55,7 @@ go run ./01-getting-started/6-reading-compiler-errors
 
 ## In Production
 
-In large systems, we want our errors to happen at **Compile Time**, not **Runtime**. A compile-time error costs a few seconds of a developer's time. A runtime error in production can cost a company millions of dollars. The compiler is the first and most important line of defense.
+In large systems, we want many mistakes to fail at **Compile Time**, not **Runtime**. A compile-time error costs a few seconds of developer attention. A runtime error in production can create customer impact, data loss, or an incident. The compiler is the first line of defense.
 
 ## Thinking Questions
 


### PR DESCRIPTION
Closes #440

## Scope
- Section: s00-s01 onboarding surfaces
- Lesson IDs: HC.3, GT.3, GT.4, GT.6
- Files: selected lesson README/source surfaces only

## Type
- [ ] [FEAT]
- [ ] [FIX]
- [ ] [DOCS]
- [ ] [TEST]
- [x] [CHORE]
- [ ] [REFACTOR]
- [ ] [SECURITY]
- [ ] [RELEASE]

## Validation
- [ ] go build ./...
- [ ] go vet ./...
- [x] gofmt check for touched Go file
- [ ] go mod tidy no-diff check
- [ ] go test ./...
- [ ] go test -race ./...
- [ ] go test -coverprofile=coverage.out ./...
- [x] go run ./scripts/validate_curriculum.go
- [x] targeted go test for touched lesson packages
- [x] git diff --check

## Review Loop
- [x] findings-first self-review complete
- [x] P0/P1/P2 findings fixed or documented
- [ ] review threads answered
- [ ] addressed threads resolved

## Tracking
- [x] issue/PR assigned when appropriate
- [x] labels applied
- [ ] milestone attached when available
- [ ] project item added to The Go Engineer v2

## Risk
- Low. No architecture, curriculum graph, or behavior change intended. This only improves onboarding wording, one encoding artifact, and Machine Role comment specificity.

## Notes
- Local Go commands pass but the environment prints a non-fatal Go telemetry token warning after completion because user-level telemetry storage is permission-locked.