### PR TITLE
Docs: Add common variable mistakes note to LB.1

### DIFF
--- a/00-how-computers-work/4-terminal-confidence/README.md
+++ b/00-how-computers-work/4-terminal-confidence/README.md
@@ -54,9 +54,20 @@ go run ./00-how-computers-work/4-terminal-confidence
 
 ## Try It
 
-1. Run the lesson normally and read both lines.
-2. Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. Only the error message stays on your screen.
-3. Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now the error is trapped in the file.
+1. Run the lesson normally and read both lines on your screen.
+2. **Redirect stdout (Descriptor 1):** Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. The `>` symbol is shorthand for `1>`. Only the error message stays on your screen because standard output is now "piped" into the file.
+3. **Redirect stderr (Descriptor 2):** Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now standard output prints to the screen, but the error message is trapped in `errors.txt`.
+4. **Capture Both:** Run `go run ./00-how-computers-work/4-terminal-confidence > all.log 2>&1`. This tells the shell to redirect stdout to a file, and then "copy" stderr (2) to the same place as stdout (1).
+
+## What the Shell is Doing
+
+When you use redirection (`>` or `2>`), the shell performs "plumbing" **before** your program even starts:
+1. It sees the redirection token in your command.
+2. It opens the target file on your disk.
+3. It uses a system call (like `dup2`) to swap the default terminal connection of File Descriptor 1 (or 2) with the newly opened file.
+4. Only then does it execute (`exec`) your program.
+
+Because this happens at the OS level, your Go code doesn't even know it's writing to a file—it just keeps writing to "stdout" as usual!
 
 ## In Production
 

--- a/02-language-basics/1-variables/README.md
+++ b/02-language-basics/1-variables/README.md
@@ -50,7 +50,19 @@ go run ./02-language-basics/1-variables
 -   **`var isRunning bool`**: Zero value is `false`.
 -   **`firstName, lastName := "John", "Doe"`**: Short declaration creates and initializes multiple variables at once.
 
-> [!TIP]
+## Common Mistakes
+
+### Unused Variables
+Unlike Python or JavaScript, Go will **not** let you keep unused local variables. This is a common source of frustration for beginners, but it's designed to keep production code clean.
+- **Error:** `name declared and not used`
+- **Solution:** Either use the variable or delete it.
+
+### Short Declaration vs. Package Level
+The `:=` syntax is for **local** variables (inside functions) only. If you try to use it at the package level (outside of any function), the compiler will complain.
+- **Error:** `non-declaration statement outside function body`
+- **Solution:** Use `var` for package-level variables.
+
+## Try It
 > The compiler strictly enforces code quality. If you declare a local variable but never use it, the compiler will refuse to build the program. This was introduced in [GT.6 Reading Compiler Errors](../../01-getting-started/6-reading-compiler-errors/README.md).
 
 ## Try It


### PR DESCRIPTION
Resolves #461.

### Changes
- Added a **Common Mistakes** section to the Variables lesson.
- Explained the "unused variable" compiler error.
- Clarified the restriction of using the short declaration operator `:=` at the package level.