### PR TITLE
[DOCS] improve public repo readiness

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,32 +1,66 @@
 # The Go Engineer Code of Conduct
 
-Like the technical community as a whole, the The Go Engineer team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
+## Our Pledge
 
-Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few ground rules that we ask people to adhere to. This code applies equally to founders, mentors and those seeking help and guidance.
+The Go Engineer community exists to help people learn Go and backend engineering with rigor, clarity, and respect.
 
-This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a guide to make it easier to enrich all of us and the technical communities in which we participate.
+We pledge to make project spaces welcoming for learners, contributors, maintainers, and reviewers regardless of background, experience level, identity, location, or ability.
 
-This code of conduct applies to all spaces managed by the The Go Engineer project or swe-labs. This includes IRC, the mailing lists, the issue tracker, DSF events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
+## Expected Behavior
 
-If you believe someone is violating the code of conduct, we ask that you report it by emailing [raselhossen052@gmail.com](mailto:raselhossen052@gmail.com). For more details please see our Link to reporting guidelines
+Participants are expected to:
 
-- **Be friendly and patient.**
-- **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
-- **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
-- **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the The Go Engineer community should be respectful when dealing with other members as well as with people outside the The Go Engineer community.
-- **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to: 
- - Violent threats or language directed against another person.
- - Discriminatory jokes and language.
- - Posting sexually explicit or violent material.
- - Posting (or threatening to post) other people's personally identifying information ("doxing").
- - Personal insults, especially those using racist or sexist terms.
- - Unwelcome sexual attention.
- - Advocating for, or encouraging, any of the above behavior.
- - Repeated harassment of others. In general, if someone asks you to stop, then stop.
-- **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and The Go Engineer is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of The Go Engineer comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+- use welcoming and inclusive language
+- assume good intent while still being clear about technical problems
+- give feedback on the work, not on the person
+- accept correction gracefully
+- keep discussions focused on learning, maintainability, and project quality
+- respect maintainer decisions about scope, architecture, licensing, and release process
 
-Original text courtesy of the [Speak Up! project](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html).
+## Unacceptable Behavior
 
-## Questions?
+Unacceptable behavior includes:
 
-If you have questions, please see rasel-hossen.vercel.app. If that doesn't answer your questions, feel free to [contact us](mailto:raselhossen052@gmail.com).
+- harassment, intimidation, threats, or personal attacks
+- discriminatory language, jokes, or imagery
+- sexualized language or unwanted attention
+- publishing private information without permission
+- sustained disruption of issues, pull requests, discussions, or reviews
+- bad-faith participation, including repeated scope derailment after maintainer guidance
+
+## Scope
+
+This code applies to all project-managed spaces, including GitHub issues, pull requests, discussions, reviews, documentation, and official project communication channels.
+
+Behavior outside project spaces may affect participation when it creates a safety, trust, or maintainability risk for the project community.
+
+## Reporting
+
+Report Code of Conduct concerns privately by using the maintainer contact path listed in [SECURITY.md](./SECURITY.md), or by emailing [raselhossen052@gmail.com](mailto:raselhossen052@gmail.com).
+
+Include:
+
+- what happened
+- where it happened
+- who was involved
+- links, screenshots, or timestamps when available
+- whether immediate action is needed
+
+Reports will be handled with as much confidentiality as practical. Maintainers may ask for more information before taking action.
+
+## Enforcement
+
+Maintainers may take any action they consider appropriate, including:
+
+- clarification or correction
+- warning
+- comment deletion
+- temporary restriction from project spaces
+- permanent ban from project spaces
+- escalation to GitHub or platform moderation when needed
+
+Enforcement decisions are based on impact, severity, history, and risk to the project community.
+
+## Attribution
+
+This document is adapted from common open source community conduct patterns and tailored for The Go Engineer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,24 @@ Read these documents before changing curriculum, code, validation, or release su
 
 If documents disagree on public curriculum structure, `ARCHITECTURE.md` wins.
 
