### PR TITLE
Docs: Add common memory allocation mistakes to HC.3

### DIFF
--- a/00-how-computers-work/3-memory-basics/README.md
+++ b/00-how-computers-work/3-memory-basics/README.md
@@ -70,6 +70,18 @@ go run ./00-how-computers-work/3-memory-basics
 - **noEscape()**: Returns a value directly. The compiler can keep `x` on the stack because no one outside the function needs a reference to its specific memory address.
 - **escapes()**: Returns a *pointer*. Because the caller needs to access the memory address of `x` after the function is gone, the compiler moves `x` to the heap.
 
+## Common Mistakes
+
+### Over-using Pointers for Small Values
+Many beginners think using pointers (`*int`, `*string`) is always faster because it "avoids copying."
+- **The Bug:** Passing pointers to small, local variables that don't need to be shared.
+- **The Consequence:** You force the variable to "escape" to the heap, which is actually **slower** than a fast stack copy because it creates work for the Garbage Collector.
+
+### Thinking the Stack is Shared
+Unlike the heap, the stack is private to each goroutine.
+- **The Mistake:** Expecting that a pointer to a stack-local variable can be safely shared across goroutines without it escaping.
+- **The Reality:** As soon as you share that address with another goroutine, the compiler sees that the variable "outlives" the current function and moves it to the heap anyway.
+
 ## Try It
 
 1. Run the lesson and compare the value-returning function with the pointer-returning one.

--- a/00-how-computers-work/4-terminal-confidence/README.md
+++ b/00-how-computers-work/4-terminal-confidence/README.md
@@ -54,9 +54,20 @@ go run ./00-how-computers-work/4-terminal-confidence
 
 ## Try It
 
-1. Run the lesson normally and read both lines.
-2. Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. Only the error message stays on your screen.
-3. Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now the error is trapped in the file.
+1. Run the lesson normally and read both lines on your screen.
+2. **Redirect stdout (Descriptor 1):** Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. The `>` symbol is shorthand for `1>`. Only the error message stays on your screen because standard output is now "piped" into the file.
+3. **Redirect stderr (Descriptor 2):** Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now standard output prints to the screen, but the error message is trapped in `errors.txt`.
+4. **Capture Both:** Run `go run ./00-how-computers-work/4-terminal-confidence > all.log 2>&1`. This tells the shell to redirect stdout to a file, and then "copy" stderr (2) to the same place as stdout (1).
+
+## What the Shell is Doing
+
+When you use redirection (`>` or `2>`), the shell performs "plumbing" **before** your program even starts:
+1. It sees the redirection token in your command.
+2. It opens the target file on your disk.
+3. It uses a system call (like `dup2`) to swap the default terminal connection of File Descriptor 1 (or 2) with the newly opened file.
+4. Only then does it execute (`exec`) your program.
+
+Because this happens at the OS level, your Go code doesn't even know it's writing to a file—it just keeps writing to "stdout" as usual!
 
 ## In Production
 


### PR DESCRIPTION
Resolves #456.

### Changes
- Added a **Common Mistakes** section to the Memory Basics lesson.
- Explained why over-using pointers for small values can be counter-productive (GC pressure).
- Clarified that stack memory is private and sharing addresses causes heap escape.