### PR TITLE
Added handler table test to HS.10 REST API exercise

### DIFF
--- a/06-backend-db/01-web-and-database/http-servers/10-rest-api-exercise/main_test.go
+++ b/06-backend-db/01-web-and-database/http-servers/10-rest-api-exercise/main_test.go
@@ -96,6 +96,27 @@ func TestRESTAPIValidation(t *testing.T) {
 	}
 }
 
+func TestRESTAPIGetTaskInvalidIDTable(t *testing.T) {
+	handler := newTestTaskAPI()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "alpha id", path: "/tasks/abc"},
+		{name: "mixed id", path: "/tasks/12x"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := serveRequest(handler, http.MethodGet, tt.path, "")
+			if resp.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", resp.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
 // serveRequest (Function): runs the serve request step and keeps its inputs, outputs, or errors visible.
 func serveRequest(handler http.Handler, method, path, body string) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(method, path, strings.NewReader(body))


### PR DESCRIPTION
assesed the issue as requested

Closes #472

## Scope

- Section:
- Lesson IDs:
- Files:

## Type

- [ ] [FEAT]
- [ ] [FIX]
- [ ] [DOCS]
- [x] [TEST]
- [ ] [CHORE]
- [ ] [REFACTOR]
- [ ] [SECURITY]
- [ ] [RELEASE]

## Summary

-

## Validation

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] gofmt check
- [x] `go mod tidy` no-diff check
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go test -coverprofile=coverage.out ./...`
- [x] `go run ./scripts/validate_curriculum.go`

## Curriculum Checklist

- [ ] Architecture v2.1 remains intact.
- [ ] `curriculum.v2.json` updated if needed.
- [ ] Section README updated if needed.
- [ ] Lesson README follows required section order if applicable.
- [ ] `Level` and `RUN:` headers match `curriculum.v2.json` if applicable.
- [ ] Machine Role comments explain role, boundary, invariant, or failure mode if applicable.
- [ ] README cross-references use `[!NOTE]` or `[!TIP]` alerts if applicable.
- [ ] `NEXT UP:` footer matches curriculum metadata if applicable.
- [x] Starter code compiles if applicable.

## Tracking

- [x] Linked issue has assignee when appropriate.
- [x] Labels are applied.
- [x] Milestone is attached when available.
- [x] Issue or PR is added to `The Go Engineer v2`.

## Review Loop

- [ ] findings-first self-review completed before commit
- [ ] P0/P1/P2 findings fixed or documented
- [ ] PR conversation reviewed
- [ ] inline review threads answered
- [ ] addressed threads resolved
- [ ] stale threads marked outdated or explained
- [ ] final readiness comment posted

## Risk

-
