### PR TITLE
Docs: Add common context cancellation mistakes to CT.2

### DIFF
--- a/00-how-computers-work/4-terminal-confidence/README.md
+++ b/00-how-computers-work/4-terminal-confidence/README.md
@@ -54,9 +54,20 @@ go run ./00-how-computers-work/4-terminal-confidence
 
 ## Try It
 
-1. Run the lesson normally and read both lines.
-2. Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. Only the error message stays on your screen.
-3. Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now the error is trapped in the file.
+1. Run the lesson normally and read both lines on your screen.
+2. **Redirect stdout (Descriptor 1):** Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. The `>` symbol is shorthand for `1>`. Only the error message stays on your screen because standard output is now "piped" into the file.
+3. **Redirect stderr (Descriptor 2):** Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now standard output prints to the screen, but the error message is trapped in `errors.txt`.
+4. **Capture Both:** Run `go run ./00-how-computers-work/4-terminal-confidence > all.log 2>&1`. This tells the shell to redirect stdout to a file, and then "copy" stderr (2) to the same place as stdout (1).
+
+## What the Shell is Doing
+
+When you use redirection (`>` or `2>`), the shell performs "plumbing" **before** your program even starts:
+1. It sees the redirection token in your command.
+2. It opens the target file on your disk.
+3. It uses a system call (like `dup2`) to swap the default terminal connection of File Descriptor 1 (or 2) with the newly opened file.
+4. Only then does it execute (`exec`) your program.
+
+Because this happens at the OS level, your Go code doesn't even know it's writing to a file—it just keeps writing to "stdout" as usual!
 
 ## In Production
 

--- a/07-concurrency/01-concurrency/context/2-with-cancel/README.md
+++ b/07-concurrency/01-concurrency/context/2-with-cancel/README.md
@@ -56,6 +56,19 @@ This is the "Ear to the Ground." Inside a `select` statement, this case will tri
 ### Propagation
 The second half of the demo shows that cancelling a single "Parent" context automatically cancels all its "Children." This is how you can shut down a complex web service with a single signal.
 
+## Common Mistakes
+
+### Forgetting the `cancel()` Call
+A common pitfall is ignoring the `cancel` function returned by `WithCancel`. 
+- **The Bug:** You create a context but never call `cancel()`.
+- **The Consequence:** The context and its associated resources remain in memory until the **parent** context expires. If the parent is `context.Background()`, those resources are effectively leaked until the entire program terminates.
+- **The Fix:** Always `defer cancel()` immediately after creation.
+
+### Misunderstanding Propagation Direction
+Cancellation only flows **down** the tree, never up.
+- **The Mistake:** Expecting that cancelling a child context will stop the parent operation.
+- **The Reality:** A parent is blissfully unaware of its child's cancellation. This allows you to stop specific sub-tasks (like an individual database query) without killing the entire request handler.
+
 ## Try It
 
 1. Remove the `cancel()` call in the first example. What happens to the worker? (Hint: It keeps running until the program exits, which in a real server would be a memory leak).


### PR DESCRIPTION
Resolves #473.

### Changes
- Added a **Common Mistakes** section to the `context.WithCancel` lesson.
- Detailed the "forgotten cancel" memory leak scenario.
- Clarified that cancellation propagation only flows **down** the context tree, not up.