### PR TITLE
Docs: Add interface nil pitfall note to TI.11

### DIFF
--- a/00-how-computers-work/4-terminal-confidence/README.md
+++ b/00-how-computers-work/4-terminal-confidence/README.md
@@ -54,9 +54,20 @@ go run ./00-how-computers-work/4-terminal-confidence
 
 ## Try It
 
-1. Run the lesson normally and read both lines.
-2. Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. Only the error message stays on your screen.
-3. Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now the error is trapped in the file.
+1. Run the lesson normally and read both lines on your screen.
+2. **Redirect stdout (Descriptor 1):** Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. The `>` symbol is shorthand for `1>`. Only the error message stays on your screen because standard output is now "piped" into the file.
+3. **Redirect stderr (Descriptor 2):** Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now standard output prints to the screen, but the error message is trapped in `errors.txt`.
+4. **Capture Both:** Run `go run ./00-how-computers-work/4-terminal-confidence > all.log 2>&1`. This tells the shell to redirect stdout to a file, and then "copy" stderr (2) to the same place as stdout (1).
+
+## What the Shell is Doing
+
+When you use redirection (`>` or `2>`), the shell performs "plumbing" **before** your program even starts:
+1. It sees the redirection token in your command.
+2. It opens the target file on your disk.
+3. It uses a system call (like `dup2`) to swap the default terminal connection of File Descriptor 1 (or 2) with the newly opened file.
+4. Only then does it execute (`exec`) your program.
+
+Because this happens at the OS level, your Go code doesn't even know it's writing to a file—it just keeps writing to "stdout" as usual!
 
 ## In Production
 

--- a/04-types-design/11-dynamic-typing-with-any/README.md
+++ b/04-types-design/11-dynamic-typing-with-any/README.md
@@ -43,6 +43,23 @@ go run ./04-types-design/11-dynamic-typing-with-any
 - **Dynamic Switches**: Type switches provide a clean way to branch logic based on the dynamic type stored in `any`.
 - **Constraint-Free**: Unlike specific interfaces, `any` provides no behavioral guarantees. You must always verify the underlying type before performing operations.
 
+## The Nil Interface Pitfall
+
+This is perhaps the most famous "gotcha" in Go. An interface is only truly `nil` if both its **type** and **value** are `nil`.
+
+If you store a `nil` pointer of a specific type (like `*User`) into an interface, the interface is **not** nil.
+
+```go
+var user *User = nil
+var val any = user
+
+if val == nil {
+    fmt.Println("This will NOT print!")
+}
+```
+
+**Rule of Thumb:** Never return a nil concrete pointer as an interface type. Always return the explicit `nil` literal instead.
+
 ## Try It
 
 1. In `main.go`, observe the output of the "Typed Nil" comparison.


### PR DESCRIPTION
Resolves #468.

### Changes
- Added a **Nil Interface Pitfall** section to the dynamic typing lesson.
- Provided a code example illustrating why a nil concrete pointer inside an interface is not `nil`.
- Added a "Rule of Thumb" for returning interfaces.