### PR TITLE
Docs: Add generics constraint common mistake to TI.14

### DIFF
--- a/00-how-computers-work/4-terminal-confidence/README.md
+++ b/00-how-computers-work/4-terminal-confidence/README.md
@@ -54,9 +54,20 @@ go run ./00-how-computers-work/4-terminal-confidence
 
 ## Try It
 
-1. Run the lesson normally and read both lines.
-2. Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. Only the error message stays on your screen.
-3. Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now the error is trapped in the file.
+1. Run the lesson normally and read both lines on your screen.
+2. **Redirect stdout (Descriptor 1):** Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. The `>` symbol is shorthand for `1>`. Only the error message stays on your screen because standard output is now "piped" into the file.
+3. **Redirect stderr (Descriptor 2):** Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now standard output prints to the screen, but the error message is trapped in `errors.txt`.
+4. **Capture Both:** Run `go run ./00-how-computers-work/4-terminal-confidence > all.log 2>&1`. This tells the shell to redirect stdout to a file, and then "copy" stderr (2) to the same place as stdout (1).
+
+## What the Shell is Doing
+
+When you use redirection (`>` or `2>`), the shell performs "plumbing" **before** your program even starts:
+1. It sees the redirection token in your command.
+2. It opens the target file on your disk.
+3. It uses a system call (like `dup2`) to swap the default terminal connection of File Descriptor 1 (or 2) with the newly opened file.
+4. Only then does it execute (`exec`) your program.
+
+Because this happens at the OS level, your Go code doesn't even know it's writing to a file—it just keeps writing to "stdout" as usual!
 
 ## In Production
 

--- a/04-types-design/14-complex-generic-constraints/README.md
+++ b/04-types-design/14-complex-generic-constraints/README.md
@@ -55,6 +55,14 @@ The built-in `comparable` constraint is a special interface satisfied by all typ
 func GetOrSet[K comparable, V any] (m map[K]V, key K, defaultVal V) V
 ```
 
+## Common Mistakes
+
+### Overly Broad Constraints (`any`)
+A common mistake is using `any` when your generic logic actually requires specific methods.
+- **The Bug:** Defining a function as `func Save[T any](val T)` but then trying to call `val.Serialize()` inside.
+- **The Result:** Compile-time error because `any` doesn't guarantee the `Serialize` method exists.
+- **The Fix:** Define a constraint interface that includes the `Serialize()` method.
+
 ## Try It
 
 ### Automated Tests

--- a/04-types-design/14-complex-generic-constraints/README.md
+++ b/04-types-design/14-complex-generic-constraints/README.md
@@ -59,7 +59,7 @@ func GetOrSet[K comparable, V any] (m map[K]V, key K, defaultVal V) V
 
 ### Overly Broad Constraints (`any`)
 A common mistake is using `any` when your generic logic actually requires specific methods.
-- **The Bug:** Defining a function as `func Save[T any](val T)` but then trying to call `val.Serialize()` inside.
+- **The Bug:** Defining a generic function with `any` (e.g., `func Save[T any] { ... }`) but then trying to call `val.Serialize()` inside.
 - **The Result:** Compile-time error because `any` doesn't guarantee the `Serialize` method exists.
 - **The Fix:** Define a constraint interface that includes the `Serialize()` method.
 

--- a/04-types-design/14-complex-generic-constraints/README.md
+++ b/04-types-design/14-complex-generic-constraints/README.md
@@ -59,7 +59,7 @@ func GetOrSet[K comparable, V any] (m map[K]V, key K, defaultVal V) V
 
 ### Overly Broad Constraints (`any`)
 A common mistake is using `any` when your generic logic actually requires specific methods.
-- **The Bug:** Defining a generic function with `any` (e.g., `func Save[T any] { ... }`) but then trying to call `val.Serialize()` inside.
+- **The Bug:** Defining a function like `Save[T any]` with parameter `v T` but then trying to call `val.Serialize()` inside.
 - **The Result:** Compile-time error because `any` doesn't guarantee the `Serialize` method exists.
 - **The Fix:** Define a constraint interface that includes the `Serialize()` method.
 


### PR DESCRIPTION
Resolves #469.

### Changes
- Added a **Common Mistakes** section to the complex generics constraints lesson.
- Explained the pitfall of using `any` when specific behaviors/methods are required by the generic logic.