+## First-Time Contributor Path
+
+New here? Start small.
+
+1. Pick an open issue labeled `good first issue`, `help wanted`, documentation, tests, or lesson-polish.
+2. Comment on the issue before starting so duplicated work is avoided.
+3. Keep the first PR narrow: one README improvement, one test improvement, one small example correction, or one contributor-facing doc fix.
+4. Run the minimum local checks:
+
+```bash
+go test ./...
+go run ./scripts/validate_curriculum.go
+```
+
+5. Open a draft PR and link the issue with `Closes #<issue>`.
+
+Maintainers will help new contributors through stricter validation, review comments, and final PR readiness. Larger curriculum, validator, CI, release, or Opslane changes must still follow the full workflow below.
+
 ## Architecture Rule
 
 The public architecture is locked at 12 sections, `s00` through `s11`.

--- a/README.md
+++ b/README.md
@@ -3,27 +3,25 @@
 [![CI](https://github.com/swe-labs/the-go-engineer/actions/workflows/ci.yml/badge.svg)](https://github.com/swe-labs/the-go-engineer/actions)
 [![License: TGE License v1.0](https://img.shields.io/badge/License-TGE_v1.0-red.svg)](#license)
 
-The Go Engineer is a repository-first Go software engineering curriculum. It teaches Go by combining runnable lessons, production-shaped examples, tests, validation, and a final integrated backend project.
+Master Go backend engineering by moving from machine fundamentals to a production-shaped SaaS backend.
 
-The stable v2.1 line is organized as a 5-phase, 12-section learning system with 215 registered curriculum items. The public structure is locked in [ARCHITECTURE.md](./ARCHITECTURE.md), and the machine-readable registry is [curriculum.v2.json](./curriculum.v2.json).
+The Go Engineer is a repository-first learning system with:
 
-## Status
+- 215 registered curriculum items
+- 12 locked sections from fundamentals to production systems
+- runnable Go lessons and exercises
+- tests, race checks, coverage, CI, and curriculum validation
+- Opslane, an integrated SaaS backend capstone
 
-Current stable line: `v2.1.x`
+If this repository helps you learn or teach Go, star it so more learners can find it.
 
-Current stable release: `v2.1.1`
+## What You Will Build
 
-Supported branches:
+The curriculum ends with [Opslane](./11-flagship/01-opslane), a production-shaped multi-tenant SaaS backend. Opslane brings the curriculum together through configuration, database models, authentication, tenant isolation, HTTP APIs, order processing, payment simulation, event workers, caching, observability, and graceful shutdown.
 
-| Branch | Purpose |
-| --- | --- |
-| `main` | active post-v2.1 implementation and integration line |
-| `release/v2` | stable v2.1.x maintenance line |
-| `release/v1` | stable v1 maintenance line |
+This is not only a syntax course. The goal is to build the habits behind real Go backend systems: explicit failure handling, clean package boundaries, tests as proof surfaces, operational thinking, and maintainable production code.
 
-Architecture v2.1 is locked. Normal work may improve lessons, tests, documentation, validators, or the Opslane flagship implementation, but must not add, remove, rename, or reorder public root sections without explicit maintainer approval.
-
-## Quick Start
+## Start Here
 
 Requirements:
 
@@ -49,7 +47,48 @@ Expected stable output:
 Success! 601 files with run commands validated, and 12 v2 sections plus 215 v2 items checked.
 ```
 
+## Who This Is For
+
+This repository is for:
+
+- beginners who want to learn Go deeply instead of memorizing syntax
+- backend developers moving to Go from another stack
+- self-taught developers who want production engineering habits
+- engineers preparing for backend interviews and system implementation work
+- teams that want a structured Go learning path with runnable proof surfaces
+
+## Status
+
+Current stable line: `v2.1.x`
+
+Current stable release: `v2.1.1`
+
+Supported branches:
+
+| Branch | Purpose |
+| --- | --- |
+| `main` | active post-v2.1 implementation and integration line |
+| `release/v2` | stable v2.1.x maintenance line |
+| `release/v1` | stable v1 maintenance line |
+
+Architecture v2.1 is locked. Normal work may improve lessons, tests, documentation, validators, or the Opslane flagship implementation, but must not add, remove, rename, or reorder public root sections without explicit maintainer approval.
+
 ## Curriculum Map
+
+```mermaid
+flowchart LR
+  s00["s00 Machine Basics"] --> s01["s01 Go Setup"]
+  s01 --> s02["s02 Language Basics"]
+  s02 --> s03["s03 Functions and Errors"]
+  s03 --> s04["s04 Types and Design"]
+  s04 --> s05["s05 Packages and I/O"]
+  s05 --> s06["s06 Backend and Databases"]
+  s06 --> s07["s07 Concurrency"]
+  s07 --> s08["s08 Quality and Testing"]
+  s08 --> s09["s09 Architecture and Security"]
+  s09 --> s10["s10 Production"]
+  s10 --> s11["s11 Opslane"]
+```
 
 | Phase | Sections | Focus | Progress |
 | --- | --- | --- | --- |
@@ -58,6 +97,20 @@ Success! 601 files with run commands validated, and 12 v2 sections plus 215 v2 i
 | 2 | s05-s08 | engineering core | 52% to 87% |
 | 3 | s09-s10 | systems engineering | 87% to 96% |
 | 4 | s11 | integrated flagship project | 96% to 100% |
+
+## Choose Your Path
+
+Use [LEARNING-PATH.md](./LEARNING-PATH.md) for the full path, bridge path, or targeted section path.
+
+For a paced route through the same material, use the [30-Day Go Engineer Challenge](./docs/challenges/30-day-go-engineer.md).
+
+## Community
+
+Use [docs/community/README.md](./docs/community/README.md) for Q&A format, progress sharing, issue etiquette, and contributor entry points.
+
+New contributors should start with `good first issue`, `help wanted`, documentation, tests, or lesson-polish tasks.
+
+Before opening a large PR, read [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Sections
 
@@ -117,6 +170,8 @@ go test -bench=. -benchmem -count=1 ./08-quality-test/01-quality-and-performance
 | [curriculum.v2.json](./curriculum.v2.json) | machine-readable curriculum registry |
 | [CURRICULUM-BLUEPRINT.md](./CURRICULUM-BLUEPRINT.md) | teaching contract and lesson authoring rules |
 | [LEARNING-PATH.md](./LEARNING-PATH.md) | recommended paths through the curriculum |
+| [docs/challenges/30-day-go-engineer.md](./docs/challenges/30-day-go-engineer.md) | paced 30-day learner challenge |
+| [docs/community/README.md](./docs/community/README.md) | community and contributor entry points |
 | [docs/PROGRESSION.md](./docs/PROGRESSION.md) | phase and milestone progression |
 | [CODE-STANDARDS.md](./CODE-STANDARDS.md) | Go source, comments, and teaching-code standards |
 | [TESTING-STANDARDS.md](./TESTING-STANDARDS.md) | test and verification expectations |

--- a/docs/challenges/30-day-go-engineer.md
+++ b/docs/challenges/30-day-go-engineer.md
@@ -1,0 +1,88 @@
+# 30-Day Go Engineer Challenge
+
+This challenge gives learners a paced route through the stable v2.1 curriculum.
+
+Use it when you want structure, public accountability, or a team study plan. It does not replace [LEARNING-PATH.md](../../LEARNING-PATH.md); it turns the same curriculum into a 30-day schedule.
+
+## Before You Start
+
+Set up the repository:
+
+```bash
+git clone https://github.com/swe-labs/the-go-engineer.git
+cd the-go-engineer
+go mod download
+go run ./scripts/validate_curriculum.go
+```
+
+Expected validator output:
+
+```text
+Success! 601 files with run commands validated, and 12 v2 sections plus 215 v2 items checked.
+```
+
+## Week 1: Machine And Language Foundations
+
+Goal: understand what Go programs are doing before moving into larger code.
+
+- Day 1: s00, machine basics and terminal confidence
+- Day 2: s01, installation, toolchain, and compiler output
+- Day 3: s02, variables, constants, and control flow
+- Day 4: s02, arrays, slices, maps, and pointers
+- Day 5: s03, functions and multiple returns
+- Day 6: s03, errors as values and validation
+- Day 7: review, rerun examples, and write down unclear concepts
+
+## Week 2: Types, Packages, I/O, And Backend Basics
+
+Goal: move from small programs to maintainable application boundaries.
+
+- Day 8: s04, structs, methods, and interfaces
+- Day 9: s04, composition, generics, and text handling
+- Day 10: s05, modules and package boundaries
+- Day 11: s05, CLI input, encoding, and filesystem work
+- Day 12: s06, HTTP server fundamentals
+- Day 13: s06, APIs, databases, and repositories
+- Day 14: review by running tests for sections s04-s06
+
+## Week 3: Concurrency, Quality, Architecture, And Security
+
+Goal: learn how production Go code handles coordination, evidence, and risk.
+
+- Day 15: s07, goroutines, wait groups, and channels
+- Day 16: s07, context, cancellation, and worker patterns
+- Day 17: s08, unit tests, subtests, mocks, and golden files
+- Day 18: s08, benchmarks, profiling, and fuzzing
+- Day 19: s09, package design and architecture patterns
+- Day 20: s09, security lessons and secure API exercise
+- Day 21: review with `go test ./...` and `go run ./scripts/validate_curriculum.go`
+
+## Week 4: Production And Opslane
+
+Goal: connect the curriculum to an integrated SaaS backend.
+
+- Day 22: s10, structured logging and configuration
+- Day 23: s10, graceful shutdown and deployment
+- Day 24: s10, observability and code generation
+- Day 25: s11, Opslane foundation, database, auth, and HTTP API
+- Day 26: s11, order processing, payment pipeline, and event workers
+- Day 27: s11, caching, observability, shutdown, and deployment
+- Day 28: run Opslane tests and read the threat model
+- Day 29: revisit weak areas and improve one note or test locally
+- Day 30: share a completion note with the command output you verified
+
+## Completion Proof
+
+A good completion note includes:
+
+- the final section or module reached
+- one concept that changed how you write Go
+- one test, validator, or Opslane command that passed locally
+- one next improvement you want to make
+
+Suggested final checks:
+
+```bash
+go test ./...
+go run ./scripts/validate_curriculum.go
+```

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -1,0 +1,51 @@
+# Community Guide
+
+The Go Engineer community is for learning Go, improving the curriculum, and building stronger backend engineering habits.
+
+## Where To Start
+
+- Use GitHub issues for confirmed bugs, docs gaps, lesson polish, tests, and scoped improvement tasks.
+- Use GitHub Discussions for questions, progress updates, design discussion, and learner show-and-tell.
+- Use pull requests for concrete changes linked to an issue.
+
+## Asking Good Questions
+
+When asking for help, include:
+
+- the section or lesson ID
+- the command you ran
+- the full error output or test failure
+- what you expected to happen
+- what you already tried
+
+This keeps answers useful for future learners.
+
+## Sharing Progress
+
+Good progress updates include:
+
+- the section or lesson completed
+- what clicked
+- what was confusing
+- one command or test that proves the work ran locally
+- the next lesson or section you plan to study
+
+## First Contributions
+
+Start with issues labeled `good first issue`, `help wanted`, documentation, tests, or lesson-polish.
+
+Good first contributions usually improve one small surface:
+
+- add expected output to a README
+- add a common mistake note
+- add a small table-driven test
+- improve one explanation
+- fix one broken or unclear command
+
+Before opening a PR, read [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Review Expectations
+
+Reviews should be direct, specific, and tied to project quality. Strong review comments explain the issue, the affected file or lesson, and the expected correction.
+
+Maintainers may close broad, stale, duplicate, or out-of-scope discussions to keep the project usable.


### PR DESCRIPTION
Closes #453

## Scope
- Repositions the README around the learner value proposition, Opslane, paths, and community entry points.
- Replaces the stale Code of Conduct text with a clean project-specific policy.
- Adds a first-time contributor path to `CONTRIBUTING.md`.
- Adds lightweight community and 30-day challenge docs.
- Leaves license and social preview assets unchanged.

## Type
- [x] [DOCS]

## Validation
- [x] `go run ./scripts/validate_curriculum.go`
- [x] `go test ./scripts/internal/curriculumvalidator`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `git diff --check`
- [x] mojibake and placeholder scan across changed public docs

## Review Loop
- [x] findings-first self-review complete
- [x] P0/P1/P2 findings fixed or documented
- [ ] review threads answered
- [ ] addressed threads resolved

## Tracking
- [x] issue created
- [x] labels applied
- [x] assignee applied

## Risk
- Documentation-only change. Main risk is broken public links or stale public messaging; validator and doc scans passed locally.