### PR TITLE
Potential fix for code scanning alert no. 2: Reflected cross-site scripting

### DIFF
--- a/06-backend-db/01-web-and-database/web-masterclass/7-forms/main.go
+++ b/06-backend-db/01-web-and-database/web-masterclass/7-forms/main.go
@@ -29,6 +29,7 @@ package main
 
 import (
 	"fmt"
+	"html"
 	"log"
 	"net/http"
 	"strings"
@@ -113,5 +114,6 @@ func handleSignup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 5. Success!
-	fmt.Fprintf(w, "Registration successful for %s!", email)
+	w.Header().Set("Content-Type", "text/html")
+	fmt.Fprintf(w, "Registration successful for %s!", html.EscapeString(email))
 }


### PR DESCRIPTION
Potential fix for [https://github.com/swe-labs/the-go-engineer/security/code-scanning/2](https://github.com/swe-labs/the-go-engineer/security/code-scanning/2)

To fix reflected XSS, apply contextual output encoding right before writing user-controlled data into the HTTP response. In Go for HTML contexts, use `html.EscapeString(...)`.

Best minimal fix for this file:
- **File:** `06-backend-db/01-web-and-database/web-masterclass/7-forms/main.go`
- **Changes needed:**
  1. Add standard library import `html`.
  2. Escape `email` in the success response: `html.EscapeString(email)`.
  3. (Optional but safe/consistent) set `Content-Type` to `text/html` in the success path before writing HTML/text response.

This preserves existing behavior while preventing injected HTML/JS from being interpreted by the browser.
