### PR TITLE
Docs: Add closure capture note to FE.8

### DIFF
--- a/00-how-computers-work/4-terminal-confidence/README.md
+++ b/00-how-computers-work/4-terminal-confidence/README.md
@@ -54,9 +54,20 @@ go run ./00-how-computers-work/4-terminal-confidence
 
 ## Try It
 
-1. Run the lesson normally and read both lines.
-2. Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. Only the error message stays on your screen.
-3. Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now the error is trapped in the file.
+1. Run the lesson normally and read both lines on your screen.
+2. **Redirect stdout (Descriptor 1):** Run `go run ./00-how-computers-work/4-terminal-confidence > output.txt`. The `>` symbol is shorthand for `1>`. Only the error message stays on your screen because standard output is now "piped" into the file.
+3. **Redirect stderr (Descriptor 2):** Run `go run ./00-how-computers-work/4-terminal-confidence 2> errors.txt`. Now standard output prints to the screen, but the error message is trapped in `errors.txt`.
+4. **Capture Both:** Run `go run ./00-how-computers-work/4-terminal-confidence > all.log 2>&1`. This tells the shell to redirect stdout to a file, and then "copy" stderr (2) to the same place as stdout (1).
+
+## What the Shell is Doing
+
+When you use redirection (`>` or `2>`), the shell performs "plumbing" **before** your program even starts:
+1. It sees the redirection token in your command.
+2. It opens the target file on your disk.
+3. It uses a system call (like `dup2`) to swap the default terminal connection of File Descriptor 1 (or 2) with the newly opened file.
+4. Only then does it execute (`exec`) your program.
+
+Because this happens at the OS level, your Go code doesn't even know it's writing to a file—it just keeps writing to "stdout" as usual!
 
 ## In Production
 

--- a/03-functions-errors/8-closures-mechanics/README.md
+++ b/03-functions-errors/8-closures-mechanics/README.md
@@ -46,6 +46,9 @@ go run ./03-functions-errors/8-closures-mechanics
 - **Variable Capture**: `sayHello` captures the `message` string. If `message` is reassigned in the outer scope, `sayHello` prints the new value.
 - **Loop Capture**: Demonstrates how to safely capture loop indices by rebinding them to a local block variable (`val := i`), which prevents all closures from sharing the final index value (a common pre-Go 1.22 bug).
 
+> [!IMPORTANT]
+> **Capture by Reference:** Go closures capture variables by **reference**, not by value. If you modify a captured variable *after* creating the closure but *before* calling it, the closure will see the updated value. This is why re-binding inside a loop was historically necessary to "freeze" a value for each closure.
+
 > [!TIP]
 > You have now learned the most advanced mechanics of Go functions. It's time to apply them in a real-world scenario. In [FE.7 Order Summary](../9-order-summary/README.md), you will use closures to create dynamic, configurable pricing rules.
 


### PR DESCRIPTION
Resolves #466.

### Changes
- Added an **IMPORTANT** note to the closure mechanics lesson.
- Explained that Go captures variables by **reference**, which is crucial for understanding stateful closures and historical loop issues.