### PR TITLE
[FIX] harden opslane release constraints and integrations

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,16 @@
+name: Benchmarks
+
+on: [push, pull_request]
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Run Benchmarks
+        run: go test -bench=. -benchmem -count=1 ./08-quality-test/01-quality-and-performance/testing/benchmarks/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Test with Race Detector
         run: go test -race ./...
 
+      - name: Vulnerability Check
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
       - name: Coverage Report
         run: |
           go test -coverprofile coverage.out ./...
@@ -48,9 +53,10 @@ jobs:
           COVERAGE=$(go tool cover -func coverage.out | grep total | awk '{print $3}')
           echo "## Code Coverage: $COVERAGE" >> $GITHUB_STEP_SUMMARY
 
-      - name: Run Benchmarks
+      - name: Coverage Threshold Check
         run: |
-          go test -bench=. -benchmem -count=1 ./08-quality-test/01-quality-and-performance/testing/benchmarks/ || true
+          COVERAGE_PERCENT=$(go tool cover -func coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
+          awk -v cov="$COVERAGE_PERCENT" -v thresh="70.0" 'BEGIN { if (cov < thresh) { print "Coverage "cov"% is below threshold of "thresh"%"; exit 1 } else { print "Coverage "cov"% is above threshold of "thresh"%" } }'
 
       - name: Validate Curriculum
         run: go run ./scripts/validate_curriculum.go

--- a/11-flagship/01-opslane/README.md
+++ b/11-flagship/01-opslane/README.md
@@ -222,12 +222,13 @@ go run ./scripts/migrate.go -direction down
 go run ./scripts/migrate.go -direction status
 ```
 
-Migrations are numbered (001-005) and include:
+Migrations are numbered (001-006) and include:
 - `001_create_tenants` - tenant registry
 - `002_create_users` - tenant-scoped users
 - `003_create_orders` - order workflow
 - `004_create_payments` - payment tracking
 - `005_seed_data` - development demo data
+- `006_create_rate_limits` - distributed rate limiting
 
 ## Database Backup & Restore
 

--- a/11-flagship/01-opslane/cmd/server/main.go
+++ b/11-flagship/01-opslane/cmd/server/main.go
@@ -18,7 +18,9 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/events"
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/handlers"
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/metrics"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/otel"
 	paymentflow "github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/payment"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/ratelimit"
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/services"
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/workers"
 )
@@ -50,6 +52,18 @@ func main() {
 		logger.Error("failed to apply database migrations", slog.Any("error", err))
 		os.Exit(1)
 	}
+
+	var otelCfg otel.Config
+	otelCfg.FromEnv()
+	tracer := otel.New(otelCfg, logger)
+	defer tracer.Stop()
+
+	rateLimiter := ratelimit.New(ratelimit.Config{
+		RequestsPerSecond: 2,
+		BurstSize:         120,
+		WindowSeconds:     60,
+		DB:                database,
+	})
 
 	tokens, err := auth.NewTokenManager(cfg.Auth.TokenSecret, cfg.Auth.TokenIssuer, cfg.Auth.TokenTTL)
 	if err != nil {
@@ -112,6 +126,7 @@ func main() {
 		Environment:       cfg.App.Env,
 		TrustedProxyCIDRs: cfg.HTTP.TrustedProxyCIDRs,
 		IsDraining:        isDraining,
+		RateLimiter:       rateLimiter,
 	}
 
 	server := &http.Server{

--- a/11-flagship/01-opslane/internal/db/migrations.go
+++ b/11-flagship/01-opslane/internal/db/migrations.go
@@ -57,6 +57,14 @@ var schemaStatements = []string{
 		FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
 		FOREIGN KEY (tenant_id, order_id) REFERENCES orders(tenant_id, id) ON DELETE CASCADE
 	);`,
+	`CREATE TABLE IF NOT EXISTS rate_limits (
+		key TEXT NOT NULL,
+		window TIMESTAMPTZ NOT NULL,
+		count BIGINT NOT NULL DEFAULT 1,
+		expires_at TIMESTAMPTZ NOT NULL,
+		PRIMARY KEY (key, window)
+	);`,
+	`CREATE INDEX IF NOT EXISTS idx_rate_limits_expires ON rate_limits(expires_at);`,
 	`CREATE INDEX IF NOT EXISTS idx_orders_tenant_status ON orders(tenant_id, status);`,
 	`CREATE INDEX IF NOT EXISTS idx_orders_tenant_user ON orders(tenant_id, user_id);`,
 	`CREATE INDEX IF NOT EXISTS idx_orders_tenant_created_at ON orders(tenant_id, created_at DESC);`,

--- a/11-flagship/01-opslane/internal/handlers/handlers.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers.go
@@ -171,8 +171,6 @@ func (app *Application) handleMe(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-
-
 func writeJSON(w http.ResponseWriter, status int, payload any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/11-flagship/01-opslane/internal/handlers/handlers.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/middleware"
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 	paymentflow "github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/payment"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/ratelimit"
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
@@ -38,6 +39,7 @@ type Application struct {
 	Environment       string
 	TrustedProxyCIDRs []netip.Prefix
 	IsDraining        *atomic.Bool
+	RateLimiter       *ratelimit.Limiter
 }
 
 // OrderWorkflow defines the subset of the Order Service required by HTTP handlers.
@@ -76,7 +78,7 @@ func (app *Application) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", app.handleIndex)
 	mux.HandleFunc("GET /health", app.handleHealth)
-	mux.HandleFunc("GET /metrics", app.handleMetrics)
+	mux.Handle("GET /metrics", metrics.PrometheusHandler(app.Metrics))
 	mux.Handle("GET /me", auth.RequireAuth(app.Tokens)(http.HandlerFunc(app.handleMe)))
 	mux.HandleFunc("POST /api/v1/tenants", app.handleCreateTenant)
 	mux.HandleFunc("POST /api/v1/users", app.handleCreateUser)
@@ -94,7 +96,12 @@ func (app *Application) Routes() http.Handler {
 			middleware.RecoverPanic(app.Logger)(mux),
 		),
 	)
-	rateLimitedHandler := middleware.RateLimit(apiRateLimitMaxRequests, apiRateLimitWindow, app.TrustedProxyCIDRs)(baseHandler)
+	var rateLimitedHandler http.Handler
+	if app.RateLimiter != nil {
+		rateLimitedHandler = ratelimit.PerIPMiddleware(app.RateLimiter, app.TrustedProxyCIDRs, app.Logger)(baseHandler)
+	} else {
+		rateLimitedHandler = middleware.RateLimit(apiRateLimitMaxRequests, apiRateLimitWindow, app.TrustedProxyCIDRs)(baseHandler)
+	}
 	httpSurface := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/health" {
 			baseHandler.ServeHTTP(w, r)
@@ -164,13 +171,7 @@ func (app *Application) handleMe(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (app *Application) handleMetrics(w http.ResponseWriter, r *http.Request) {
-	if app.Metrics == nil || app.Metrics.Registry == nil {
-		http.Error(w, "metrics not configured", http.StatusNotImplemented)
-		return
-	}
-	writeJSON(w, http.StatusOK, app.Metrics.Registry.Snapshot())
-}
+
 
 func writeJSON(w http.ResponseWriter, status int, payload any) {
 	w.Header().Set("Content-Type", "application/json")

--- a/11-flagship/01-opslane/internal/middleware/middleware.go
+++ b/11-flagship/01-opslane/internal/middleware/middleware.go
@@ -103,7 +103,7 @@ func RateLimit(maxRequests int, window time.Duration, trustedProxyCIDRs []netip.
 				return
 			}
 
-			clientIP := clientAddress(r, trustedProxyCIDRs)
+			clientIP := ClientAddress(r, trustedProxyCIDRs)
 			now := time.Now()
 
 			mu.Lock()
@@ -153,7 +153,7 @@ func SecureHeaders(next http.Handler) http.Handler {
 	})
 }
 
-func clientAddress(r *http.Request, trustedProxyCIDRs []netip.Prefix) string {
+func ClientAddress(r *http.Request, trustedProxyCIDRs []netip.Prefix) string {
 	peerIP := remotePeerIP(r.RemoteAddr)
 	if peerIP.IsValid() && isTrustedProxy(peerIP, trustedProxyCIDRs) {
 		if forwardedIP, ok := forwardedClientIP(r); ok {

--- a/11-flagship/01-opslane/internal/ratelimit/middleware.go
+++ b/11-flagship/01-opslane/internal/ratelimit/middleware.go
@@ -5,24 +5,21 @@ package ratelimit
 
 import (
 	"net/http"
-	"strings"
+	"net/netip"
+
 	"sync"
-	"time"
 
 	"log/slog"
+
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/middleware"
 )
 
 type LimiterKey func(r *http.Request) string
 
-func ByIP(r *http.Request) string {
-	ip := r.Header.Get("X-Forwarded-For")
-	if ip == "" {
-		ip = r.RemoteAddr
-		if idx := strings.LastIndex(ip, ":"); idx != -1 {
-			ip = ip[:idx]
-		}
+func ByIP(trustedProxyCIDRs []netip.Prefix) LimiterKey {
+	return func(r *http.Request) string {
+		return middleware.ClientAddress(r, trustedProxyCIDRs)
 	}
-	return ip
 }
 
 func ByHeader(header string) func(r *http.Request) string {
@@ -67,8 +64,8 @@ func Middleware(limiter *Limiter, keyFunc LimiterKey, logger *slog.Logger) func(
 	}
 }
 
-func PerIPMiddleware(limiter *Limiter, logger *slog.Logger) func(http.Handler) http.Handler {
-	return Middleware(limiter, ByIP, logger)
+func PerIPMiddleware(limiter *Limiter, trustedProxyCIDRs []netip.Prefix, logger *slog.Logger) func(http.Handler) http.Handler {
+	return Middleware(limiter, ByIP(trustedProxyCIDRs), logger)
 }
 
 func AuthenticatedMiddleware(limiter *Limiter, tenantIDFunc, userIDFunc func(*http.Request) string, logger *slog.Logger) func(http.Handler) http.Handler {
@@ -94,37 +91,4 @@ func GetLimiter(name string) *Limiter {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
 	return pool.limiters[name]
-}
-
-func Middleger(limiter *Limiter, keyFunc LimiterKey, logger *slog.Logger) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			key := keyFunc(r)
-
-			allowed, err := limiter.Allow(key)
-			if err != nil {
-				if logger != nil {
-					logger.Warn("rate limit check failed, allowing request",
-						slog.String("key", key),
-						slog.Any("error", err))
-				}
-			}
-
-			if !allowed {
-				retryAfter := "1"
-				w.Header().Set("Retry-After", retryAfter)
-				w.Header().Set("X-RateLimit-Limit", "10")
-				w.Header().Set("X-RateLimit-Remaining", "0")
-				w.Header().Set("X-RateLimit-Reset", time.Now().Add(time.Second).Format(time.RFC1123))
-				http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
-				return
-			}
-
-			w.Header().Set("X-RateLimit-Limit", "10")
-			w.Header().Set("X-RateLimit-Remaining", "0")
-			w.Header().Set("X-RateLimit-Reset", time.Now().Add(time.Second).Format(time.RFC1123))
-
-			next.ServeHTTP(w, r)
-		})
-	}
 }

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -38,11 +38,11 @@ The `internal/events/bus.go` implementation is an in-memory channel router.
 
 ## Distributed Tracing
 
-The `internal/tracing/tracing.go` file implements a lightweight span context.
+The `internal/otel` package contains the foundation for OpenTelemetry distributed tracing and is wired into the application. However, the OTLP `Export` method is currently a teaching stub.
 
-**Why we built it this way:** To teach the concept of span propagation and how correlation IDs move across boundaries, without importing heavy external SDKs.
+**Why we built it this way:** To teach the concept of span propagation and how correlation IDs move across boundaries, without requiring a live Jaeger or Datadog backend or heavy external SDKs during local development.
 
-**Production Reality:** A production system would use OpenTelemetry (`go.opentelemetry.io/otel/trace`) with real trace and span IDs, sampling rules, and context propagation headers (like W3C Trace Context) to export telemetry to backends like Jaeger or Datadog.
+**Production Reality:** A production system would use OpenTelemetry (`go.opentelemetry.io/otel/trace`) with real trace and span IDs, sampling rules, and context propagation headers (like W3C Trace Context) to export telemetry via a fully implemented network exporter to backends like Jaeger or Datadog.
 
 ## Summary
 

--- a/scripts/internal/curriculumvalidator/validator.go
+++ b/scripts/internal/curriculumvalidator/validator.go
@@ -200,6 +200,7 @@ func Validate(root string, report func(string)) (Result, error) {
 
 	markdownErrors := validateMarkdownSurfaces(root, report)
 	standardsErrors := validateRepositoryStandards(root, report)
+	opslaneErrors := validateOpslaneConsistency(root, report)
 
 	return Result{
 		FilesScanned:     filesScanned,
@@ -207,8 +208,101 @@ func Validate(root string, report func(string)) (Result, error) {
 		V2ItemCount:      v2ItemCount,
 		PlaceholderCount: v2PlaceholderCount,
 		HasV2:            hasV2,
-		ErrorCount:       runErrors + v2Errors + markdownErrors + standardsErrors,
+		ErrorCount:       runErrors + v2Errors + markdownErrors + standardsErrors + opslaneErrors,
 	}, nil
+}
+
+func validateOpslaneConsistency(root string, report func(string)) int {
+	errorsFound := 0
+	baseDir := filepath.Join(root, "11-flagship/01-opslane")
+
+	readmeBytes, err := os.ReadFile(filepath.Join(baseDir, "README.md"))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			report(fmt.Sprintf("Failed to read Opslane README: %v", err))
+			return 1
+		}
+		return 0 // Opslane not present
+	}
+	readmeStr := string(readmeBytes)
+
+	modulesBytes, err := os.ReadFile(filepath.Join(baseDir, "MODULES.md"))
+	if err != nil {
+		report(fmt.Sprintf("Failed to read Opslane MODULES.md: %v", err))
+		return 1
+	}
+	modulesStr := string(modulesBytes)
+
+	for i := 1; i <= 10; i++ {
+		readmeKey := fmt.Sprintf("`OPSL.%d` complete:", i)
+		if !strings.Contains(readmeStr, readmeKey) {
+			report(fmt.Sprintf("Opslane README.md missing progress line: %s", readmeKey))
+			errorsFound++
+		}
+		moduleKey := fmt.Sprintf("`OPSL.%d` |", i)
+		if !strings.Contains(modulesStr, moduleKey) {
+			report(fmt.Sprintf("Opslane MODULES.md missing module: %s", moduleKey))
+			errorsFound++
+		}
+	}
+
+	migrationsDir := filepath.Join(baseDir, "migrations")
+	entries, err := os.ReadDir(migrationsDir)
+	if err != nil {
+		report(fmt.Sprintf("Failed to read Opslane migrations dir: %v", err))
+		return errorsFound + 1
+	}
+
+	var upCount int
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".up.sql") {
+			upCount++
+			base := strings.TrimSuffix(entry.Name(), ".up.sql")
+			if !strings.Contains(readmeStr, base) {
+				report(fmt.Sprintf("Opslane README.md missing migration file mention: %s", base))
+				errorsFound++
+			}
+		}
+	}
+
+	rangeStr := fmt.Sprintf("(001-%03d)", upCount)
+	if !strings.Contains(readmeStr, rangeStr) {
+		report(fmt.Sprintf("Opslane README.md missing correct migration range: %s", rangeStr))
+		errorsFound++
+	}
+
+	migrationsBytes, err := os.ReadFile(filepath.Join(baseDir, "internal/db/migrations.go"))
+	if err != nil {
+		report(fmt.Sprintf("Failed to read Opslane embedded migrations: %v", err))
+		return errorsFound + 1
+	}
+	migrationsStr := string(migrationsBytes)
+
+	tableRegex := regexp.MustCompile(`(?i)CREATE TABLE IF NOT EXISTS (\w+)`)
+	embeddedTables := tableRegex.FindAllStringSubmatch(migrationsStr, -1)
+
+	for _, tMatch := range embeddedTables {
+		tableName := tMatch[1]
+		foundInSQL := false
+		for _, entry := range entries {
+			if strings.HasSuffix(entry.Name(), ".up.sql") {
+				content, err := os.ReadFile(filepath.Join(migrationsDir, entry.Name()))
+				if err != nil {
+					continue
+				}
+				if strings.Contains(strings.ToLower(string(content)), strings.ToLower(tableName)) {
+					foundInSQL = true
+					break
+				}
+			}
+		}
+		if !foundInSQL {
+			report(fmt.Sprintf("Opslane migration drift: table %s found in embedded migrations but not in .up.sql files", tableName))
+			errorsFound++
+		}
+	}
+
+	return errorsFound
 }
 
 func isPlaceholderPath(path string) bool {

--- a/scripts/internal/curriculumvalidator/validator.go
+++ b/scripts/internal/curriculumvalidator/validator.go
@@ -228,6 +228,9 @@ func validateOpslaneConsistency(root string, report func(string)) int {
 
 	modulesBytes, err := os.ReadFile(filepath.Join(baseDir, "MODULES.md"))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
 		report(fmt.Sprintf("Failed to read Opslane MODULES.md: %v", err))
 		return 1
 	}
@@ -249,6 +252,9 @@ func validateOpslaneConsistency(root string, report func(string)) int {
 	migrationsDir := filepath.Join(baseDir, "migrations")
 	entries, err := os.ReadDir(migrationsDir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
 		report(fmt.Sprintf("Failed to read Opslane migrations dir: %v", err))
 		return errorsFound + 1
 	}
@@ -273,6 +279,9 @@ func validateOpslaneConsistency(root string, report func(string)) int {
 
 	migrationsBytes, err := os.ReadFile(filepath.Join(baseDir, "internal/db/migrations.go"))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
 		report(fmt.Sprintf("Failed to read Opslane embedded migrations: %v", err))
 		return errorsFound + 1
 	}


### PR DESCRIPTION
Closes #444

## Scope
- Section: s11
- Lesson IDs: OPSL.1-OPSL.10
- Files: 11-flagship/01-opslane/*, .github/workflows/*, docs/KNOWN_LIMITATIONS.md, scripts/internal/curriculumvalidator/validator.go

## Type
- [ ] [FEAT]
- [x] [FIX]
- [ ] [DOCS]
- [ ] [TEST]
- [ ] [CHORE]
- [ ] [REFACTOR]
- [ ] [SECURITY]
- [ ] [RELEASE]

## Validation
- [x] go build ./...
- [x] go vet ./...
- [x] gofmt check
- [x] go mod tidy no-diff check
- [x] go test ./...
- [x] go test -race ./...
- [x] go test -coverprofile=coverage.out ./...
- [x] go run ./scripts/validate_curriculum.go

## Review Loop
- [x] findings-first self-review complete
- [x] P0/P1/P2 findings fixed or documented
- [x] review threads answered
- [x] addressed threads resolved

## Tracking
- [x] issue/PR assigned when appropriate
- [x] labels applied
- [x] milestone attached when available
- [x] project item added to `The Go Engineer v2`

## Risk
- Low risk. The changes improve configuration wiring for the Opslane flagship and enforce stricter test and curriculum validation constraints without modifying curriculum foundations.
