### PR TITLE
[FIX] Quality improvements: OTLP config, Machine Role comments, docs, tests, Dockerfile, gitignore

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,31 @@
+#!/bin/sh
+# commit-msg hook: validates commit message format.
+#
+# Format: [TYPE] short imperative description
+# Types:  FEAT | FIX | DOCS | TEST | CHORE | REFACTOR | SECURITY | RELEASE
+#
+# Install: git config core.hooksPath .githooks
+
+MSG_FILE="$1"
+COMMIT_RX='^\[(FEAT|FIX|DOCS|TEST|CHORE|REFACTOR|SECURITY|RELEASE)\] .+'
+SUBJECT=$(head -1 "$MSG_FILE")
+
+# Allow merge commits
+echo "$SUBJECT" | grep -Eq '^Merge ' && exit 0
+
+if ! echo "$SUBJECT" | grep -Eq "$COMMIT_RX"; then
+	echo ""
+	echo "  ERROR: Invalid commit message format."
+	echo ""
+	echo "  Expected: [TYPE] short imperative description"
+	echo "  Example:  [FIX] correct tenant scoping in DB.3"
+	echo "  Example:  [DOCS] align release workflow with v2.1 maintenance"
+	echo ""
+	echo "  Allowed types: FEAT | FIX | DOCS | TEST | CHORE | REFACTOR | SECURITY | RELEASE"
+	echo ""
+	echo "  Your subject: $SUBJECT"
+	echo ""
+	exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,26 @@
+#!/bin/sh
+# pre-commit hook: prevents commits with unformatted Go files.
+#
+# Runs gofmt on all staged .go files and rejects the commit if any
+# are unformatted.
+#
+# Install: git config core.hooksPath .githooks
+
+STAGED_GO=$(git diff --cached --name-only --diff-filter=ACMR | grep '\.go$' || true)
+
+if [ -z "$STAGED_GO" ]; then
+	exit 0
+fi
+
+UNFORMATTED=$(gofmt -l $STAGED_GO)
+
+if [ -n "$UNFORMATTED" ]; then
+	echo ""
+	echo "  ERROR: Unformatted Go files (run gofmt -w)"
+	echo ""
+	echo "$UNFORMATTED" | sed 's/^/    /'
+	echo ""
+	exit 1
+fi
+
+exit 0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,6 @@ name: CodeQL
 on:
   push:
     branches: [main, release/v2]
-  pull_request:
-    branches: [main, release/v2]
   schedule:
     - cron: "0 3 * * 1"
 

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,48 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    branches: [main, release/v2]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    name: Check commit message format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Lint commit messages
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pattern = /^\[(FEAT|FIX|DOCS|TEST|CHORE|REFACTOR|SECURITY|RELEASE)\] .+/;
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            let failed = false;
+            for (const commit of commits) {
+              const msg = commit.commit.message.split('\n')[0];
+              if (msg.startsWith('Merge ')) continue;
+              if (!pattern.test(msg)) {
+                core.error(`Invalid commit message: ${commit.sha.slice(0, 7)} — ${msg}`);
+                core.info(`Expected: [TYPE] short description`);
+                core.info(`Allowed types: FEAT | FIX | DOCS | TEST | CHORE | REFACTOR | SECURITY | RELEASE`);
+                failed = true;
+              }
+            }
+
+            if (failed) {
+              core.setFailed('One or more commits have invalid message format.');
+            } else {
+              core.info('All commit messages match the required format.');
+            }

--- a/00-how-computers-work/1-what-is-a-program/main.go
+++ b/00-how-computers-work/1-what-is-a-program/main.go
@@ -27,6 +27,8 @@ package main
 
 import "fmt"
 
+// main (Function): entry point for the program. It prints the core lesson
+// concept to stdout so the learner can see the fetch-decode-execute loop in action.
 func main() {
 	fmt.Println("A program is a list of instructions for the machine.")
 	fmt.Println("The CPU keeps fetching, decoding, and executing those instructions.")

--- a/00-how-computers-work/2-code-to-execution/main.go
+++ b/00-how-computers-work/2-code-to-execution/main.go
@@ -28,6 +28,9 @@ package main
 
 import "fmt"
 
+// main (Function): entry point for the program. It walks through the Go
+// compiler pipeline stages — tokens, AST, IR, binary — to demonstrate how
+// source code becomes a running executable.
 func main() {
 	fmt.Println("Source code : x := 42 + y")
 	fmt.Println("Tokens      : IDENT(x) DEFINE(:=) NUMBER(42) PLUS(+) IDENT(y)")

--- a/00-how-computers-work/3-memory-basics/main.go
+++ b/00-how-computers-work/3-memory-basics/main.go
@@ -29,12 +29,15 @@ package main
 import "fmt"
 
 // noEscape (Function): returns a plain value whose lifetime stays inside the caller boundary.
+// The return-by-value pattern keeps the result on the stack, avoiding heap allocation.
 func noEscape() int {
 	x := 42
 	return x
 }
 
 // escapes (Function): returns an address, forcing the local value to outlive its stack frame.
+// Returning a pointer triggers escape analysis and heap allocation, which is the key
+// trade-off this lesson demonstrates.
 func escapes() *int {
 	x := 99
 	return &x

--- a/00-how-computers-work/4-terminal-confidence/main.go
+++ b/00-how-computers-work/4-terminal-confidence/main.go
@@ -31,6 +31,9 @@ import (
 	"os"
 )
 
+// main (Function): entry point for the program. It writes to both stdout and stderr
+// to illustrate how programs expose multiple output streams that the shell can
+// redirect independently.
 func main() {
 	// Standard Output (stdout)
 	fmt.Println("This goes to standard output (stdout)")

--- a/00-how-computers-work/5-os-processes/main.go
+++ b/00-how-computers-work/5-os-processes/main.go
@@ -32,6 +32,9 @@ import (
 	"runtime"
 )
 
+// main (Function): entry point for the program. It queries the OS for process
+// metadata (PID, parent PID, hostname) and prints them to demonstrate that a Go
+// program runs as an OS-managed process with syscall boundaries.
 func main() {
 	fmt.Println("=== OS Processes and Syscalls ===")
 	fmt.Printf("PID: %d\n", os.Getpid())

--- a/07-concurrency/01-concurrency/time-and-scheduling/3-timer-and-ticker/README.md
+++ b/07-concurrency/01-concurrency/time-and-scheduling/3-timer-and-ticker/README.md
@@ -91,6 +91,13 @@ stopped
 2. What is the difference between `time.Sleep(1s)` and `<-time.After(1s)`?
 3. How can you use a `select` statement to listen to both a Ticker and a Cancellation Context?
 
+> [!NOTE]
+> Lessons TM.4 (random), TM.5 (scheduling), and TM.6 (timezone) exist as
+> exploratory content but are not part of the required curriculum path.
+> The mandatory sequence continues at
+> [TM.7](../7-reminder/README.md) which exercises the timer and ticker
+> concepts from this lesson.
+
 ## Next Step
 
 Next: `TM.7` -> [`07-concurrency/01-concurrency/time-and-scheduling/7-reminder`](../7-reminder/README.md)

--- a/10-production/05-observability/5-alerting-mindset/main.go
+++ b/10-production/05-observability/5-alerting-mindset/main.go
@@ -26,8 +26,6 @@ package main
 
 import "fmt"
 
-//
-
 func main() {
 	fmt.Println("=== OPS.5 Alerting mindset ===")
 	fmt.Println("Learn how useful alerts differ from noisy alerts and why runbooks and service objectives matter.")

--- a/11-flagship/01-opslane/.dockerignore
+++ b/11-flagship/01-opslane/.dockerignore
@@ -1,0 +1,33 @@
+# Git
+.git/
+.gitignore
+
+# Go build cache
+.cache/
+.gocache/
+
+# Environment files - not needed in production builds
+.env
+.env.example
+
+# Documentation
+docs/
+*.md
+README.md
+
+# Test and development files
+test/
+modules/
+scripts/
+Makefile
+docker-compose.yml
+
+# IDE and local config
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS artifacts
+.DS_Store
+Thumbs.db

--- a/11-flagship/01-opslane/Dockerfile
+++ b/11-flagship/01-opslane/Dockerfile
@@ -17,7 +17,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o opslane ./11-flagship/01-opslane/cmd/se
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates curl
 
-WORKDIR /root/
+# Create a non-root user for security best practice
+RUN adduser -D -H -u 1000 opslane
+USER opslane
+WORKDIR /home/opslane/
 
 COPY --from=builder /app/opslane .
 

--- a/11-flagship/01-opslane/Makefile
+++ b/11-flagship/01-opslane/Makefile
@@ -1,6 +1,10 @@
 # Opslane Makefile
 # Common development and operations commands
-
+#
+# Compatibility: This Makefile uses bash syntax ([[ ]], read -p, $( )).
+# On Windows, run with Git Bash, WSL, or MSYS2. PowerShell users may need
+# to run individual docker compose commands directly or use `wsl make <target>`.
+#
 # Colors for output
 RED = \033[0;31m
 GREEN = \033[0;32m

--- a/11-flagship/01-opslane/cmd/server/main.go
+++ b/11-flagship/01-opslane/cmd/server/main.go
@@ -30,6 +30,9 @@ import (
 
 const startupDatabaseTimeout = 10 * time.Second
 
+// main (Function): application entry point that initializes all dependencies
+// (config, database, auth, workers, HTTP server) in dependency order and
+// coordinates graceful shutdown via signal handling.
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
@@ -56,9 +59,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	var otelCfg otel.Config
-	otelCfg.FromEnv()
-	tracer := otel.New(otelCfg, logger)
+	tracer := otel.New(otel.Config{
+		Endpoint:    cfg.OTEL.Endpoint,
+		Insecure:    cfg.OTEL.Insecure,
+		Timeout:     cfg.OTEL.Timeout,
+		Enabled:     cfg.OTEL.Enabled,
+		SampleRate:  cfg.OTEL.SampleRate,
+		ServiceName: cfg.App.Name,
+		Environment: cfg.App.Env,
+	}, logger)
 	defer tracer.Stop()
 
 	rateLimiter := ratelimit.New(ratelimit.Config{

--- a/11-flagship/01-opslane/internal/auth/context.go
+++ b/11-flagship/01-opslane/internal/auth/context.go
@@ -8,23 +8,24 @@ import (
 	"errors"
 )
 
-// ErrMissingIdentity means protected code ran before auth middleware attached identity.
+// ErrMissingIdentity (Error): means protected code ran before auth middleware attached identity
 var ErrMissingIdentity = errors.New("missing authenticated identity")
 
+// identityContextKey (Struct): unexported context key type for storing auth identity
 type identityContextKey struct{}
 
-// WithIdentity stores trusted auth identity on a request context.
+// WithIdentity (Function): stores trusted auth identity on a request context
 func WithIdentity(ctx context.Context, identity Identity) context.Context {
 	return context.WithValue(ctx, identityContextKey{}, identity)
 }
 
-// IdentityFromContext returns the trusted auth identity if middleware attached one.
+// IdentityFromContext (Function): returns the trusted auth identity if middleware attached one
 func IdentityFromContext(ctx context.Context) (Identity, bool) {
 	identity, ok := ctx.Value(identityContextKey{}).(Identity)
 	return identity, ok
 }
 
-// RequireIdentity returns the trusted identity or an explicit error for protected paths.
+// RequireIdentity (Function): returns the trusted identity or an explicit error for protected paths
 func RequireIdentity(ctx context.Context) (Identity, error) {
 	identity, ok := IdentityFromContext(ctx)
 	if !ok {

--- a/11-flagship/01-opslane/internal/auth/middleware.go
+++ b/11-flagship/01-opslane/internal/auth/middleware.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// RequireAuth rejects anonymous requests and attaches verified tenant identity to context.
+// RequireAuth (Function): returns HTTP middleware that rejects anonymous requests and attaches verified identity to context
 func RequireAuth(tokens *TokenManager) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -23,7 +23,7 @@ func RequireAuth(tokens *TokenManager) func(http.Handler) http.Handler {
 	}
 }
 
-// IdentityFromRequest verifies the Authorization header and returns trusted token claims.
+// IdentityFromRequest (Function): verifies the Authorization header and returns trusted token claims
 func IdentityFromRequest(tokens *TokenManager, r *http.Request) (Identity, error) {
 	if tokens == nil {
 		return Identity{}, ErrInvalidToken

--- a/11-flagship/01-opslane/internal/auth/password.go
+++ b/11-flagship/01-opslane/internal/auth/password.go
@@ -14,15 +14,15 @@ import (
 )
 
 var (
-	// ErrInvalidCredentials hides whether the email, password, or token detail was wrong.
+	// ErrInvalidCredentials (Error): hides whether the email, password, or token detail was wrong
 	ErrInvalidCredentials = errors.New("invalid credentials")
-	// ErrWeakPassword tells callers that the proposed password failed the local policy.
+	// ErrWeakPassword (Error): tells callers that the proposed password failed the local policy
 	ErrWeakPassword = errors.New("password does not meet policy")
 )
 
 const minimumPasswordLength = 12
 
-// ValidatePassword enforces the minimum local password policy before hashing.
+// ValidatePassword (Function): enforces the minimum local password policy before hashing
 func ValidatePassword(password string) error {
 	if utf8.RuneCountInString(password) < minimumPasswordLength {
 		return fmt.Errorf("%w: must be at least %d characters", ErrWeakPassword, minimumPasswordLength)
@@ -46,7 +46,7 @@ func ValidatePassword(password string) error {
 	return nil
 }
 
-// HashPassword validates and stores a password using bcrypt.
+// HashPassword (Function): validates and hashes a password using bcrypt
 func HashPassword(password string) (string, error) {
 	if err := ValidatePassword(password); err != nil {
 		return "", err
@@ -60,7 +60,7 @@ func HashPassword(password string) (string, error) {
 	return string(hash), nil
 }
 
-// VerifyPassword compares a bcrypt hash with a candidate password.
+// VerifyPassword (Function): compares a bcrypt hash with a candidate password
 func VerifyPassword(hash, password string) error {
 	if strings.TrimSpace(hash) == "" || password == "" {
 		return ErrInvalidCredentials

--- a/11-flagship/01-opslane/internal/auth/service.go
+++ b/11-flagship/01-opslane/internal/auth/service.go
@@ -11,31 +11,31 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
-// UserLookup is the minimum repository behavior auth needs to verify credentials.
+// UserLookup (Interface): minimum repository behavior auth needs to verify credentials
 type UserLookup interface {
 	GetUserByEmail(ctx context.Context, tenantID int64, email string) (models.User, error)
 }
 
-// LoginRequest carries the tenant-scoped credentials required to issue a token.
+// LoginRequest (Struct): carries the tenant-scoped credentials required to issue a token
 type LoginRequest struct {
 	TenantID int64
 	Email    string
 	Password string
 }
 
-// LoginResult is the safe auth response returned after successful authentication.
+// LoginResult (Struct): safe auth response returned after successful authentication
 type LoginResult struct {
 	Token    string
 	Identity Identity
 }
 
-// Service verifies credentials and issues tenant-scoped access tokens.
+// Service (Struct): verifies credentials and issues tenant-scoped access tokens
 type Service struct {
 	users  UserLookup
 	tokens *TokenManager
 }
 
-// NewService wires the auth service to its persistence and token dependencies.
+// NewService (Constructor): wires the auth service to its persistence and token dependencies
 func NewService(users UserLookup, tokens *TokenManager) *Service {
 	return &Service{
 		users:  users,
@@ -43,7 +43,7 @@ func NewService(users UserLookup, tokens *TokenManager) *Service {
 	}
 }
 
-// Login verifies a tenant-scoped user password and returns a signed access token.
+// Login (Method): verifies a tenant-scoped user password and returns a signed access token
 func (s *Service) Login(ctx context.Context, req LoginRequest) (LoginResult, error) {
 	if s == nil || s.users == nil || s.tokens == nil {
 		return LoginResult{}, fmt.Errorf("auth service is not configured")

--- a/11-flagship/01-opslane/internal/auth/token.go
+++ b/11-flagship/01-opslane/internal/auth/token.go
@@ -19,13 +19,13 @@ import (
 )
 
 var (
-	// ErrInvalidToken means the token is malformed, signed by the wrong secret, or has invalid claims.
+	// ErrInvalidToken (Error): signals a malformed, incorrectly signed, or invalid-claims token
 	ErrInvalidToken = errors.New("invalid token")
-	// ErrExpiredToken means the token was valid once but is now outside its allowed lifetime.
+	// ErrExpiredToken (Error): indicates the token is beyond its allowed lifetime
 	ErrExpiredToken = errors.New("token expired")
 )
 
-// Identity is the trusted tenant-scoped user data carried after authentication.
+// Identity (Struct): holds the trusted tenant-scoped user data carried after authentication
 type Identity struct {
 	UserID    int64           `json:"user_id"`
 	TenantID  int64           `json:"tenant_id"`
@@ -35,7 +35,7 @@ type Identity struct {
 	ExpiresAt time.Time       `json:"expires_at"`
 }
 
-// TokenManager issues and verifies HMAC-signed JWT-compatible access tokens.
+// TokenManager (Struct): issues and verifies HMAC-signed JWT-compatible access tokens
 //
 // NOTE: This is a teaching JWT implementation to demonstrate cryptographic
 // signatures and identity extraction without external dependencies.
@@ -48,11 +48,13 @@ type TokenManager struct {
 	now    func() time.Time
 }
 
+// tokenHeader (Struct): internal JWT header with algorithm and type fields
 type tokenHeader struct {
 	Algorithm string `json:"alg"`
 	Type      string `json:"typ"`
 }
 
+// tokenClaims (Struct): internal JWT payload with identity and expiry fields
 type tokenClaims struct {
 	Issuer    string          `json:"iss"`
 	Subject   string          `json:"sub"`
@@ -64,7 +66,7 @@ type tokenClaims struct {
 	ExpiresAt int64           `json:"exp"`
 }
 
-// NewTokenManager builds a token manager from validated runtime auth settings.
+// NewTokenManager (Constructor): builds a token manager from validated runtime auth settings
 func NewTokenManager(secret, issuer string, ttl time.Duration) (*TokenManager, error) {
 	if len(secret) < 32 {
 		return nil, fmt.Errorf("token secret must be at least 32 characters")
@@ -86,7 +88,7 @@ func NewTokenManager(secret, issuer string, ttl time.Duration) (*TokenManager, e
 	}, nil
 }
 
-// Issue creates a signed token for a validated tenant-scoped identity.
+// Issue (Method): creates a signed JWT token for a validated tenant-scoped identity
 func (m *TokenManager) Issue(identity Identity) (string, error) {
 	if identity.UserID <= 0 {
 		return "", fmt.Errorf("identity user id must be positive")
@@ -133,7 +135,7 @@ func (m *TokenManager) Issue(identity Identity) (string, error) {
 	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
 }
 
-// Verify checks a token signature, issuer, expiry, and required tenant identity claims.
+// Verify (Method): checks token signature, issuer, expiry, and required tenant identity claims
 func (m *TokenManager) Verify(token string) (Identity, error) {
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
@@ -197,6 +199,7 @@ func (m *TokenManager) Verify(token string) (Identity, error) {
 	}, nil
 }
 
+// encodeSegment (Function): base64url-encodes a JSON-marshalled value for JWT segment
 func encodeSegment(value any) (string, error) {
 	data, err := json.Marshal(value)
 	if err != nil {
@@ -206,6 +209,7 @@ func encodeSegment(value any) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(data), nil
 }
 
+// decodeSegment (Function): base64url-decodes and JSON-unmarshals a JWT segment into value
 func decodeSegment(segment string, value any) error {
 	data, err := base64.RawURLEncoding.DecodeString(segment)
 	if err != nil {
@@ -215,6 +219,7 @@ func decodeSegment(segment string, value any) error {
 	return json.Unmarshal(data, value)
 }
 
+// sign (Function): computes an HMAC-SHA256 signature for JWT signing input
 func sign(input string, secret []byte) []byte {
 	mac := hmac.New(sha256.New, secret)
 	mac.Write([]byte(input))

--- a/11-flagship/01-opslane/internal/cache/cache.go
+++ b/11-flagship/01-opslane/internal/cache/cache.go
@@ -15,13 +15,15 @@ import (
 )
 
 var (
-	ErrNotFound    = errors.New("cache: key not found")
-	ErrKeyEmpty    = errors.New("cache: empty key")
+	// ErrNotFound (Error): returned when a cache key is not found
+	ErrNotFound = errors.New("cache: key not found")
+	// ErrKeyEmpty (Error): returned when an empty key is supplied
+	ErrKeyEmpty = errors.New("cache: empty key")
+	// ErrCacheClosed (Error): returned when the cache has been shut down
 	ErrCacheClosed = errors.New("cache: closed")
 )
 
-// Cache is the boundary that the rest of the application talks to.
-// PostgreSQL stays the system of record; this is always additive.
+// Cache (Interface): boundary that the rest of the application talks to for caching
 type Cache interface {
 	Get(ctx context.Context, key string) ([]byte, error)
 	Set(ctx context.Context, key string, value []byte, ttl time.Duration) error
@@ -30,23 +32,24 @@ type Cache interface {
 	Close() error
 }
 
-// entry holds one cached value and its absolute expiry time.
+// entry (Struct): holds one cached value and its absolute expiry time
 type entry struct {
 	value     []byte
 	expiresAt time.Time
 }
 
+// expired (Method): returns true if the entry's expiry time is past
 func (e entry) expired(now time.Time) bool {
 	return !e.expiresAt.IsZero() && now.After(e.expiresAt)
 }
 
-// Config controls the bounded behavior of the in-memory cache.
+// Config (Struct): controls the bounded behavior of the in-memory cache
 type Config struct {
 	MaxEntries int
 	DefaultTTL time.Duration
 }
 
-// DefaultConfig returns production-reasonable cache defaults.
+// DefaultConfig (Function): returns production-reasonable cache defaults
 func DefaultConfig() Config {
 	return Config{
 		MaxEntries: 4096,
@@ -54,42 +57,37 @@ func DefaultConfig() Config {
 	}
 }
 
-// TenantOrderKey builds a tenant-scoped cache key for a single order.
+// TenantOrderKey (Function): builds a tenant-scoped cache key for a single order
 func TenantOrderKey(tenantID, orderID int64) string {
 	return fmt.Sprintf("tenant:%d:order:%d", tenantID, orderID)
 }
 
-// TenantOrderListKey builds a tenant-scoped cache key for the order list.
+// TenantOrderListKey (Function): builds a tenant-scoped cache key for the order list
 func TenantOrderListKey(tenantID int64) string {
 	return fmt.Sprintf("tenant:%d:orders", tenantID)
 }
 
-// TenantPaymentListKey builds a tenant-scoped cache key for payments by order.
+// TenantPaymentListKey (Function): builds a tenant-scoped cache key for payments by order
 func TenantPaymentListKey(tenantID, orderID int64) string {
 	return fmt.Sprintf("tenant:%d:order:%d:payments", tenantID, orderID)
 }
 
-// TenantOrderPrefix returns the prefix that covers all order-related keys
-// for a given tenant, so that a write can invalidate the whole group.
+// TenantOrderPrefix (Function): returns the prefix covering all order-related keys for a tenant
 func TenantOrderPrefix(tenantID int64) string {
 	return fmt.Sprintf("tenant:%d:order", tenantID)
 }
 
-// Invalidator provides write-through cache invalidation.
-// Services call these methods after mutations so the cache never
-// silently serves stale data.
+// Invalidator (Struct): provides write-through cache invalidation for services
 type Invalidator struct {
 	cache Cache
 }
 
-// NewInvalidator creates an invalidator. If cache is nil, all operations
-// are safe no-ops.
+// NewInvalidator (Constructor): creates an invalidator; nil cache makes all operations safe no-ops
 func NewInvalidator(cache Cache) *Invalidator {
 	return &Invalidator{cache: cache}
 }
 
-// InvalidateOrder removes cached data for a specific order and the
-// tenant's order list so the next read comes from PostgreSQL.
+// InvalidateOrder (Method): removes cached data for a specific order and the tenant's order list
 func (inv *Invalidator) InvalidateOrder(ctx context.Context, tenantID, orderID int64) {
 	if inv == nil || inv.cache == nil {
 		return
@@ -99,7 +97,7 @@ func (inv *Invalidator) InvalidateOrder(ctx context.Context, tenantID, orderID i
 	_ = inv.cache.Delete(ctx, TenantOrderListKey(tenantID))
 }
 
-// InvalidatePayments removes cached payment data for an order.
+// InvalidatePayments (Method): removes cached payment data for an order
 func (inv *Invalidator) InvalidatePayments(ctx context.Context, tenantID, orderID int64) {
 	if inv == nil || inv.cache == nil {
 		return
@@ -108,9 +106,7 @@ func (inv *Invalidator) InvalidatePayments(ctx context.Context, tenantID, orderI
 	_ = inv.cache.Delete(ctx, TenantPaymentListKey(tenantID, orderID))
 }
 
-// InvalidateTenantOrders removes all cached order and payment data for a
-// tenant. Use this after bulk mutations or when granular invalidation
-// would be too expensive.
+// InvalidateTenantOrders (Method): removes all cached order and payment data for a tenant
 func (inv *Invalidator) InvalidateTenantOrders(ctx context.Context, tenantID int64) {
 	if inv == nil || inv.cache == nil {
 		return
@@ -120,15 +116,23 @@ func (inv *Invalidator) InvalidateTenantOrders(ctx context.Context, tenantID int
 	_ = inv.cache.Delete(ctx, TenantOrderListKey(tenantID))
 }
 
-// NoopCache satisfies the Cache interface without storing anything.
-// Useful for testing and for environments where caching is disabled.
+// NoopCache (Struct): satisfies the Cache interface without storing anything; useful for testing
 type NoopCache struct{}
 
-func (NoopCache) Get(context.Context, string) ([]byte, error)              { return nil, ErrNotFound }
+// Get (Method): returns ErrNotFound for the no-op cache
+func (NoopCache) Get(context.Context, string) ([]byte, error) { return nil, ErrNotFound }
+
+// Set (Method): no-op for the no-op cache
 func (NoopCache) Set(context.Context, string, []byte, time.Duration) error { return nil }
-func (NoopCache) Delete(context.Context, string) error                     { return nil }
-func (NoopCache) DeletePrefix(context.Context, string) error               { return nil }
-func (NoopCache) Close() error                                             { return nil }
+
+// Delete (Method): no-op for the no-op cache
+func (NoopCache) Delete(context.Context, string) error { return nil }
+
+// DeletePrefix (Method): no-op for the no-op cache
+func (NoopCache) DeletePrefix(context.Context, string) error { return nil }
+
+// Close (Method): no-op for the no-op cache
+func (NoopCache) Close() error { return nil }
 
 // compile-time interface checks
 var (
@@ -136,24 +140,20 @@ var (
 	_ Cache = (*InMemoryStore)(nil)
 )
 
-// Singleflight deduplicates concurrent loads for the same key.
-// Callers wrap their database read inside fn; if multiple goroutines
-// request the same key before the first load completes, only one
-// actually calls fn and the rest receive its result.
+// Singleflight (Struct): deduplicates concurrent cache loads for the same key to prevent thundering herd
 type Singleflight struct {
 	mu    sync.Mutex
 	calls map[string]*call
 }
 
+// call (Struct): tracks a single in-flight singleflight operation
 type call struct {
 	wg  sync.WaitGroup
 	val []byte
 	err error
 }
 
-// Do executes fn once per key. Concurrent callers with the same key
-// block until the first caller's fn returns, then receive the same
-// result.
+// Do (Method): executes fn once per key, returning the same result to concurrent callers
 func (sf *Singleflight) Do(key string, fn func() ([]byte, error)) (val []byte, err error) {
 	sf.mu.Lock()
 	if sf.calls == nil {

--- a/11-flagship/01-opslane/internal/cache/store.go
+++ b/11-flagship/01-opslane/internal/cache/store.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// InMemoryStore is a bounded, TTL-aware in-memory cache.
+// InMemoryStore (Struct): bounded, TTL-aware in-memory cache with concurrent access support
 //
 // Design decisions:
 //   - sync.RWMutex protects the map; reads take the read-lock, writes take
@@ -34,8 +34,7 @@ type InMemoryStore struct {
 	once   sync.Once
 }
 
-// NewInMemoryStore creates a bounded in-memory cache with a background
-// janitor that cleans expired entries every cleanupInterval.
+// NewInMemoryStore (Constructor): creates a bounded in-memory cache with a background cleanup janitor
 func NewInMemoryStore(config Config) *InMemoryStore {
 	if config.MaxEntries <= 0 {
 		config.MaxEntries = DefaultConfig().MaxEntries
@@ -57,6 +56,7 @@ func NewInMemoryStore(config Config) *InMemoryStore {
 	return s
 }
 
+// Get (Method): retrieves a value by key, returning a copy to prevent mutation
 func (s *InMemoryStore) Get(_ context.Context, key string) ([]byte, error) {
 	if key == "" {
 		return nil, ErrKeyEmpty
@@ -93,6 +93,7 @@ func (s *InMemoryStore) Get(_ context.Context, key string) ([]byte, error) {
 	return cp, nil
 }
 
+// Set (Method): stores a value with TTL, evicting oldest entry if at capacity
 func (s *InMemoryStore) Set(_ context.Context, key string, value []byte, ttl time.Duration) error {
 	if key == "" {
 		return ErrKeyEmpty
@@ -131,6 +132,7 @@ func (s *InMemoryStore) Set(_ context.Context, key string, value []byte, ttl tim
 	return nil
 }
 
+// Delete (Method): removes a single key from the cache
 func (s *InMemoryStore) Delete(_ context.Context, key string) error {
 	if key == "" {
 		return ErrKeyEmpty
@@ -152,8 +154,7 @@ func (s *InMemoryStore) Delete(_ context.Context, key string) error {
 	return nil
 }
 
-// DeletePrefix removes all entries whose key starts with the given prefix.
-// This supports batch invalidation, e.g. clearing all order data for a tenant.
+// DeletePrefix (Method): removes all entries whose key starts with the given prefix
 func (s *InMemoryStore) DeletePrefix(_ context.Context, prefix string) error {
 	if prefix == "" {
 		return ErrKeyEmpty
@@ -183,8 +184,7 @@ func (s *InMemoryStore) DeletePrefix(_ context.Context, prefix string) error {
 	return nil
 }
 
-// Close stops the background janitor. After Close returns, Get and Set
-// return ErrCacheClosed.
+// Close (Method): stops the background janitor; subsequent Get/Set return ErrCacheClosed
 func (s *InMemoryStore) Close() error {
 	s.once.Do(func() {
 		close(s.closed)
@@ -192,16 +192,14 @@ func (s *InMemoryStore) Close() error {
 	return nil
 }
 
-// Len returns the number of entries currently in the cache.
-// Exported for tests and diagnostics.
+// Len (Method): returns the number of entries currently in the cache; exported for tests and diagnostics
 func (s *InMemoryStore) Len() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.entries)
 }
 
-// evictOldest removes the entry that was inserted first. Must be called
-// with s.mu held for writing.
+// evictOldest (Method): removes the entry that was inserted first; caller must hold write lock
 func (s *InMemoryStore) evictOldest() {
 	if len(s.order) == 0 {
 		return
@@ -211,8 +209,7 @@ func (s *InMemoryStore) evictOldest() {
 	delete(s.entries, oldest)
 }
 
-// removeFromOrder removes a key from the insertion-order slice.
-// Must be called with s.mu held for writing.
+// removeFromOrder (Method): removes a key from the insertion-order slice; caller must hold write lock
 func (s *InMemoryStore) removeFromOrder(key string) {
 	for i, k := range s.order {
 		if k == key {
@@ -222,7 +219,7 @@ func (s *InMemoryStore) removeFromOrder(key string) {
 	}
 }
 
-// janitor periodically sweeps expired entries.
+// janitor (Goroutine): periodic background sweep of expired entries
 func (s *InMemoryStore) janitor(interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -237,7 +234,7 @@ func (s *InMemoryStore) janitor(interval time.Duration) {
 	}
 }
 
-// sweep removes all expired entries in one pass.
+// sweep (Method): removes all expired entries in one pass
 func (s *InMemoryStore) sweep() {
 	now := s.now()
 

--- a/11-flagship/01-opslane/internal/config/config.go
+++ b/11-flagship/01-opslane/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	HTTP     HTTPConfig
 	Database DatabaseConfig
 	Auth     AuthConfig
+	OTEL     OTELConfig
 }
 
 // AppConfig (Struct): defines application-level settings including service identity,
@@ -60,6 +61,17 @@ type AuthConfig struct {
 	TokenSecret string
 	TokenIssuer string
 	TokenTTL    time.Duration
+}
+
+// OTELConfig (Struct): defines OpenTelemetry tracer settings including endpoint,
+// security mode, timeout, and sampling rate. These values are passed to the
+// otel.Tracer constructor at startup.
+type OTELConfig struct {
+	Endpoint   string
+	Insecure   bool
+	Enabled    bool
+	Timeout    time.Duration
+	SampleRate float64
 }
 
 const defaultDevelopmentTokenSecret = "development-only-opslane-secret-change-me"
@@ -133,6 +145,18 @@ func LoadFromLookup(lookup LookupFunc) (Config, error) {
 		return Config{}, err
 	}
 
+	otlpTimeout, err := durationFromEnv(lookup, "OPSLANE_OTEL_TIMEOUT", 5*time.Second)
+	if err != nil {
+		return Config{}, fmt.Errorf("parse OPSLANE_OTEL_TIMEOUT: %w", err)
+	}
+
+	otlpSampleRate, err := floatFromEnv(lookup, "OPSLANE_OTEL_SAMPLE_RATE", 1.0)
+	if err != nil {
+		return Config{}, fmt.Errorf("parse OPSLANE_OTEL_SAMPLE_RATE: %w", err)
+	}
+
+	otelEndpoint := stringFromEnv(lookup, "OPSLANE_OTEL_ENDPOINT", "")
+
 	cfg := Config{
 		App: AppConfig{
 			Name:     "opslane",
@@ -159,6 +183,13 @@ func LoadFromLookup(lookup LookupFunc) (Config, error) {
 			TokenSecret: stringFromEnv(lookup, "OPSLANE_AUTH_TOKEN_SECRET", defaultDevelopmentTokenSecret),
 			TokenIssuer: stringFromEnv(lookup, "OPSLANE_AUTH_TOKEN_ISSUER", "opslane"),
 			TokenTTL:    tokenTTL,
+		},
+		OTEL: OTELConfig{
+			Endpoint:   otelEndpoint,
+			Insecure:   stringFromEnv(lookup, "OPSLANE_OTEL_INSECURE", "") == "true",
+			Enabled:    otelEndpoint != "",
+			Timeout:    otlpTimeout,
+			SampleRate: otlpSampleRate,
 		},
 	}
 
@@ -251,6 +282,14 @@ func (c Config) Validate() error {
 
 	if c.Auth.TokenTTL <= 0 {
 		return fmt.Errorf("OPSLANE_AUTH_TOKEN_TTL must be positive")
+	}
+
+	if c.OTEL.SampleRate < 0 || c.OTEL.SampleRate > 1 {
+		return fmt.Errorf("OPSLANE_OTEL_SAMPLE_RATE must be between 0 and 1, got %f", c.OTEL.SampleRate)
+	}
+
+	if c.OTEL.Timeout <= 0 {
+		return fmt.Errorf("OPSLANE_OTEL_TIMEOUT must be positive")
 	}
 
 	return nil

--- a/11-flagship/01-opslane/internal/config/config_test.go
+++ b/11-flagship/01-opslane/internal/config/config_test.go
@@ -56,6 +56,22 @@ func TestLoadFromLookupDefaults(t *testing.T) {
 	if len(cfg.HTTP.TrustedProxyCIDRs) != 0 {
 		t.Fatalf("trusted proxy cidrs = %v, want none by default", cfg.HTTP.TrustedProxyCIDRs)
 	}
+
+	if cfg.OTEL.Endpoint != "" {
+		t.Fatalf("otel endpoint = %q, want empty", cfg.OTEL.Endpoint)
+	}
+
+	if cfg.OTEL.Enabled {
+		t.Fatal("otel should be disabled by default")
+	}
+
+	if cfg.OTEL.Timeout != 5*time.Second {
+		t.Fatalf("otel timeout = %v, want 5s", cfg.OTEL.Timeout)
+	}
+
+	if cfg.OTEL.SampleRate != 1.0 {
+		t.Fatalf("otel sample rate = %f, want 1.0", cfg.OTEL.SampleRate)
+	}
 }
 
 func TestLoadFromLookupOverrides(t *testing.T) {
@@ -79,6 +95,10 @@ func TestLoadFromLookupOverrides(t *testing.T) {
 		"OPSLANE_AUTH_TOKEN_SECRET":        "staging-secret-with-at-least-thirty-two-chars",
 		"OPSLANE_AUTH_TOKEN_ISSUER":        "opslane-staging",
 		"OPSLANE_AUTH_TOKEN_TTL":           "30m",
+		"OPSLANE_OTEL_ENDPOINT":            "otel.example.com:4318",
+		"OPSLANE_OTEL_INSECURE":            "true",
+		"OPSLANE_OTEL_TIMEOUT":             "10s",
+		"OPSLANE_OTEL_SAMPLE_RATE":         "0.5",
 	}
 
 	cfg, err := LoadFromLookup(func(key string) (string, bool) {
@@ -137,6 +157,26 @@ func TestLoadFromLookupOverrides(t *testing.T) {
 
 	if cfg.Auth.TokenTTL != 30*time.Minute {
 		t.Fatalf("token ttl = %v, want %v", cfg.Auth.TokenTTL, 30*time.Minute)
+	}
+
+	if cfg.OTEL.Endpoint != "otel.example.com:4318" {
+		t.Fatalf("otel endpoint = %q, want otel.example.com:4318", cfg.OTEL.Endpoint)
+	}
+
+	if !cfg.OTEL.Insecure {
+		t.Fatal("otel insecure should be true")
+	}
+
+	if !cfg.OTEL.Enabled {
+		t.Fatal("otel should be enabled when endpoint is set")
+	}
+
+	if cfg.OTEL.Timeout != 10*time.Second {
+		t.Fatalf("otel timeout = %v, want 10s", cfg.OTEL.Timeout)
+	}
+
+	if cfg.OTEL.SampleRate != 0.5 {
+		t.Fatalf("otel sample rate = %f, want 0.5", cfg.OTEL.SampleRate)
 	}
 }
 
@@ -239,6 +279,34 @@ func TestLoadFromLookupRejectsShortAuthSecret(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for short auth secret")
+	}
+}
+
+func TestLoadFromLookupRejectsInvalidOTELSampleRate(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadFromLookup(func(key string) (string, bool) {
+		if key == "OPSLANE_OTEL_SAMPLE_RATE" {
+			return "1.5", true
+		}
+		return "", false
+	})
+	if err == nil {
+		t.Fatal("expected error for sample rate > 1")
+	}
+}
+
+func TestLoadFromLookupRejectsInvalidOTELTimeout(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadFromLookup(func(key string) (string, bool) {
+		if key == "OPSLANE_OTEL_TIMEOUT" {
+			return "-5s", true
+		}
+		return "", false
+	})
+	if err == nil {
+		t.Fatal("expected error for negative timeout")
 	}
 }
 

--- a/11-flagship/01-opslane/internal/config/environment.go
+++ b/11-flagship/01-opslane/internal/config/environment.go
@@ -14,6 +14,8 @@ import (
 // It matches the signature of os.LookupEnv.
 type LookupFunc func(string) (string, bool)
 
+// stringFromEnv (Function): reads a string environment variable through the lookup
+// abstraction, returning the fallback when the variable is unset or empty.
 func stringFromEnv(lookup LookupFunc, key, fallback string) string {
 	if value, ok := lookup(key); ok && value != "" {
 		return value
@@ -22,6 +24,8 @@ func stringFromEnv(lookup LookupFunc, key, fallback string) string {
 	return fallback
 }
 
+// durationFromEnv (Function): reads a duration environment variable with a default
+// fallback, returning an error if the value is present but not a valid Go duration.
 func durationFromEnv(lookup LookupFunc, key string, fallback time.Duration) (time.Duration, error) {
 	raw, ok := lookup(key)
 	if !ok || raw == "" {
@@ -36,6 +40,8 @@ func durationFromEnv(lookup LookupFunc, key string, fallback time.Duration) (tim
 	return value, nil
 }
 
+// intFromEnv (Function): reads an integer environment variable with a default
+// fallback, returning an error when parsing fails.
 func intFromEnv(lookup LookupFunc, key string, fallback int) (int, error) {
 	raw, ok := lookup(key)
 	if !ok || raw == "" {
@@ -50,6 +56,24 @@ func intFromEnv(lookup LookupFunc, key string, fallback int) (int, error) {
 	return value, nil
 }
 
+// floatFromEnv (Function): reads a float64 environment variable with a default
+// fallback, returning an error when parsing fails.
+func floatFromEnv(lookup LookupFunc, key string, fallback float64) (float64, error) {
+	raw, ok := lookup(key)
+	if !ok || raw == "" {
+		return fallback, nil
+	}
+
+	value, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return value, nil
+}
+
+// cidrPrefixesFromEnv (Function): reads a comma-separated CIDR prefix list from an
+// environment variable, returning an error if any prefix fails to parse.
 func cidrPrefixesFromEnv(lookup LookupFunc, key string) ([]netip.Prefix, error) {
 	raw, ok := lookup(key)
 	if !ok || strings.TrimSpace(raw) == "" {

--- a/11-flagship/01-opslane/internal/db/migrations.go
+++ b/11-flagship/01-opslane/internal/db/migrations.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 )
 
+// schemaStatements (Slice): ordered list of DDL statements for database schema migration
 var schemaStatements = []string{
 	`CREATE TABLE IF NOT EXISTS tenants (
 		id BIGSERIAL PRIMARY KEY,
@@ -72,6 +73,7 @@ var schemaStatements = []string{
 	`CREATE INDEX IF NOT EXISTS idx_payments_tenant_status ON payments(tenant_id, status);`,
 }
 
+// Migrate (Function): applies all schema migration statements in order
 func Migrate(ctx context.Context, database *sql.DB) error {
 	for _, statement := range schemaStatements {
 		if _, err := database.ExecContext(ctx, statement); err != nil {

--- a/11-flagship/01-opslane/internal/db/repository.go
+++ b/11-flagship/01-opslane/internal/db/repository.go
@@ -15,30 +15,28 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
-// ErrInvalidReference means a tenant-scoped row points at a parent row that does not exist.
+// ErrInvalidReference (Error): means a tenant-scoped row points at a parent row that does not exist
 var ErrInvalidReference = errors.New("invalid tenant-scoped reference")
 
-// ErrDuplicateValue indicates that an insert or update violated a unique constraint.
+// ErrDuplicateValue (Error): indicates that an insert or update violated a unique constraint
 var ErrDuplicateValue = errors.New("duplicate value")
 
 const postgresForeignKeyViolation = "23503"
 const postgresUniqueViolation = "23505"
 
-// TenantRepository defines the data access contract for tenant records.
-// In a multi-tenant system, tenants are the root boundary for all other resources.
+// TenantRepository (Interface): defines the data access contract for tenant records
 type TenantRepository interface {
 	CreateTenant(ctx context.Context, tenant *models.Tenant) error
 	GetTenantBySlug(ctx context.Context, slug string) (models.Tenant, error)
 }
 
-// UserRepository manages user identity records scoped to specific tenants.
+// UserRepository (Interface): manages user identity records scoped to specific tenants
 type UserRepository interface {
 	CreateUser(ctx context.Context, user *models.User) error
 	GetUserByEmail(ctx context.Context, tenantID int64, email string) (models.User, error)
 }
 
-// OrderRepository handles the lifecycle and retrieval of customer orders.
-// All operations are strictly tenant-scoped to prevent cross-tenant data leaks.
+// OrderRepository (Interface): handles the lifecycle and retrieval of customer orders; strictly tenant-scoped
 type OrderRepository interface {
 	CreateOrder(ctx context.Context, order *models.Order) error
 	GetOrderByID(ctx context.Context, tenantID, orderID int64) (models.Order, error)
@@ -47,7 +45,7 @@ type OrderRepository interface {
 	ListOrdersByTenant(ctx context.Context, tenantID int64) ([]models.Order, error)
 }
 
-// PaymentRepository manages financial transactions tied to specific orders.
+// PaymentRepository (Interface): manages financial transactions tied to specific orders
 type PaymentRepository interface {
 	CreatePayment(ctx context.Context, payment *models.Payment) error
 	GetPaymentByProviderReference(ctx context.Context, tenantID int64, providerReference string) (models.Payment, error)
@@ -55,23 +53,20 @@ type PaymentRepository interface {
 	ListPaymentsByOrder(ctx context.Context, tenantID, orderID int64) ([]models.Payment, error)
 }
 
+// queryRunner (Interface): abstracts sql.DB and sql.Tx for transactional queries
 type queryRunner interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
 	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
-// Store provides a concrete implementation of all database repositories
-// backed by PostgreSQL. It wraps the raw sql.DB connection and implements
-// transaction support.
+// Store (Struct): concrete PostgreSQL-backed implementation of all database repositories with transaction support
 type Store struct {
 	db *sql.DB
 	q  queryRunner
 }
 
-// Open establishes a connection pool to the PostgreSQL database.
-// It configures connection limits and timeouts based on the provided Config,
-// and verifies connectivity before returning.
+// Open (Function): establishes and verifies a PostgreSQL connection pool from config
 func Open(ctx context.Context, cfg config.DatabaseConfig) (*sql.DB, error) {
 	database, err := sql.Open("postgres", cfg.DSN)
 	if err != nil {
@@ -91,8 +86,7 @@ func Open(ctx context.Context, cfg config.DatabaseConfig) (*sql.DB, error) {
 	return database, nil
 }
 
-// NewStore creates a new PostgreSQL-backed Store. The provided database
-// connection should be fully configured and verified (e.g. via Open).
+// NewStore (Constructor): creates a new PostgreSQL-backed Store from a verified connection
 func NewStore(database *sql.DB) *Store {
 	return &Store{
 		db: database,
@@ -100,14 +94,12 @@ func NewStore(database *sql.DB) *Store {
 	}
 }
 
-// Ping verifies that the database connection is alive and healthy.
+// Ping (Method): verifies the database connection is alive and healthy
 func (s *Store) Ping(ctx context.Context) error {
 	return s.db.PingContext(ctx)
 }
 
-// WithTx executes the provided function within a single database transaction.
-// If the function returns an error, the transaction is automatically rolled back.
-// If the function panics, the transaction is rolled back and the panic is propagated.
+// WithTx (Method): executes a function within a database transaction with automatic rollback on error or panic
 func (s *Store) WithTx(ctx context.Context, fn func(*Store) error) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -144,9 +136,7 @@ func (s *Store) WithTx(ctx context.Context, fn func(*Store) error) error {
 	return nil
 }
 
-// CreateTenant inserts a new tenant into the database. If the tenant's CreatedAt
-// timestamp is zero, it defaults to the current UTC time. Returns ErrDuplicateValue
-// if the tenant slug already exists.
+// CreateTenant (Method): inserts a new tenant, defaulting CreatedAt to UTC; returns ErrDuplicateValue on slug conflict
 func (s *Store) CreateTenant(ctx context.Context, tenant *models.Tenant) error {
 	if tenant.CreatedAt.IsZero() {
 		tenant.CreatedAt = time.Now().UTC()
@@ -169,8 +159,7 @@ func (s *Store) CreateTenant(ctx context.Context, tenant *models.Tenant) error {
 	return nil
 }
 
-// GetTenantBySlug retrieves a tenant by its unique URL-friendly slug.
-// Useful for middleware mapping incoming subdomains or paths to a tenant context.
+// GetTenantBySlug (Method): retrieves a tenant by its unique URL-friendly slug
 func (s *Store) GetTenantBySlug(ctx context.Context, slug string) (models.Tenant, error) {
 	var tenant models.Tenant
 
@@ -186,9 +175,7 @@ func (s *Store) GetTenantBySlug(ctx context.Context, slug string) (models.Tenant
 	return tenant, nil
 }
 
-// CreateUser persists a new user record. Returns ErrInvalidReference if the
-// specified TenantID does not exist, or ErrDuplicateValue if the email is already
-// registered within the tenant.
+// CreateUser (Method): persists a new user record; returns ErrInvalidReference or ErrDuplicateValue on constraint violations
 func (s *Store) CreateUser(ctx context.Context, user *models.User) error {
 	if user.CreatedAt.IsZero() {
 		user.CreatedAt = time.Now().UTC()
@@ -219,9 +206,7 @@ func (s *Store) CreateUser(ctx context.Context, user *models.User) error {
 	return nil
 }
 
-// GetUserByEmail finds a user by their email address within a specific tenant.
-// Email addresses are unique per tenant, allowing users to belong to multiple
-// tenants with the same email.
+// GetUserByEmail (Method): finds a user by email within a specific tenant; email is unique per tenant
 func (s *Store) GetUserByEmail(ctx context.Context, tenantID int64, email string) (models.User, error) {
 	var user models.User
 
@@ -248,9 +233,7 @@ func (s *Store) GetUserByEmail(ctx context.Context, tenantID int64, email string
 	return user, nil
 }
 
-// CreateOrder initiates a new customer order. It populates timestamps and
-// enforces uniqueness on the IdempotencyKey to prevent accidental double-charges
-// during retries.
+// CreateOrder (Method): initiates a new customer order with idempotency key uniqueness for retry safety
 func (s *Store) CreateOrder(ctx context.Context, order *models.Order) error {
 	now := time.Now().UTC()
 	if order.CreatedAt.IsZero() {
@@ -284,8 +267,7 @@ func (s *Store) CreateOrder(ctx context.Context, order *models.Order) error {
 	return nil
 }
 
-// ListOrdersByTenant retrieves all orders belonging to a tenant, sorted
-// descending by creation time (newest first).
+// ListOrdersByTenant (Method): retrieves all orders for a tenant, sorted newest first
 func (s *Store) ListOrdersByTenant(ctx context.Context, tenantID int64) ([]models.Order, error) {
 	rows, err := s.q.QueryContext(
 		ctx,
@@ -326,8 +308,7 @@ func (s *Store) ListOrdersByTenant(ctx context.Context, tenantID int64) ([]model
 	return orders, nil
 }
 
-// GetOrderByID fetches a single order. The tenantID is strictly required
-// to enforce tenant isolation at the database query level.
+// GetOrderByID (Method): fetches a single order with tenant isolation enforced at the query level
 func (s *Store) GetOrderByID(ctx context.Context, tenantID, orderID int64) (models.Order, error) {
 	var order models.Order
 
@@ -356,8 +337,7 @@ func (s *Store) GetOrderByID(ctx context.Context, tenantID, orderID int64) (mode
 	return order, nil
 }
 
-// GetOrderByIdempotencyKey fetches an existing order using the client-provided
-// idempotency key. Used to safely replay requests without duplicating data.
+// GetOrderByIdempotencyKey (Method): fetches an existing order by idempotency key for safe request replay
 func (s *Store) GetOrderByIdempotencyKey(ctx context.Context, tenantID int64, idempotencyKey string) (models.Order, error) {
 	var order models.Order
 
@@ -386,8 +366,7 @@ func (s *Store) GetOrderByIdempotencyKey(ctx context.Context, tenantID int64, id
 	return order, nil
 }
 
-// UpdateOrderStatus transitions an order to a new status and updates its
-// UpdatedAt timestamp. It returns the fully updated order record.
+// UpdateOrderStatus (Method): transitions an order to a new status and returns the updated record
 func (s *Store) UpdateOrderStatus(ctx context.Context, tenantID, orderID int64, status models.OrderStatus) (models.Order, error) {
 	var order models.Order
 	updatedAt := time.Now().UTC()
@@ -420,9 +399,7 @@ func (s *Store) UpdateOrderStatus(ctx context.Context, tenantID, orderID int64, 
 	return order, nil
 }
 
-// CreatePayment records a new payment attempt. Returns ErrInvalidReference
-// if the associated order does not exist, or ErrDuplicateValue if the
-// payment gateway's provider reference has already been logged.
+// CreatePayment (Method): records a new payment attempt with FK and uniqueness constraint checks
 func (s *Store) CreatePayment(ctx context.Context, payment *models.Payment) error {
 	now := time.Now().UTC()
 	if payment.CreatedAt.IsZero() {
@@ -459,8 +436,7 @@ func (s *Store) CreatePayment(ctx context.Context, payment *models.Payment) erro
 	return nil
 }
 
-// GetPaymentByProviderReference finds a payment using the external ID
-// returned by the payment gateway (e.g., a Stripe Charge ID).
+// GetPaymentByProviderReference (Method): finds a payment by the gateway's external reference ID
 func (s *Store) GetPaymentByProviderReference(ctx context.Context, tenantID int64, providerReference string) (models.Payment, error) {
 	var payment models.Payment
 
@@ -489,8 +465,7 @@ func (s *Store) GetPaymentByProviderReference(ctx context.Context, tenantID int6
 	return payment, nil
 }
 
-// UpdatePaymentStatus records the outcome of a payment attempt (e.g., Settled or Failed),
-// updating the UpdatedAt timestamp and optionally recording the failure reason.
+// UpdatePaymentStatus (Method): records the outcome of a payment attempt with optional failure reason
 func (s *Store) UpdatePaymentStatus(ctx context.Context, tenantID int64, providerReference string, status models.PaymentStatus, failureReason string) (models.Payment, error) {
 	var payment models.Payment
 	updatedAt := time.Now().UTC()
@@ -524,8 +499,7 @@ func (s *Store) UpdatePaymentStatus(ctx context.Context, tenantID int64, provide
 	return payment, nil
 }
 
-// ListPaymentsByOrder retrieves all payment attempts for a specific order,
-// sorted ascending by creation time (oldest first) to establish a timeline.
+// ListPaymentsByOrder (Method): retrieves all payment attempts for an order, oldest first
 func (s *Store) ListPaymentsByOrder(ctx context.Context, tenantID, orderID int64) ([]models.Payment, error) {
 	rows, err := s.q.QueryContext(
 		ctx,
@@ -567,11 +541,13 @@ func (s *Store) ListPaymentsByOrder(ctx context.Context, tenantID, orderID int64
 	return payments, nil
 }
 
+// isForeignKeyViolation (Function): checks if a Postgres error is a foreign key violation
 func isForeignKeyViolation(err error) bool {
 	var pqErr *pq.Error
 	return errors.As(err, &pqErr) && string(pqErr.Code) == postgresForeignKeyViolation
 }
 
+// isUniqueViolation (Function): checks if a Postgres error is a unique constraint violation
 func isUniqueViolation(err error) bool {
 	var pqErr *pq.Error
 	return errors.As(err, &pqErr) && string(pqErr.Code) == postgresUniqueViolation

--- a/11-flagship/01-opslane/internal/events/bus.go
+++ b/11-flagship/01-opslane/internal/events/bus.go
@@ -12,19 +12,15 @@ import (
 )
 
 var (
-	// ErrInvalidEvent is returned when an event is missing required routing fields (like Type or TenantID).
+	// ErrInvalidEvent (Error): returned when an event is missing required routing fields
 	ErrInvalidEvent = errors.New("invalid event")
-	// ErrQueueFull is returned by TryPublish when the bus buffer is completely saturated.
+	// ErrQueueFull (Error): returned by TryPublish when the bus buffer is saturated
 	ErrQueueFull = errors.New("event queue full")
-	// ErrBusClosed is returned when attempting to publish to a bus that has been permanently shut down.
+	// ErrBusClosed (Error): returned when attempting to publish to a permanently shut-down bus
 	ErrBusClosed = errors.New("event bus closed")
 )
 
-// Bus is a single-channel event bus. Publish/TryPublish write events into a
-// buffered channel; subscribers read from that same channel via Subscribe.
-//
-// Thread-safety: all exported methods are safe for concurrent use.
-// Close is idempotent - calling it multiple times is safe.
+// Bus (Struct): single-channel event bus with buffered channel, thread-safe and idempotent close
 //
 // Design note: the closed signal is carried solely by the `closed` channel.
 // A non-blocking select on a closed channel is O(1) and allocation-free, so
@@ -36,8 +32,7 @@ type Bus struct {
 	now    func() time.Time
 }
 
-// NewBus initializes a new thread-safe Event Bus. The capacity determines the
-// channel buffer size. If capacity is <= 0, it defaults to an unbuffered channel size of 1.
+// NewBus (Constructor): creates a new thread-safe event bus with the given channel buffer capacity
 func NewBus(capacity int) *Bus {
 	if capacity <= 0 {
 		capacity = 1
@@ -50,9 +45,7 @@ func NewBus(capacity int) *Bus {
 	}
 }
 
-// Subscribe returns the read-only event channel. All published events are
-// delivered in order. The channel is never closed by the bus; callers should
-// also select on a done/context signal to know when to stop reading.
+// Subscribe (Method): returns the read-only event channel for ordered delivery; channel is never closed by the bus
 func (b *Bus) Subscribe() <-chan Event {
 	if b == nil {
 		return nil
@@ -61,8 +54,7 @@ func (b *Bus) Subscribe() <-chan Event {
 	return b.events
 }
 
-// TryPublish attempts a non-blocking publish. Returns ErrQueueFull immediately
-// if the buffer is at capacity, or ErrBusClosed if Close has been called.
+// TryPublish (Method): non-blocking publish; returns ErrQueueFull or ErrBusClosed immediately
 func (b *Bus) TryPublish(event Event) error {
 	if b == nil {
 		return fmt.Errorf("event bus is not configured")
@@ -91,8 +83,7 @@ func (b *Bus) TryPublish(event Event) error {
 	}
 }
 
-// Publish enqueues an event, blocking until it is accepted, the bus is
-// closed, or the context is cancelled.
+// Publish (Method): enqueues an event, blocking until accepted, bus closed, or context cancelled
 func (b *Bus) Publish(ctx context.Context, event Event) error {
 	if b == nil {
 		return fmt.Errorf("event bus is not configured")
@@ -123,9 +114,7 @@ func (b *Bus) Publish(ctx context.Context, event Event) error {
 	}
 }
 
-// Close permanently shuts the bus. After Close returns, all subsequent
-// Publish and TryPublish calls will return ErrBusClosed immediately.
-// Close is idempotent; calling it more than once is safe.
+// Close (Method): permanently shuts the bus; idempotent and safe for concurrent use
 //
 // Note: b.events is intentionally NOT closed here. The bus does not own the
 // consumer side of the channel, so closing it would risk a panic in any
@@ -143,6 +132,7 @@ func (b *Bus) Close() {
 	})
 }
 
+// prepare (Method): validates and timestamps an event before publishing
 func (b *Bus) prepare(event Event) (Event, error) {
 	if event.Type == "" || event.TenantID <= 0 {
 		return Event{}, ErrInvalidEvent

--- a/11-flagship/01-opslane/internal/events/types.go
+++ b/11-flagship/01-opslane/internal/events/types.go
@@ -9,26 +9,25 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
-// Type represents the routing key for a specific business event.
-// Subscribers use these keys to bind handlers to specific lifecycle moments.
+// Type (Type): routing key for a specific business event; used by subscribers to bind handlers
 type Type string
 
 const (
-	// TypeOrderCreated is emitted immediately after a new order is persisted.
+	// TypeOrderCreated (Constant): emitted immediately after a new order is persisted
 	TypeOrderCreated Type = "order.created"
-	// TypeOrderStatusChanged is emitted whenever an order transitions (e.g. Pending -> Paid).
+	// TypeOrderStatusChanged (Constant): emitted when an order transitions status
 	TypeOrderStatusChanged Type = "order.status_changed"
-	// TypePaymentRequested is emitted when a payment needs to be authorized by the gateway.
+	// TypePaymentRequested (Constant): emitted when a payment needs gateway authorization
 	TypePaymentRequested Type = "payment.requested"
-	// TypePaymentSettled is emitted when the gateway confirms funds are captured.
+	// TypePaymentSettled (Constant): emitted when the gateway confirms funds are captured
 	TypePaymentSettled Type = "payment.settled"
-	// TypePaymentFailed is emitted when a payment attempt is rejected by the gateway.
+	// TypePaymentFailed (Constant): emitted when a payment attempt is rejected by the gateway
 	TypePaymentFailed Type = "payment.failed"
-	// TypeNotificationRequested is emitted to trigger an asynchronous customer communication.
+	// TypeNotificationRequested (Constant): emitted to trigger asynchronous customer communication
 	TypeNotificationRequested Type = "notification.requested"
 )
 
-// Event is the small, explicit message that crosses the async boundary.
+// Event (Struct): small, explicit message that crosses the async event boundary
 type Event struct {
 	ID                string
 	Type              Type
@@ -44,8 +43,7 @@ type Event struct {
 	Metadata          map[string]string
 }
 
-// WithOccurredAt returns a copy of the event with the timestamp populated.
-// If the event already has a timestamp, it is preserved.
+// WithOccurredAt (Method): returns a copy of the event with the timestamp populated if absent
 func (e Event) WithOccurredAt(now time.Time) Event {
 	if e.OccurredAt.IsZero() {
 		e.OccurredAt = now

--- a/11-flagship/01-opslane/internal/handlers/handlers.go
+++ b/11-flagship/01-opslane/internal/handlers/handlers.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/auth"
+	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/db"
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/logging"
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/metrics"
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/middleware"
@@ -25,6 +26,11 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/ratelimit"
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
+
+// Compile-time assertion that *db.Store satisfies the Store interface.
+// If db.Store adds or removes a method, this line will fail to compile,
+// preventing silent interface drift between the handler layer and the repository.
+var _ Store = (*db.Store)(nil)
 
 const healthDatabaseTimeout = 2 * time.Second
 const apiRateLimitWindow = time.Minute
@@ -135,6 +141,8 @@ func (app *Application) Routes() http.Handler {
 	return handler
 }
 
+// handleIndex (Method): serves the root endpoint with a simple service identity
+// response used for connectivity verification.
 func (app *Application) handleIndex(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{
 		"service": app.ServiceName,
@@ -143,6 +151,8 @@ func (app *Application) handleIndex(w http.ResponseWriter, _ *http.Request) {
 	})
 }
 
+// handleHealth (Method): combines database ping and drain state into a composite
+// health check response for orchestration probes (k8s readiness/liveness).
 func (app *Application) handleHealth(w http.ResponseWriter, r *http.Request) {
 	statusCode := http.StatusOK
 	databaseStatus := "ok"
@@ -170,6 +180,8 @@ func (app *Application) handleHealth(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleMe (Method): returns the authenticated user's identity information
+// extracted from the JWT token in the request context.
 func (app *Application) handleMe(w http.ResponseWriter, r *http.Request) {
 	identity, err := auth.RequireIdentity(r.Context())
 	if err != nil {
@@ -186,6 +198,8 @@ func (app *Application) handleMe(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleLiveness (Method): returns a minimal alive response for liveness probes
+// without checking dependencies like the database.
 func (app *Application) handleLiveness(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{
 		"service": app.ServiceName,
@@ -194,6 +208,8 @@ func (app *Application) handleLiveness(w http.ResponseWriter, _ *http.Request) {
 	})
 }
 
+// writeJSON (Function): serializes the payload as JSON and writes it with the
+// given HTTP status code, setting the Content-Type header appropriately.
 func writeJSON(w http.ResponseWriter, status int, payload any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/11-flagship/01-opslane/internal/logging/context.go
+++ b/11-flagship/01-opslane/internal/logging/context.go
@@ -13,34 +13,28 @@ import (
 
 // correlationIDKey is the context key for the request correlation ID.
 // Using an unexported struct type prevents collisions with other packages.
+// correlationIDKey (Struct): unexported context key type for the request correlation ID
 type correlationIDKey struct{}
 
-// WithCorrelationID stores a correlation ID on the context. Every log
-// line produced from this context can include the ID, making it possible
-// to trace one request through HTTP handlers, services, and workers.
+// WithCorrelationID (Function): stores a correlation ID on the context for request tracing through logs
 func WithCorrelationID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, correlationIDKey{}, id)
 }
 
-// CorrelationID retrieves the correlation ID from the context.
-// Returns an empty string if no ID was set.
+// CorrelationID (Function): retrieves the correlation ID from the context; returns empty string if absent
 func CorrelationID(ctx context.Context) string {
 	id, _ := ctx.Value(correlationIDKey{}).(string)
 	return id
 }
 
-// GenerateCorrelationID produces a 16-byte hex-encoded random string.
-// Using crypto/rand avoids adding an external UUID dependency while still
-// providing collision-resistant identifiers.
+// GenerateCorrelationID (Function): produces a 16-byte hex-encoded random correlation ID using crypto/rand
 func GenerateCorrelationID() string {
 	b := make([]byte, 16)
 	_, _ = rand.Read(b)
 	return hex.EncodeToString(b)
 }
 
-// CorrelationIDFromRequest extracts the X-Correlation-ID header from
-// an HTTP request. If the header is absent or empty, it generates a
-// new correlation ID.
+// CorrelationIDFromRequest (Function): extracts or generates a correlation ID from an HTTP request header
 func CorrelationIDFromRequest(r *http.Request) string {
 	if id := r.Header.Get("X-Correlation-ID"); id != "" {
 		return id
@@ -48,10 +42,7 @@ func CorrelationIDFromRequest(r *http.Request) string {
 	return GenerateCorrelationID()
 }
 
-// ContextAttrs extracts structured log attributes from a context.
-// It reads correlation_id from the logging context. Auth identity
-// (tenant_id, user_id) should be added by the caller using
-// auth.IdentityFromContext, keeping this package free of auth imports.
+// ContextAttrs (Function): extracts structured slog attributes (correlation_id) from a context
 func ContextAttrs(ctx context.Context) []slog.Attr {
 	var attrs []slog.Attr
 	if id := CorrelationID(ctx); id != "" {

--- a/11-flagship/01-opslane/internal/logging/logger.go
+++ b/11-flagship/01-opslane/internal/logging/logger.go
@@ -9,14 +9,7 @@ import (
 	"log/slog"
 )
 
-// New creates a structured logger. The format parameter selects the
-// slog handler: "json" produces machine-readable output suitable for
-// production log aggregation; "text" produces human-friendly output
-// for local development.
-//
-// This factory centralises logger construction so the application has
-// one place to control output format, level filtering, and handler
-// options.
+// New (Function): creates a structured slog logger with json or text format
 func New(w io.Writer, level slog.Level, format string) *slog.Logger {
 	opts := &slog.HandlerOptions{Level: level}
 
@@ -31,12 +24,7 @@ func New(w io.Writer, level slog.Level, format string) *slog.Logger {
 	return slog.New(handler)
 }
 
-// WithContext returns a new logger enriched with fields from the context.
-// It reads the correlation ID from the logging context and, if present,
-// any auth identity that the caller has attached.
-//
-// This bridges context-based request identity into structured log output
-// without requiring every call site to extract the fields manually.
+// WithContext (Function): returns a logger enriched with correlation and auth fields from context
 func WithContext(ctx context.Context, logger *slog.Logger) *slog.Logger {
 	attrs := ContextAttrs(ctx)
 	if len(attrs) == 0 {
@@ -50,22 +38,22 @@ func WithContext(ctx context.Context, logger *slog.Logger) *slog.Logger {
 	return logger.With(args...)
 }
 
-// Info logs an info message enriched with context fields.
+// Info (Function): logs an info message enriched with context fields
 func Info(ctx context.Context, logger *slog.Logger, msg string, args ...any) {
 	WithContext(ctx, logger).InfoContext(ctx, msg, args...)
 }
 
-// Error logs an error message enriched with context fields.
+// Error (Function): logs an error message enriched with context fields
 func Error(ctx context.Context, logger *slog.Logger, msg string, args ...any) {
 	WithContext(ctx, logger).ErrorContext(ctx, msg, args...)
 }
 
-// Debug logs a debug message enriched with context fields.
+// Debug (Function): logs a debug message enriched with context fields
 func Debug(ctx context.Context, logger *slog.Logger, msg string, args ...any) {
 	WithContext(ctx, logger).DebugContext(ctx, msg, args...)
 }
 
-// Warn logs a warning message enriched with context fields.
+// Warn (Function): logs a warning message enriched with context fields
 func Warn(ctx context.Context, logger *slog.Logger, msg string, args ...any) {
 	WithContext(ctx, logger).WarnContext(ctx, msg, args...)
 }

--- a/11-flagship/01-opslane/internal/logging/middleware.go
+++ b/11-flagship/01-opslane/internal/logging/middleware.go
@@ -11,17 +11,14 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/otel"
 )
 
-// statusRecorder wraps http.ResponseWriter to capture the status code
-// written by downstream handlers. This is necessary because the
-// standard ResponseWriter does not expose the status after WriteHeader
-// is called.
+// statusRecorder (Struct): wraps http.ResponseWriter to capture the status code for logging
 type statusRecorder struct {
 	http.ResponseWriter
 	status      int
 	wroteHeader bool
 }
 
-// WriteHeader captures the HTTP status code before delegating to the underlying response writer.
+// WriteHeader (Method): captures the HTTP status code before delegating to the underlying writer
 func (sr *statusRecorder) WriteHeader(code int) {
 	if !sr.wroteHeader {
 		sr.status = code
@@ -30,7 +27,7 @@ func (sr *statusRecorder) WriteHeader(code int) {
 	sr.ResponseWriter.WriteHeader(code)
 }
 
-// Write captures the default 200 OK status if WriteHeader wasn't explicitly called first.
+// Write (Method): captures the default 200 OK status if WriteHeader wasn't explicitly called
 func (sr *statusRecorder) Write(b []byte) (int, error) {
 	if !sr.wroteHeader {
 		sr.status = http.StatusOK
@@ -39,17 +36,7 @@ func (sr *statusRecorder) Write(b []byte) (int, error) {
 	return sr.ResponseWriter.Write(b)
 }
 
-// RequestLogger returns HTTP middleware that:
-//
-//  1. Extracts or generates a correlation ID from the X-Correlation-ID header.
-//  2. Injects the correlation ID into the request context.
-//  3. Sets the correlation ID on the response header so clients can reference it.
-//  4. Wraps the ResponseWriter to capture the status code.
-//  5. Logs a structured request-completion line with method, path, status,
-//     latency, and correlation_id.
-//
-// This middleware replaces ad-hoc request logging with a single structured
-// entry that contains enough context to trace a request through the system.
+// RequestLogger (Function): returns HTTP middleware that logs structured request completions with correlation ID
 func RequestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/11-flagship/01-opslane/internal/metrics/metrics.go
+++ b/11-flagship/01-opslane/internal/metrics/metrics.go
@@ -13,28 +13,21 @@ import (
 	"sync/atomic"
 )
 
-// Counter is a thread-safe monotonically increasing counter.
-// It uses sync/atomic for lock-free concurrent access.
+// Counter (Struct): thread-safe monotonically increasing counter using sync/atomic
 type Counter struct {
 	value atomic.Int64
 }
 
-// Inc increments the counter by one.
+// Inc (Method): increments the counter by one
 func (c *Counter) Inc() { c.value.Add(1) }
 
-// Add increments the counter by n.
+// Add (Method): increments the counter by n
 func (c *Counter) Add(n int64) { c.value.Add(n) }
 
-// Value returns the current counter value.
+// Value (Method): returns the current counter value
 func (c *Counter) Value() int64 { return c.value.Load() }
 
-// Histogram records observations into fixed buckets for latency
-// distribution analysis. Each bucket counts how many observations
-// were less than or equal to its upper bound.
-//
-// This is a simplified teaching implementation. Production systems
-// use more efficient representations (e.g., HDR histograms or
-// Prometheus-style cumulative buckets).
+// Histogram (Struct): records observations into fixed buckets for latency distribution analysis
 type Histogram struct {
 	mu      sync.Mutex
 	bounds  []float64 // sorted upper bounds
@@ -43,8 +36,7 @@ type Histogram struct {
 	sum     float64
 }
 
-// NewHistogram creates a histogram with the given bucket boundaries.
-// Boundaries are sorted automatically.
+// NewHistogram (Constructor): creates a histogram with automatically sorted bucket boundaries
 func NewHistogram(bounds []float64) *Histogram {
 	sorted := make([]float64, len(bounds))
 	copy(sorted, bounds)
@@ -56,8 +48,7 @@ func NewHistogram(bounds []float64) *Histogram {
 	}
 }
 
-// Observe records a single value. The value is placed in the first
-// bucket whose upper bound is greater than or equal to the value.
+// Observe (Method): records a single value into the appropriate bucket
 func (h *Histogram) Observe(v float64) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -75,7 +66,7 @@ func (h *Histogram) Observe(v float64) {
 	h.buckets[len(h.bounds)]++
 }
 
-// HistogramSnapshot holds a point-in-time copy of a histogram.
+// HistogramSnapshot (Struct): point-in-time copy of a histogram for serialization
 type HistogramSnapshot struct {
 	Bounds  []float64 `json:"bounds"`
 	Buckets []int64   `json:"buckets"`
@@ -83,7 +74,7 @@ type HistogramSnapshot struct {
 	Sum     float64   `json:"sum"`
 }
 
-// Snapshot returns a point-in-time copy of the histogram data.
+// Snapshot (Method): returns a point-in-time copy of the histogram data
 func (h *Histogram) Snapshot() HistogramSnapshot {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -102,15 +93,14 @@ func (h *Histogram) Snapshot() HistogramSnapshot {
 	}
 }
 
-// Registry holds named counters and histograms. It provides a single
-// collection point for all application metrics.
+// Registry (Struct): holds named counters and histograms as a single metrics collection point
 type Registry struct {
 	mu         sync.RWMutex
 	counters   map[string]*Counter
 	histograms map[string]*Histogram
 }
 
-// NewRegistry creates an empty metric registry.
+// NewRegistry (Constructor): creates an empty metric registry
 func NewRegistry() *Registry {
 	return &Registry{
 		counters:   make(map[string]*Counter),
@@ -118,7 +108,7 @@ func NewRegistry() *Registry {
 	}
 }
 
-// Counter returns the named counter, creating it if necessary.
+// Counter (Method): returns the named counter, creating it if necessary (thread-safe)
 func (r *Registry) Counter(name string) *Counter {
 	r.mu.RLock()
 	if c, ok := r.counters[name]; ok {
@@ -140,9 +130,7 @@ func (r *Registry) Counter(name string) *Counter {
 	return c
 }
 
-// Histogram returns the named histogram, creating it with the given
-// bounds if necessary. If the histogram already exists, bounds are
-// ignored.
+// Histogram (Method): returns the named histogram, creating it with the given bounds if necessary
 func (r *Registry) Histogram(name string, bounds []float64) *Histogram {
 	r.mu.RLock()
 	if h, ok := r.histograms[name]; ok {
@@ -163,7 +151,7 @@ func (r *Registry) Histogram(name string, bounds []float64) *Histogram {
 	return h
 }
 
-// Snapshot returns all metrics as a serializable map.
+// Snapshot (Method): returns all metrics as a serializable map
 func (r *Registry) Snapshot() map[string]any {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -180,13 +168,12 @@ func (r *Registry) Snapshot() map[string]any {
 	return result
 }
 
-// DefaultHTTPBuckets are latency bucket boundaries in seconds,
-// suitable for HTTP request duration tracking.
+// DefaultHTTPBuckets (Slice): latency bucket boundaries in seconds for HTTP request duration tracking
 var DefaultHTTPBuckets = []float64{
 	0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
 }
 
-// AppMetrics holds pre-registered application-level metrics.
+// AppMetrics (Struct): holds pre-registered application-level metrics for HTTP, cache, and workers
 type AppMetrics struct {
 	Registry *Registry
 
@@ -206,8 +193,7 @@ type AppMetrics struct {
 	WorkerJobsFailed    *Counter
 }
 
-// NewAppMetrics creates the application metrics with pre-registered
-// counters and histograms.
+// NewAppMetrics (Constructor): creates the application metrics with pre-registered counters and histograms
 func NewAppMetrics() *AppMetrics {
 	r := NewRegistry()
 
@@ -225,7 +211,7 @@ func NewAppMetrics() *AppMetrics {
 	}
 }
 
-// ClassifyStatus increments the appropriate HTTP status class counter.
+// ClassifyStatus (Method): increments the appropriate HTTP status class counter (2xx, 4xx, 5xx)
 func (m *AppMetrics) ClassifyStatus(status int) {
 	switch {
 	case status >= 200 && status < 300:
@@ -237,8 +223,7 @@ func (m *AppMetrics) ClassifyStatus(status int) {
 	}
 }
 
-// RoundToMs rounds a float64 seconds value to millisecond precision.
-// Useful for human-readable duration display.
+// RoundToMs (Function): rounds a float64 seconds value to millisecond precision
 func RoundToMs(seconds float64) float64 {
 	return math.Round(seconds*1000) / 1000
 }

--- a/11-flagship/01-opslane/internal/metrics/middleware.go
+++ b/11-flagship/01-opslane/internal/metrics/middleware.go
@@ -8,14 +8,14 @@ import (
 	"time"
 )
 
-// statusRecorder wraps http.ResponseWriter to capture the status code.
+// statusRecorder (Struct): wraps http.ResponseWriter to capture the status code for metrics
 type statusRecorder struct {
 	http.ResponseWriter
 	status      int
 	wroteHeader bool
 }
 
-// WriteHeader intercepts the status code for metric recording before passing it to the client.
+// WriteHeader (Method): intercepts the status code for metric recording before passing to the client
 func (sr *statusRecorder) WriteHeader(code int) {
 	if !sr.wroteHeader {
 		sr.status = code
@@ -24,7 +24,7 @@ func (sr *statusRecorder) WriteHeader(code int) {
 	sr.ResponseWriter.WriteHeader(code)
 }
 
-// Write assumes a 200 OK status for metrics if WriteHeader was not explicitly called.
+// Write (Method): assumes default 200 OK status for metrics if WriteHeader was not explicitly called
 func (sr *statusRecorder) Write(b []byte) (int, error) {
 	if !sr.wroteHeader {
 		sr.status = http.StatusOK
@@ -33,14 +33,7 @@ func (sr *statusRecorder) Write(b []byte) (int, error) {
 	return sr.ResponseWriter.Write(b)
 }
 
-// HTTPMetrics returns middleware that records per-request metrics:
-//
-//   - http_requests_total: incremented for every request
-//   - http_request_duration_seconds: latency histogram
-//   - http_responses_2xx / 4xx / 5xx: status class counters
-//
-// This middleware should be placed early in the middleware chain so
-// it wraps the full request lifecycle.
+// HTTPMetrics (Function): returns HTTP middleware recording request count, latency, and status class metrics
 func HTTPMetrics(m *AppMetrics) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/11-flagship/01-opslane/internal/metrics/prometheus.go
+++ b/11-flagship/01-opslane/internal/metrics/prometheus.go
@@ -9,9 +9,7 @@ import (
 	"net/http"
 )
 
-// PrometheusHandler returns an HTTP handler that exposes metrics
-// in Prometheus text format. This endpoint should be mounted at
-// /metrics for Prometheus scraper compatibility.
+// PrometheusHandler (Function): returns an HTTP handler exposing metrics in Prometheus text format
 func PrometheusHandler(m *AppMetrics) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
@@ -47,10 +45,12 @@ func PrometheusHandler(m *AppMetrics) http.HandlerFunc {
 	}
 }
 
+// prometheusWriter (Struct): wraps io.Writer for Prometheus text format output
 type prometheusWriter struct {
 	io.Writer
 }
 
+// printHistogramProm (Function): writes a Prometheus histogram text representation to writer
 func printHistogramProm(w io.Writer, name string, h *Histogram) {
 	snap := h.Snapshot()
 

--- a/11-flagship/01-opslane/internal/middleware/cache.go
+++ b/11-flagship/01-opslane/internal/middleware/cache.go
@@ -9,13 +9,7 @@ import (
 	"time"
 )
 
-// CacheControl sets Cache-Control headers on responses. Use this for
-// public endpoints like health or static assets. Protected API
-// endpoints should use "no-store" to prevent proxies and browsers from
-// caching authenticated data.
-//
-// maxAge controls how long clients and intermediary proxies are allowed
-// to serve the cached response without revalidating with the origin.
+// CacheControl (Function): middleware setting Cache-Control with public max-age for cacheable endpoints
 func CacheControl(maxAge time.Duration) func(http.Handler) http.Handler {
 	seconds := int(maxAge.Seconds())
 	publicValue := fmt.Sprintf("public, max-age=%d", seconds)
@@ -32,9 +26,7 @@ func CacheControl(maxAge time.Duration) func(http.Handler) http.Handler {
 	}
 }
 
-// NoCache sets Cache-Control: no-store on responses. This is the right
-// default for authenticated API endpoints where stale data could leak
-// across tenants or users.
+// NoCache (Function): middleware setting Cache-Control: no-store for authenticated API endpoints
 func NoCache(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")

--- a/11-flagship/01-opslane/internal/middleware/middleware.go
+++ b/11-flagship/01-opslane/internal/middleware/middleware.go
@@ -31,11 +31,7 @@ import (
 //   Every request *must* pass through these layers first before hitting `ServeMux`.
 // ============================================================================
 
-// RecoverPanic acts as the outermost onion shell.
-// By wrapping `next.ServeHTTP` inside a function containing a `defer recover()`,
-// we guarantee that if ANY downstream handler throws a fatal panic, this
-// middleware will instantly catch it, write a 500 status code, and prevent
-// the entire server process from crashing!
+// RecoverPanic (Function): outermost middleware that catches panics, logs stack trace, and returns 500
 func RecoverPanic(logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -55,8 +51,7 @@ func RecoverPanic(logger *slog.Logger) func(http.Handler) http.Handler {
 	}
 }
 
-// LogRequest wraps the HTTP handler to log the HTTP method, path, and total request duration.
-// It acts as a lightweight access log for the server.
+// LogRequest (Function): lightweight access log middleware logging method, path, and latency
 func LogRequest(logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -71,7 +66,7 @@ func LogRequest(logger *slog.Logger) func(http.Handler) http.Handler {
 	}
 }
 
-// CORS allows browser-based clients to call the API during local development.
+// CORS (Function): middleware allowing browser-based API calls during local development
 func CORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -87,12 +82,13 @@ func CORS(next http.Handler) http.Handler {
 	})
 }
 
+// clientWindow (Struct): tracks request count and reset time for a single client's rate limit window
 type clientWindow struct {
 	count   int
 	resetAt time.Time
 }
 
-// RateLimit bounds how many requests one client IP can make inside a fixed window.
+// RateLimit (Function): per-IP rate limiting middleware with fixed window and proxy-aware client address
 func RateLimit(maxRequests int, window time.Duration, trustedProxyCIDRs []netip.Prefix) func(http.Handler) http.Handler {
 	var mu sync.Mutex
 	clients := make(map[string]clientWindow)
@@ -135,6 +131,7 @@ func RateLimit(maxRequests int, window time.Duration, trustedProxyCIDRs []netip.
 	}
 }
 
+// pruneExpiredClientWindows (Function): removes rate limit entries whose window has expired
 func pruneExpiredClientWindows(clients map[string]clientWindow, now time.Time) {
 	for clientIP, state := range clients {
 		if !now.Before(state.resetAt) {
@@ -143,7 +140,7 @@ func pruneExpiredClientWindows(clients map[string]clientWindow, now time.Time) {
 	}
 }
 
-// SecureHeaders sets mandatory security directives for browsers.
+// SecureHeaders (Function): middleware setting mandatory browser security headers (X-Frame-Options, X-Content-Type-Options)
 func SecureHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Prevent Clickjacking (disallow being loaded in an iframe)
@@ -174,6 +171,7 @@ func ClientAddress(r *http.Request, trustedProxyCIDRs []netip.Prefix) string {
 	return r.RemoteAddr
 }
 
+// remotePeerIP (Function): extracts the IP address from a remote address string
 func remotePeerIP(remoteAddr string) netip.Addr {
 	host, _, err := net.SplitHostPort(remoteAddr)
 	if err == nil {
@@ -190,6 +188,7 @@ func remotePeerIP(remoteAddr string) netip.Addr {
 	return ip.Unmap()
 }
 
+// forwardedClientIP (Function): extracts the client IP from X-Forwarded-For or X-Real-IP headers
 func forwardedClientIP(r *http.Request) (netip.Addr, bool) {
 	if forwardedFor := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); forwardedFor != "" {
 		firstHop := strings.TrimSpace(strings.Split(forwardedFor, ",")[0])
@@ -207,6 +206,7 @@ func forwardedClientIP(r *http.Request) (netip.Addr, bool) {
 	return netip.Addr{}, false
 }
 
+// isTrustedProxy (Function): checks if an IP address is within any of the trusted proxy CIDR ranges
 func isTrustedProxy(ip netip.Addr, trustedProxyCIDRs []netip.Prefix) bool {
 	for _, prefix := range trustedProxyCIDRs {
 		if prefix.Contains(ip) {

--- a/11-flagship/01-opslane/internal/models/models_test.go
+++ b/11-flagship/01-opslane/internal/models/models_test.go
@@ -1,0 +1,231 @@
+package models
+
+import (
+	"testing"
+)
+
+func TestUserRoleValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		role UserRole
+		want string
+	}{
+		{role: UserRoleAdmin, want: "admin"},
+		{role: UserRoleMember, want: "member"},
+		{role: UserRoleBilling, want: "billing"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.role) != tt.want {
+			t.Fatalf("UserRole(%q) = %q, want %q", tt.role, string(tt.role), tt.want)
+		}
+	}
+}
+
+func TestUserRoleUniqueness(t *testing.T) {
+	t.Parallel()
+
+	roles := map[UserRole]bool{
+		UserRoleAdmin:   true,
+		UserRoleMember:  true,
+		UserRoleBilling: true,
+	}
+
+	if len(roles) != 3 {
+		t.Fatalf("expected 3 unique user roles, got %d", len(roles))
+	}
+}
+
+func TestUserStructFields(t *testing.T) {
+	t.Parallel()
+
+	u := User{
+		ID:       1,
+		TenantID: 10,
+		Email:    "test@example.com",
+		Role:     UserRoleAdmin,
+	}
+
+	if u.ID != 1 {
+		t.Fatalf("User.ID = %d, want 1", u.ID)
+	}
+	if u.TenantID != 10 {
+		t.Fatalf("User.TenantID = %d, want 10", u.TenantID)
+	}
+	if u.Email != "test@example.com" {
+		t.Fatalf("User.Email = %q", u.Email)
+	}
+	if u.Role != UserRoleAdmin {
+		t.Fatalf("User.Role = %q, want admin", u.Role)
+	}
+}
+
+func TestOrderStatusValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status OrderStatus
+		want   string
+	}{
+		{status: OrderStatusPending, want: "pending"},
+		{status: OrderStatusProcessing, want: "processing"},
+		{status: OrderStatusPaid, want: "paid"},
+		{status: OrderStatusFailed, want: "failed"},
+		{status: OrderStatusCancelled, want: "cancelled"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.status) != tt.want {
+			t.Fatalf("OrderStatus(%q) = %q, want %q", tt.status, string(tt.status), tt.want)
+		}
+	}
+}
+
+func TestOrderStatusUniqueness(t *testing.T) {
+	t.Parallel()
+
+	statuses := map[OrderStatus]bool{
+		OrderStatusPending:    true,
+		OrderStatusProcessing: true,
+		OrderStatusPaid:       true,
+		OrderStatusFailed:     true,
+		OrderStatusCancelled:  true,
+	}
+
+	if len(statuses) != 5 {
+		t.Fatalf("expected 5 unique order statuses, got %d", len(statuses))
+	}
+}
+
+func TestPaymentStatusValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status PaymentStatus
+		want   string
+	}{
+		{status: PaymentStatusPending, want: "pending"},
+		{status: PaymentStatusAuthorized, want: "authorized"},
+		{status: PaymentStatusSettled, want: "settled"},
+		{status: PaymentStatusFailed, want: "failed"},
+		{status: PaymentStatusRefunded, want: "refunded"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.status) != tt.want {
+			t.Fatalf("PaymentStatus(%q) = %q, want %q", tt.status, string(tt.status), tt.want)
+		}
+	}
+}
+
+func TestPaymentStatusUniqueness(t *testing.T) {
+	t.Parallel()
+
+	statuses := map[PaymentStatus]bool{
+		PaymentStatusPending:    true,
+		PaymentStatusAuthorized: true,
+		PaymentStatusSettled:    true,
+		PaymentStatusFailed:     true,
+		PaymentStatusRefunded:   true,
+	}
+
+	if len(statuses) != 5 {
+		t.Fatalf("expected 5 unique payment statuses, got %d", len(statuses))
+	}
+}
+
+func TestTenantStructFields(t *testing.T) {
+	t.Parallel()
+
+	t1 := Tenant{
+		ID:   1,
+		Name: "Test Corp",
+		Slug: "test-corp",
+	}
+
+	if t1.ID != 1 {
+		t.Fatalf("Tenant.ID = %d, want 1", t1.ID)
+	}
+	if t1.Name != "Test Corp" {
+		t.Fatalf("Tenant.Name = %q", t1.Name)
+	}
+	if t1.Slug != "test-corp" {
+		t.Fatalf("Tenant.Slug = %q", t1.Slug)
+	}
+}
+
+func TestOrderStructFields(t *testing.T) {
+	t.Parallel()
+
+	o := Order{
+		ID:             1,
+		TenantID:       10,
+		UserID:         100,
+		Status:         OrderStatusPending,
+		TotalCents:     5000,
+		Currency:       "USD",
+		IdempotencyKey: "idem-001",
+	}
+
+	if o.ID != 1 {
+		t.Fatalf("Order.ID = %d, want 1", o.ID)
+	}
+	if o.TenantID != 10 {
+		t.Fatalf("Order.TenantID = %d, want 10", o.TenantID)
+	}
+	if o.Status != OrderStatusPending {
+		t.Fatalf("Order.Status = %q, want pending", o.Status)
+	}
+	if o.TotalCents != 5000 {
+		t.Fatalf("Order.TotalCents = %d, want 5000", o.TotalCents)
+	}
+	if o.IdempotencyKey != "idem-001" {
+		t.Fatalf("Order.IdempotencyKey = %q", o.IdempotencyKey)
+	}
+}
+
+func TestPaymentStructFields(t *testing.T) {
+	t.Parallel()
+
+	p := Payment{
+		ID:                1,
+		TenantID:          10,
+		OrderID:           100,
+		Status:            PaymentStatusPending,
+		ProviderReference: "prov-ref-001",
+		AmountCents:       5000,
+	}
+
+	if p.ID != 1 {
+		t.Fatalf("Payment.ID = %d, want 1", p.ID)
+	}
+	if p.TenantID != 10 {
+		t.Fatalf("Payment.TenantID = %d, want 10", p.TenantID)
+	}
+	if p.OrderID != 100 {
+		t.Fatalf("Payment.OrderID = %d, want 100", p.OrderID)
+	}
+	if p.Status != PaymentStatusPending {
+		t.Fatalf("Payment.Status = %q, want pending", p.Status)
+	}
+	if p.ProviderReference != "prov-ref-001" {
+		t.Fatalf("Payment.ProviderReference = %q", p.ProviderReference)
+	}
+	if p.AmountCents != 5000 {
+		t.Fatalf("Payment.AmountCents = %d, want 5000", p.AmountCents)
+	}
+}
+
+func TestTenantSlugUniqueness(t *testing.T) {
+	t.Parallel()
+
+	t1 := Tenant{ID: 1, Slug: "acme"}
+	t2 := Tenant{ID: 2, Slug: "acme"}
+
+	slugs := map[string]bool{}
+	slugs[t1.Slug] = true
+	if slugs[t2.Slug] {
+		t.Log("duplicate slug would violate uniqueness constraint — the DB layer must enforce this")
+	}
+}

--- a/11-flagship/01-opslane/internal/otel/otel.go
+++ b/11-flagship/01-opslane/internal/otel/otel.go
@@ -17,7 +17,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,30 +32,6 @@ type Config struct {
 	SampleRate  float64
 	ServiceName string
 	Environment string
-}
-
-func (c *Config) FromEnv() {
-	c.Endpoint = os.Getenv("OPSLANE_OTEL_ENDPOINT")
-	c.Insecure = os.Getenv("OPSLANE_OTEL_INSECURE") == "true"
-	c.Enabled = c.Endpoint != ""
-	c.ServiceName = os.Getenv("OPSLANE_SERVICE_NAME")
-	c.Environment = os.Getenv("OPSLANE_ENV")
-
-	timeout := os.Getenv("OPSLANE_OTEL_TIMEOUT")
-	if timeout != "" {
-		if d, err := time.ParseDuration(timeout); err == nil {
-			c.Timeout = d
-		}
-	}
-	if c.Timeout == 0 {
-		c.Timeout = 5 * time.Second
-	}
-	c.SampleRate = 1.0
-	if sampleRate := os.Getenv("OPSLANE_OTEL_SAMPLE_RATE"); sampleRate != "" {
-		if f, err := strconv.ParseFloat(sampleRate, 64); err == nil && f >= 0 && f <= 1 {
-			c.SampleRate = f
-		}
-	}
 }
 
 // Tracer (Struct): provides OpenTelemetry tracing for the Opslane backend.
@@ -83,6 +58,8 @@ type Span struct {
 	StatusMessage string
 }
 
+// New (Constructor): creates a Tracer and starts the background export loop if
+// tracing is enabled. Returns a no-op tracer when cfg.Enabled is false.
 func New(cfg Config, logger *slog.Logger) *Tracer {
 	if !cfg.Enabled {
 		return &Tracer{config: cfg}
@@ -104,6 +81,9 @@ func New(cfg Config, logger *slog.Logger) *Tracer {
 	return t
 }
 
+// exportLoop (Goroutine): drains the span channel on a 5-second tick or 100-span
+// batch boundary, then sends the batch to the OTLP endpoint. Runs in a background
+// goroutine started by New().
 func (t *Tracer) exportLoop() {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
@@ -136,6 +116,9 @@ func (t *Tracer) exportLoop() {
 	}
 }
 
+// StartSpan (Method): creates a new span with the given name and attributes,
+// sampling according to the configured rate. Returns a context containing the
+// span and a finish function that records the end time and enqueues the span.
 func (t *Tracer) StartSpan(ctx context.Context, name string, attrs ...string) (context.Context, func()) {
 	if t.config.Enabled && t.config.SampleRate < 1.0 {
 		if shouldDropSpan(t.config.SampleRate) {
@@ -171,6 +154,8 @@ func (t *Tracer) StartSpan(ctx context.Context, name string, attrs ...string) (c
 	}
 }
 
+// Stop (Method): signals the export loop to flush remaining spans and waits for
+// the background goroutine to finish, then closes the OTLP HTTP client.
 func (t *Tracer) Stop() {
 	if t.client != nil {
 		close(t.stopped)
@@ -179,10 +164,14 @@ func (t *Tracer) Stop() {
 	}
 }
 
+// Enabled (Method): reports whether the tracer was configured with a non-empty
+// endpoint, allowing callers to skip tracing work when disabled.
 func (t *Tracer) Enabled() bool {
 	return t.config.Enabled
 }
 
+// HTTPMiddleware (Function): returns an HTTP middleware that wraps each request
+// in a named span with method and path attributes, enabling per-request tracing.
 func HTTPMiddleware(tracer *Tracer) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -196,8 +185,19 @@ func HTTPMiddleware(tracer *Tracer) func(http.Handler) http.Handler {
 	}
 }
 
-var spanKey = struct{}{}
+// contextKey (Type): uniquely typed key for context.WithValue lookups.
+// Using a named int type guarantees keys never collide across packages or
+// with other values in the same context chain.
+type contextKey int
 
+const (
+	traceIDKey contextKey = iota
+	spanIDKey
+	spanKey
+)
+
+// getOrCreateTraceID (Function): retrieves the trace ID from context, generating a
+// new one if none exists. Each trace represents one end-to-end request flow.
 func getOrCreateTraceID(ctx context.Context) string {
 	if traceID, ok := ctx.Value(traceIDKey).(string); ok && traceID != "" {
 		return traceID
@@ -205,6 +205,8 @@ func getOrCreateTraceID(ctx context.Context) string {
 	return generateTraceID()
 }
 
+// attrsToMap (Function): converts a flat key-value string slice into a string map
+// for efficient attribute storage on spans.
 func attrsToMap(attrs []string) map[string]string {
 	m := make(map[string]string)
 	for i := 0; i < len(attrs)-1; i += 2 {
@@ -213,21 +215,24 @@ func attrsToMap(attrs []string) map[string]string {
 	return m
 }
 
+// generateSpanID (Function): creates a random 8-byte hex span ID for OTLP compatibility.
 func generateSpanID() string {
 	return randomHex(8)
 }
 
+// generateTraceID (Function): creates a random 16-byte hex trace ID for OTLP compatibility.
 func generateTraceID() string {
 	return randomHex(16)
 }
 
-var traceIDKey = struct{}{}
-var spanIDKey = struct{}{}
-
+// WithTraceID (Function): stores the trace ID in context for propagation through
+// / the call chain without explicit parameter passing.
 func WithTraceID(ctx context.Context, traceID string) context.Context {
 	return context.WithValue(ctx, traceIDKey, traceID)
 }
 
+// GetTraceID (Function): extracts the trace ID from context, returning empty string
+// if tracing has not been initialized for this request.
 func GetTraceID(ctx context.Context) string {
 	if traceID, ok := ctx.Value(traceIDKey).(string); ok {
 		return traceID
@@ -235,10 +240,14 @@ func GetTraceID(ctx context.Context) string {
 	return ""
 }
 
+// WithSpanID (Function): stores the span ID in context so child spans can reference
+// their parent without direct parameter plumbing.
 func WithSpanID(ctx context.Context, spanID string) context.Context {
 	return context.WithValue(ctx, spanIDKey, spanID)
 }
 
+// GetSpanID (Function): extracts the current span ID from context, returning empty
+// string if the request has no active span.
 func GetSpanID(ctx context.Context) string {
 	if spanID, ok := ctx.Value(spanIDKey).(string); ok {
 		return spanID
@@ -246,6 +255,8 @@ func GetSpanID(ctx context.Context) string {
 	return ""
 }
 
+// WithTraceParent (Function): parses a W3C Trace-Context header value and stores
+// the extracted trace/span IDs in context for distributed trace propagation.
 func WithTraceParent(ctx context.Context, traceParent string) context.Context {
 	traceID, parentID, ok := ParseTraceParent(traceParent)
 	if !ok {
@@ -255,6 +266,8 @@ func WithTraceParent(ctx context.Context, traceParent string) context.Context {
 	return WithSpanID(ctx, parentID)
 }
 
+// ParseTraceParent (Function): validates and splits a W3C traceparent header into
+// its trace ID, parent span ID, and trace flags components.
 func ParseTraceParent(traceParent string) (traceID, parentID string, ok bool) {
 	parts := strings.Split(strings.TrimSpace(traceParent), "-")
 	if len(parts) != 4 {
@@ -278,6 +291,8 @@ func ParseTraceParent(traceParent string) (traceID, parentID string, ok bool) {
 	return traceID, parentID, true
 }
 
+// isValidHex (Function): checks that every character in the string is a valid
+// hexadecimal digit, used to validate trace and span IDs.
 func isValidHex(s string) bool {
 	for _, r := range s {
 		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
@@ -287,6 +302,8 @@ func isValidHex(s string) bool {
 	return len(s) > 0
 }
 
+// isAllZero (Function): returns true when the string consists entirely of zero
+// characters, used to reject invalid zero-value trace and span IDs.
 func isAllZero(s string) bool {
 	for _, r := range s {
 		if r != '0' {
@@ -296,6 +313,8 @@ func isAllZero(s string) bool {
 	return true
 }
 
+// FormatTraceParent (Function): builds a W3C traceparent header string from the
+// given trace and span IDs for downstream propagation.
 func FormatTraceParent(traceID, spanID string) string {
 	if len(traceID) != 32 || len(spanID) != 16 {
 		return ""
@@ -303,6 +322,8 @@ func FormatTraceParent(traceID, spanID string) string {
 	return fmt.Sprintf("00-%s-%s-01", strings.ToLower(traceID), strings.ToLower(spanID))
 }
 
+// shouldDropSpan (Function): probabilistically decides whether to sample a span
+// based on the configured sample rate, using crypto/rand for unbiased selection.
 func shouldDropSpan(sampleRate float64) bool {
 	if sampleRate <= 0 {
 		return true
@@ -318,6 +339,8 @@ func shouldDropSpan(sampleRate float64) bool {
 	return v > sampleRate
 }
 
+// randomHex (Function): generates n random bytes and returns them as a hex string,
+// falling back to nanosecond timestamps if crypto/rand fails.
 func randomHex(n int) string {
 	buf := make([]byte, n)
 	if _, err := rand.Read(buf); err != nil {
@@ -326,6 +349,8 @@ func randomHex(n int) string {
 	return hex.EncodeToString(buf)
 }
 
+// otlpClient (Struct): manages the HTTP connection and serialization for sending
+// OTLP trace data to an OpenTelemetry-compatible backend.
 type otlpClient struct {
 	endpoint    string
 	insecure    bool
@@ -335,6 +360,8 @@ type otlpClient struct {
 	environment string
 }
 
+// newOTLPClient (Constructor): creates an OTLP HTTP client configured with the
+// given endpoint, security mode, and timeout. Uses HTTPS by default.
 func newOTLPClient(endpoint string, insecure bool, timeout time.Duration, serviceName, environment string) *otlpClient {
 	scheme := "https"
 	if insecure {
@@ -360,6 +387,8 @@ func newOTLPClient(endpoint string, insecure bool, timeout time.Duration, servic
 	}
 }
 
+// Export (Method): serializes a batch of spans into OTLP JSON format and sends
+// them to the configured endpoint via HTTP POST.
 func (c *otlpClient) Export(ctx context.Context, spans []Span) error {
 	if len(spans) == 0 {
 		return nil
@@ -415,6 +444,8 @@ func (c *otlpClient) Export(ctx context.Context, spans []Span) error {
 	return nil
 }
 
+// toOTLPSpans (Function): converts internal Span structs into the OTLP JSON wire
+// format for transmission to the telemetry backend.
 func toOTLPSpans(spans []Span) []map[string]any {
 	out := make([]map[string]any, 0, len(spans))
 	for _, span := range spans {
@@ -444,6 +475,7 @@ func toOTLPSpans(spans []Span) []map[string]any {
 	return out
 }
 
+// Close (Method): closes idle HTTP connections held by the OTLP client's transport.
 func (c *otlpClient) Close() {
 	if c.client != nil {
 		c.client.CloseIdleConnections()

--- a/11-flagship/01-opslane/internal/otel/otel_test.go
+++ b/11-flagship/01-opslane/internal/otel/otel_test.go
@@ -1,0 +1,503 @@
+package otel
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{Enabled: false}
+	tracer := New(cfg, slog.Default())
+
+	if tracer.Enabled() {
+		t.Fatal("expected disabled tracer")
+	}
+}
+
+func TestNewEnabledNoEndpointNoBlock(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Enabled:     true,
+		Timeout:     time.Second,
+		SampleRate:  1.0,
+		ServiceName: "test",
+		Environment: "test",
+	}
+	tracer := New(cfg, slog.Default())
+	defer tracer.Stop()
+
+	if !tracer.Enabled() {
+		t.Fatal("expected enabled tracer")
+	}
+}
+
+func TestSpanLifecycleWithoutExport(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Enabled:     true,
+		Timeout:     time.Second,
+		SampleRate:  1.0,
+		ServiceName: "test",
+		Environment: "test",
+	}
+	tracer := New(cfg, slog.Default())
+
+	ctx, finish := tracer.StartSpan(context.Background(), "test.operation",
+		"key1", "value1",
+		"key2", "value2",
+	)
+	if ctx == nil {
+		t.Fatal("expected non-nil context")
+	}
+
+	traceID := GetTraceID(ctx)
+	if traceID == "" {
+		t.Fatal("expected non-empty trace ID")
+	}
+
+	spanID := GetSpanID(ctx)
+	if spanID == "" {
+		t.Fatal("expected non-empty span ID")
+	}
+
+	finish()
+	tracer.Stop()
+}
+
+func TestTraceIDPropagation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctx = WithTraceID(ctx, "abcdef0123456789abcdef0123456789")
+
+	got := GetTraceID(ctx)
+	if got != "abcdef0123456789abcdef0123456789" {
+		t.Fatalf("trace ID = %q, want %q", got, "abcdef0123456789abcdef0123456789")
+	}
+}
+
+func TestSpanIDPropagation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctx = WithSpanID(ctx, "deadbeefdeadbeef")
+
+	got := GetSpanID(ctx)
+	if got != "deadbeefdeadbeef" {
+		t.Fatalf("span ID = %q, want %q", got, "deadbeefdeadbeef")
+	}
+}
+
+func TestTraceAndSpanIDKeysDoNotCollide(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctx = WithTraceID(ctx, "abcdef0123456789abcdef0123456789")
+	ctx = WithSpanID(ctx, "deadbeefdeadbeef")
+
+	traceID := GetTraceID(ctx)
+	if traceID != "abcdef0123456789abcdef0123456789" {
+		t.Fatalf("trace ID = %q, want abcdef... (keys collided)", traceID)
+	}
+
+	spanID := GetSpanID(ctx)
+	if spanID != "deadbeefdeadbeef" {
+		t.Fatalf("span ID = %q, want deadbeef... (keys collided)", spanID)
+	}
+}
+
+func TestGetTraceIDFromEmptyContext(t *testing.T) {
+	t.Parallel()
+
+	if got := GetTraceID(context.Background()); got != "" {
+		t.Fatalf("expected empty trace ID, got %q", got)
+	}
+}
+
+func TestGetSpanIDFromEmptyContext(t *testing.T) {
+	t.Parallel()
+
+	if got := GetSpanID(context.Background()); got != "" {
+		t.Fatalf("expected empty span ID, got %q", got)
+	}
+}
+
+func TestWithTraceParentValid(t *testing.T) {
+	t.Parallel()
+
+	parent := "00-abcdef0123456789abcdef0123456789-deadbeefdeadbeef-01"
+	ctx := WithTraceParent(context.Background(), parent)
+
+	traceID := GetTraceID(ctx)
+	if traceID != "abcdef0123456789abcdef0123456789" {
+		t.Fatalf("trace ID = %q, want abcdef...", traceID)
+	}
+
+	spanID := GetSpanID(ctx)
+	if spanID != "deadbeefdeadbeef" {
+		t.Fatalf("span ID = %q, want deadbeef...", spanID)
+	}
+}
+
+func TestWithTraceParentInvalid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "empty", input: ""},
+		{name: "wrong version", input: "01-abc-def-01"},
+		{name: "short trace ID", input: "00-abc-def-01"},
+		{name: "short span ID", input: "00-abcdef0123456789abcdef0123456789-abc-01"},
+		{name: "all zero trace", input: "00-00000000000000000000000000000000-deadbeefdeadbeef-01"},
+		{name: "all zero span", input: "00-abcdef0123456789abcdef0123456789-0000000000000000-01"},
+		{name: "non-hex chars", input: "00-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-deadbeefdeadbeef-01"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithTraceParent(context.Background(), tt.input)
+			if traceID := GetTraceID(ctx); traceID != "" {
+				t.Fatalf("expected empty trace ID for invalid input, got %q", traceID)
+			}
+		})
+	}
+}
+
+func TestParseTraceParent(t *testing.T) {
+	t.Parallel()
+
+	traceID, spanID, ok := ParseTraceParent("00-abcdef0123456789abcdef0123456789-deadbeefdeadbeef-01")
+	if !ok {
+		t.Fatal("expected valid parse")
+	}
+	if traceID != "abcdef0123456789abcdef0123456789" {
+		t.Fatalf("trace ID = %q", traceID)
+	}
+	if spanID != "deadbeefdeadbeef" {
+		t.Fatalf("span ID = %q", spanID)
+	}
+}
+
+func TestParseTraceParentInvalid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "empty", input: ""},
+		{name: "too few parts", input: "00-abc-def"},
+		{name: "too many parts", input: "00-abc-def-01-extra"},
+		{name: "non-hex", input: "00-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-yyyyyyyyyyyyyyyy-01"},
+		{name: "all zero trace", input: "00-00000000000000000000000000000000-deadbeefdeadbeef-01"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, ok := ParseTraceParent(tt.input)
+			if ok {
+				t.Fatalf("expected parse failure for %q", tt.name)
+			}
+		})
+	}
+}
+
+func TestFormatTraceParent(t *testing.T) {
+	t.Parallel()
+
+	result := FormatTraceParent("abcdef0123456789abcdef0123456789", "deadbeefdeadbeef")
+	want := "00-abcdef0123456789abcdef0123456789-deadbeefdeadbeef-01"
+	if result != want {
+		t.Fatalf("FormatTraceParent = %q, want %q", result, want)
+	}
+}
+
+func TestFormatTraceParentShortID(t *testing.T) {
+	t.Parallel()
+
+	if result := FormatTraceParent("short", "also-short"); result != "" {
+		t.Fatalf("expected empty result for short IDs, got %q", result)
+	}
+}
+
+func TestIsValidHex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{input: "abcdef0123456789", want: true},
+		{input: "ABCDEF0123456789", want: true},
+		{input: "xyz", want: false},
+		{input: "", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := isValidHex(tt.input); got != tt.want {
+			t.Fatalf("isValidHex(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIsAllZero(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{input: "0000000000000000", want: true},
+		{input: "abcdef0123456789", want: false},
+		{input: "", want: true},
+	}
+
+	for _, tt := range tests {
+		if got := isAllZero(tt.input); got != tt.want {
+			t.Fatalf("isAllZero(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestAttrsToMap(t *testing.T) {
+	t.Parallel()
+
+	result := attrsToMap([]string{"key1", "value1", "key2", "value2"})
+	if len(result) != 2 {
+		t.Fatalf("expected 2 attributes, got %d", len(result))
+	}
+	if result["key1"] != "value1" {
+		t.Fatalf("key1 = %q", result["key1"])
+	}
+	if result["key2"] != "value2" {
+		t.Fatalf("key2 = %q", result["key2"])
+	}
+}
+
+func TestAttrsToMapOddCount(t *testing.T) {
+	t.Parallel()
+
+	result := attrsToMap([]string{"key1", "value1", "key2"})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 attribute for odd input, got %d", len(result))
+	}
+}
+
+func TestRandomHexLength(t *testing.T) {
+	t.Parallel()
+
+	result := randomHex(8)
+	if len(result) != 16 {
+		t.Fatalf("randomHex(8) length = %d, want 16", len(result))
+	}
+}
+
+func TestShouldDropSpan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sampleRate float64
+		wantDrop   bool
+	}{
+		{name: "zero rate drops all", sampleRate: 0, wantDrop: true},
+		{name: "negative rate drops all", sampleRate: -1, wantDrop: true},
+		{name: "full rate keeps all", sampleRate: 1.0, wantDrop: false},
+		{name: "above one keeps all", sampleRate: 2.0, wantDrop: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldDropSpan(tt.sampleRate); got != tt.wantDrop {
+				t.Fatalf("shouldDropSpan(%f) = %v, want %v", tt.sampleRate, got, tt.wantDrop)
+			}
+		})
+	}
+}
+
+func TestGenerateSpanID(t *testing.T) {
+	t.Parallel()
+
+	id := generateSpanID()
+	if len(id) != 16 {
+		t.Fatalf("span ID length = %d, want 16", len(id))
+	}
+	if !isValidHex(id) {
+		t.Fatalf("span ID contains non-hex characters: %q", id)
+	}
+}
+
+func TestGenerateTraceID(t *testing.T) {
+	t.Parallel()
+
+	id := generateTraceID()
+	if len(id) != 32 {
+		t.Fatalf("trace ID length = %d, want 32", len(id))
+	}
+	if !isValidHex(id) {
+		t.Fatalf("trace ID contains non-hex characters: %q", id)
+	}
+}
+
+func TestOTLPSpanSerialization(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	spans := []Span{
+		{
+			TraceID:       "abcdef0123456789abcdef0123456789",
+			SpanID:        "deadbeefdeadbeef",
+			ParentID:      "",
+			Name:          "test.op",
+			StartTime:     now,
+			EndTime:       now.Add(100 * time.Millisecond),
+			Attributes:    map[string]string{"key": "value"},
+			Status:        "ok",
+			StatusMessage: "",
+		},
+		{
+			TraceID:   "abcdef0123456789abcdef0123456789",
+			SpanID:    "cafebabecafebabe",
+			ParentID:  "deadbeefdeadbeef",
+			Name:      "",
+			StartTime: now,
+			EndTime:   now.Add(50 * time.Millisecond),
+		},
+	}
+
+	result := toOTLPSpans(spans)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 OTLP spans, got %d", len(result))
+	}
+
+	if result[0]["name"] != "test.op" {
+		t.Fatalf("span[0] name = %q", result[0]["name"])
+	}
+
+	if result[1]["name"] != "unnamed" {
+		t.Fatalf("span[1] name should default to 'unnamed', got %q", result[1]["name"])
+	}
+}
+
+func TestDisabledTracerStartSpanReturnsNoopContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{Enabled: false}
+	tracer := New(cfg, slog.Default())
+
+	ctx, finish := tracer.StartSpan(context.Background(), "noop")
+	if ctx == nil {
+		t.Fatal("expected non-nil context even for disabled tracer")
+	}
+
+	finish()
+}
+
+func TestOTLPClientExportEmptySpans(t *testing.T) {
+	t.Parallel()
+
+	client := newOTLPClient("otlp.example.com:4318", true, time.Second, "test", "test")
+	defer client.Close()
+
+	if err := client.Export(context.Background(), nil); err != nil {
+		t.Fatalf("expected nil for empty export, got %v", err)
+	}
+
+	if err := client.Export(context.Background(), []Span{}); err != nil {
+		t.Fatalf("expected nil for empty export, got %v", err)
+	}
+}
+
+func TestGenerateIDsAreUnique(t *testing.T) {
+	t.Parallel()
+
+	ids := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		id := generateSpanID()
+		if ids[id] {
+			t.Fatal("duplicate span ID generated")
+		}
+		ids[id] = true
+	}
+}
+
+func TestClientCloseIdempotent(t *testing.T) {
+	t.Parallel()
+
+	client := newOTLPClient("otlp.example.com:4318", true, time.Second, "test", "test")
+	client.Close()
+	client.Close()
+}
+
+func TestMultipleGoroutinesUseIndependentContexts(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Enabled:     true,
+		Timeout:     time.Second,
+		SampleRate:  1.0,
+		ServiceName: "test",
+		Environment: "test",
+	}
+	tracer := New(cfg, slog.Default())
+	defer tracer.Stop()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, finish := tracer.StartSpan(context.Background(), "goroutine")
+			if GetTraceID(ctx) == "" {
+				t.Error("expected non-empty trace ID in goroutine")
+			}
+			if GetSpanID(ctx) == "" {
+				t.Error("expected non-empty span ID in goroutine")
+			}
+			finish()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestEnabledTracerStopWithoutExportLoopIsSafe(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Enabled:     true,
+		Timeout:     time.Second,
+		SampleRate:  1.0,
+		ServiceName: "test",
+	}
+	tracer := New(cfg, slog.Default())
+	tracer.Stop()
+}
+
+func TestStartSpanSamplingDropsBelowThreshold(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Enabled:     true,
+		Timeout:     time.Second,
+		SampleRate:  0.0,
+		ServiceName: "test",
+	}
+	tracer := New(cfg, slog.Default())
+	defer tracer.Stop()
+
+	ctx, finish := tracer.StartSpan(context.Background(), "dropped")
+	traceID := GetTraceID(ctx)
+	if traceID != "" {
+		t.Fatalf("expected empty trace ID when sample rate is 0, got %q", traceID)
+	}
+	finish()
+}

--- a/11-flagship/01-opslane/internal/payment/gateway.go
+++ b/11-flagship/01-opslane/internal/payment/gateway.go
@@ -15,13 +15,13 @@ import (
 )
 
 var (
-	// ErrGatewayTimeout is returned when the external payment provider does not respond within the deadline.
+	// ErrGatewayTimeout (Error): returned when the external payment provider does not respond within the deadline
 	ErrGatewayTimeout = errors.New("payment gateway timeout")
-	// ErrGatewayUnavailable is returned when the external provider is experiencing an outage.
+	// ErrGatewayUnavailable (Error): returned when the external provider is experiencing an outage
 	ErrGatewayUnavailable = errors.New("payment gateway unavailable")
 )
 
-// Job is the tenant-scoped payment work item used by services and workers.
+// Job (Struct): tenant-scoped payment work item used by services and workers
 type Job struct {
 	TenantID          int64
 	OrderID           int64
@@ -29,8 +29,7 @@ type Job struct {
 	AmountCents       int64
 }
 
-// GatewayRequest contains the minimal tenant-scoped information required to process a charge
-// against an external provider (e.g., Stripe or Adyen).
+// GatewayRequest (Struct): tenant-scoped information required to process a charge against an external provider
 type GatewayRequest struct {
 	TenantID          int64
 	OrderID           int64
@@ -38,20 +37,18 @@ type GatewayRequest struct {
 	AmountCents       int64
 }
 
-// GatewayResult normalizes the response from an external payment provider into
-// internal Opslane statuses.
+// GatewayResult (Struct): normalizes the response from an external payment provider into internal statuses
 type GatewayResult struct {
 	Status        models.PaymentStatus
 	FailureReason string
 }
 
-// Gateway defines the contract for communicating with external payment processors.
-// In a real application, implementations of this interface would wrap the Stripe or Adyen SDKs.
+// Gateway (Interface): contract for communicating with external payment processors
 type Gateway interface {
 	Charge(ctx context.Context, req GatewayRequest) (GatewayResult, error)
 }
 
-// SimulatedGateway gives the flagship a deterministic gateway boundary before real providers exist.
+// SimulatedGateway (Struct): deterministic gateway boundary for development and testing before real providers exist
 type SimulatedGateway struct {
 	Delay         time.Duration
 	Status        models.PaymentStatus
@@ -59,14 +56,14 @@ type SimulatedGateway struct {
 	Err           error
 }
 
-// NewSimulatedGateway creates a test-friendly Gateway that always succeeds immediately.
+// NewSimulatedGateway (Constructor): creates a test-friendly Gateway that always succeeds immediately
 func NewSimulatedGateway() SimulatedGateway {
 	return SimulatedGateway{
 		Status: models.PaymentStatusSettled,
 	}
 }
 
-// Charge simulates an external network call, applying the configured delay and returning the mock status.
+// Charge (Method): simulates an external network call with configured delay and mock status/error
 func (g SimulatedGateway) Charge(ctx context.Context, _ GatewayRequest) (GatewayResult, error) {
 	if g.Delay > 0 {
 		timer := time.NewTimer(g.Delay)

--- a/11-flagship/01-opslane/internal/payment/worker.go
+++ b/11-flagship/01-opslane/internal/payment/worker.go
@@ -8,17 +8,16 @@ import (
 	"fmt"
 )
 
-// Handler processes one payment job.
+// Handler (Function): processes one payment job; returns error if processing fails
 type Handler func(context.Context, Job) error
 
-// Worker consumes tenant-scoped payment jobs until the queue closes or context stops.
+// Worker (Struct): consumes tenant-scoped payment jobs until the queue closes or context is cancelled
 type Worker struct {
 	handler Handler
 	jobs    <-chan Job
 }
 
-// NewWorker instantiates a consumer that reads payment jobs from a channel
-// and processes them sequentially using the provided handler.
+// NewWorker (Constructor): creates a consumer that reads and processes payment jobs from a channel
 func NewWorker(jobs <-chan Job, handler Handler) Worker {
 	return Worker{
 		jobs:    jobs,
@@ -26,8 +25,7 @@ func NewWorker(jobs <-chan Job, handler Handler) Worker {
 	}
 }
 
-// Run blocks until the context is cancelled or the jobs channel is closed.
-// It executes the handler for each job received.
+// Run (Method): blocks until context cancelled or jobs channel closed, executing handler for each job
 func (w Worker) Run(ctx context.Context) error {
 	if w.handler == nil {
 		return fmt.Errorf("payment worker handler is not configured")

--- a/11-flagship/01-opslane/internal/ratelimit/middleware.go
+++ b/11-flagship/01-opslane/internal/ratelimit/middleware.go
@@ -16,26 +16,31 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/middleware"
 )
 
+// LimiterKey (Function): extracts a rate limit key from an HTTP request
 type LimiterKey func(r *http.Request) string
 
+// ByIP (Function): creates a LimiterKey that extracts the client IP address
 func ByIP(trustedProxyCIDRs []netip.Prefix) LimiterKey {
 	return func(r *http.Request) string {
 		return middleware.ClientAddress(r, trustedProxyCIDRs)
 	}
 }
 
+// ByHeader (Function): creates a LimiterKey that extracts a specific HTTP header value
 func ByHeader(header string) func(r *http.Request) string {
 	return func(r *http.Request) string {
 		return r.Header.Get(header)
 	}
 }
 
+// ByTenantAndUser (Function): creates a LimiterKey combining tenant and user identifiers
 func ByTenantAndUser(tenantID, userID func(*http.Request) string) func(r *http.Request) string {
 	return func(r *http.Request) string {
 		return tenantID(r) + ":" + userID(r)
 	}
 }
 
+// Middleware (Function): HTTP rate limiting middleware with fail-open and rate limit headers
 func Middleware(limiter *Limiter, keyFunc LimiterKey, logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -68,6 +73,7 @@ func Middleware(limiter *Limiter, keyFunc LimiterKey, logger *slog.Logger) func(
 	}
 }
 
+// setRateLimitHeaders (Function): sets X-RateLimit-* and Retry-After response headers
 func setRateLimitHeaders(w http.ResponseWriter, d Decision) {
 	limit := d.Limit
 	if limit <= 0 {
@@ -91,29 +97,35 @@ func setRateLimitHeaders(w http.ResponseWriter, d Decision) {
 	}
 }
 
+// PerIPMiddleware (Function): convenience middleware for per-IP rate limiting
 func PerIPMiddleware(limiter *Limiter, trustedProxyCIDRs []netip.Prefix, logger *slog.Logger) func(http.Handler) http.Handler {
 	return Middleware(limiter, ByIP(trustedProxyCIDRs), logger)
 }
 
+// AuthenticatedMiddleware (Function): convenience middleware for per-tenant-user rate limiting
 func AuthenticatedMiddleware(limiter *Limiter, tenantIDFunc, userIDFunc func(*http.Request) string, logger *slog.Logger) func(http.Handler) http.Handler {
 	return Middleware(limiter, ByTenantAndUser(tenantIDFunc, userIDFunc), logger)
 }
 
+// LimiterPool (Struct): thread-safe registry of named limiters
 type LimiterPool struct {
 	mu       sync.RWMutex
 	limiters map[string]*Limiter
 }
 
+// pool (Struct): package-level default limiter pool
 var pool = &LimiterPool{
 	limiters: make(map[string]*Limiter),
 }
 
+// RegisterLimiter (Function): registers a named limiter in the default pool
 func RegisterLimiter(name string, limiter *Limiter) {
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 	pool.limiters[name] = limiter
 }
 
+// GetLimiter (Function): retrieves a named limiter from the default pool
 func GetLimiter(name string) *Limiter {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()

--- a/11-flagship/01-opslane/internal/ratelimit/ratelimit.go
+++ b/11-flagship/01-opslane/internal/ratelimit/ratelimit.go
@@ -43,11 +43,13 @@ type Decision struct {
 	ResetAt   time.Time
 }
 
+// windowCounter (Struct): tracks request count and window end time for a rate limit key
 type windowCounter struct {
 	count     int64
 	windowEnd time.Time
 }
 
+// New (Constructor): creates a rate limiter with configurable requests per second, burst, and window
 func New(cfg Config) *Limiter {
 	if cfg.RequestsPerSecond == 0 {
 		cfg.RequestsPerSecond = 10
@@ -65,16 +67,19 @@ func New(cfg Config) *Limiter {
 	}
 }
 
+// Allow (Method): checks if a key is allowed, returning a bool decision
 func (l *Limiter) Allow(key string) (bool, error) {
 	d, err := l.AllowWithDecision(context.Background(), key)
 	return d.Allowed, err
 }
 
+// AllowContext (Method): checks if a key is allowed with context support
 func (l *Limiter) AllowContext(ctx context.Context, key string) (bool, error) {
 	d, err := l.AllowWithDecision(ctx, key)
 	return d.Allowed, err
 }
 
+// AllowWithDecision (Method): checks if a key is allowed, returning a full Decision struct
 func (l *Limiter) AllowWithDecision(ctx context.Context, key string) (Decision, error) {
 	if l.cfg.DB == nil {
 		return l.localAllow(key), nil
@@ -82,6 +87,7 @@ func (l *Limiter) AllowWithDecision(ctx context.Context, key string) (Decision, 
 	return l.dbAllow(ctx, key)
 }
 
+// localAllow (Method): in-memory rate limit check with mutex protection
 func (l *Limiter) localAllow(key string) Decision {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -124,6 +130,7 @@ func (l *Limiter) localAllow(key string) Decision {
 	}
 }
 
+// dbAllow (Method): PostgreSQL-backed rate limit check with upsert query
 func (l *Limiter) dbAllow(ctx context.Context, key string) (Decision, error) {
 	now := time.Now()
 	window := now.Truncate(time.Duration(l.cfg.WindowSeconds) * time.Second)
@@ -170,6 +177,7 @@ func (l *Limiter) dbAllow(ctx context.Context, key string) (Decision, error) {
 	}, nil
 }
 
+// Reset (Method): clears rate limit counters for a key in local or DB mode
 func (l *Limiter) Reset(key string) error {
 	if l.cfg.DB == nil {
 		l.mu.Lock()
@@ -182,23 +190,27 @@ func (l *Limiter) Reset(key string) error {
 	return err
 }
 
+// MultiLimiter (Struct): manages multiple named rate limiters for different API routes
 type MultiLimiter struct {
 	limiters map[string]*Limiter
 	mu       sync.Mutex
 }
 
+// NewMultiLimiter (Constructor): creates a named limiter registry
 func NewMultiLimiter() *MultiLimiter {
 	return &MultiLimiter{
 		limiters: make(map[string]*Limiter),
 	}
 }
 
+// Register (Method): adds a named rate limiter to the multi-limiter pool
 func (m *MultiLimiter) Register(name string, cfg Config) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.limiters[name] = New(cfg)
 }
 
+// Allow (Method): checks rate limit for a named limiter; returns true if limiter not found (fail-open)
 func (m *MultiLimiter) Allow(name, key string) (bool, error) {
 	m.mu.Lock()
 	limiter, ok := m.limiters[name]
@@ -211,6 +223,7 @@ func (m *MultiLimiter) Allow(name, key string) (bool, error) {
 	return limiter.Allow(key)
 }
 
+// CreateRateLimitTable (Function): creates the rate_limits table and index in PostgreSQL
 func CreateRateLimitTable(ctx context.Context, db *sql.DB) error {
 	_, err := db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS rate_limits (

--- a/11-flagship/01-opslane/internal/services/inventory.go
+++ b/11-flagship/01-opslane/internal/services/inventory.go
@@ -5,7 +5,7 @@ package services
 
 import "context"
 
-// InventoryReservation describes the tenant-scoped stock hold the order workflow needs.
+// InventoryReservation (Struct): tenant-scoped stock hold description for the order workflow
 type InventoryReservation struct {
 	TenantID       int64
 	UserID         int64
@@ -15,7 +15,7 @@ type InventoryReservation struct {
 	IdempotencyKey string
 }
 
-// InventoryCoordinator is the seam between the order workflow and stock reservation behavior.
+// InventoryCoordinator (Interface): seam between the order workflow and stock reservation behavior
 type InventoryCoordinator interface {
 	Reserve(ctx context.Context, reservation InventoryReservation) error
 	// Release must be safe for cleanup retries on duplicate or idempotent order creation flows.
@@ -24,20 +24,20 @@ type InventoryCoordinator interface {
 	Release(ctx context.Context, reservation InventoryReservation) error
 }
 
-// NoopInventoryCoordinator keeps Module 5 focused on the workflow boundary before real stock logic exists.
+// NoopInventoryCoordinator (Struct): stub inventory coordinator for development before real stock logic exists
 type NoopInventoryCoordinator struct{}
 
-// NewNoopInventoryCoordinator creates an inventory stub that always succeeds.
+// NewNoopInventoryCoordinator (Constructor): creates an inventory stub that always succeeds
 func NewNoopInventoryCoordinator() NoopInventoryCoordinator {
 	return NoopInventoryCoordinator{}
 }
 
-// Reserve simulates successfully acquiring stock for an order.
+// Reserve (Method): no-op that simulates successfully acquiring stock
 func (NoopInventoryCoordinator) Reserve(context.Context, InventoryReservation) error {
 	return nil
 }
 
-// Release simulates successfully dropping a hold on stock after an order fails or cancels.
+// Release (Method): no-op that simulates successfully releasing stock hold
 func (NoopInventoryCoordinator) Release(context.Context, InventoryReservation) error {
 	return nil
 }

--- a/11-flagship/01-opslane/internal/services/order.go
+++ b/11-flagship/01-opslane/internal/services/order.go
@@ -13,7 +13,7 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
-// OrderRepository is the minimum persistence surface the order workflow needs.
+// OrderRepository (Interface): minimum persistence surface for the order workflow
 type OrderRepository interface {
 	CreateOrder(ctx context.Context, order *models.Order) error
 	GetOrderByID(ctx context.Context, tenantID, orderID int64) (models.Order, error)
@@ -21,7 +21,7 @@ type OrderRepository interface {
 	UpdateOrderStatus(ctx context.Context, tenantID, orderID int64, status models.OrderStatus) (models.Order, error)
 }
 
-// CreateOrderInput carries the tenant-scoped values required to begin an order workflow.
+// CreateOrderInput (Struct): tenant-scoped values required to begin an order workflow
 type CreateOrderInput struct {
 	TenantID       int64
 	UserID         int64
@@ -30,27 +30,26 @@ type CreateOrderInput struct {
 	IdempotencyKey string
 }
 
-// CreateOrderResult differentiates a brand-new order from an idempotent replay.
+// CreateOrderResult (Struct): differentiates a brand-new order from an idempotent replay
 type CreateOrderResult struct {
 	Order   models.Order
 	Created bool
 }
 
-// TransitionOrderRequest describes a tenant-scoped order status change.
+// TransitionOrderRequest (Struct): tenant-scoped order status change request
 type TransitionOrderRequest struct {
 	TenantID int64
 	OrderID  int64
 	Status   models.OrderStatus
 }
 
-// OrderService moves order creation and state changes out of handlers and into business workflow code.
+// OrderService (Struct): handles order creation and state change business workflows
 type OrderService struct {
 	orders    OrderRepository
 	inventory InventoryCoordinator
 }
 
-// NewOrderService initializes the core business logic for order management.
-// If no inventory coordinator is provided, it defaults to a no-op implementation.
+// NewOrderService (Constructor): initializes order management business logic with optional inventory coordinator
 func NewOrderService(orders OrderRepository, inventory InventoryCoordinator) *OrderService {
 	if inventory == nil {
 		noop := NewNoopInventoryCoordinator()
@@ -63,9 +62,7 @@ func NewOrderService(orders OrderRepository, inventory InventoryCoordinator) *Or
 	}
 }
 
-// CreateOrder handles the business logic of initiating a new purchase.
-// It reserves inventory synchronously before writing to the database, ensuring
-// that stock cannot be oversold even under high concurrency.
+// CreateOrder (Method): initiates a new purchase with synchronous inventory reservation and idempotency support
 func (s *OrderService) CreateOrder(ctx context.Context, input CreateOrderInput) (CreateOrderResult, error) {
 	if s == nil || s.orders == nil || s.inventory == nil {
 		return CreateOrderResult{}, fmt.Errorf("order service is not configured")
@@ -132,9 +129,7 @@ func (s *OrderService) CreateOrder(ctx context.Context, input CreateOrderInput) 
 	}, nil
 }
 
-// TransitionOrder safely moves an order from one state to another (e.g. Pending -> Paid).
-// It coordinates state-specific side effects, such as releasing inventory holds
-// when an order is cancelled or marked as failed.
+// TransitionOrder (Method): safely moves an order between states with inventory side-effect coordination
 func (s *OrderService) TransitionOrder(ctx context.Context, req TransitionOrderRequest) (models.Order, error) {
 	if s == nil || s.orders == nil || s.inventory == nil {
 		return models.Order{}, fmt.Errorf("order service is not configured")
@@ -205,6 +200,7 @@ func (s *OrderService) TransitionOrder(ctx context.Context, req TransitionOrderR
 	return updated, nil
 }
 
+// inventoryReservationFromOrder (Function): maps an order to an inventory reservation for release
 func inventoryReservationFromOrder(order models.Order) InventoryReservation {
 	return InventoryReservation{
 		TenantID:       order.TenantID,

--- a/11-flagship/01-opslane/internal/services/payment.go
+++ b/11-flagship/01-opslane/internal/services/payment.go
@@ -17,48 +17,47 @@ import (
 )
 
 var (
-	// ErrInvalidPayment is returned when a payment request lacks required data or attempts an illegal state transition.
+	// ErrInvalidPayment (Error): returned when a payment request lacks required data or attempts an illegal state transition
 	ErrInvalidPayment = errors.New("invalid payment")
-	// ErrPaymentNotFound is returned when a specific provider reference cannot be located in the database.
+	// ErrPaymentNotFound (Error): returned when a specific provider reference cannot be located in the database
 	ErrPaymentNotFound = errors.New("payment not found")
-	// ErrOrderNotPayable is returned when attempting to pay for an order that is already paid, cancelled, or in an invalid state.
+	// ErrOrderNotPayable (Error): returned when attempting to pay for an order that is not in a payable state
 	ErrOrderNotPayable = errors.New("order not in a payable state")
 )
 
 const defaultPaymentGatewayTimeout = 2 * time.Second
 const defaultPaymentAttempts = 2
 
-// PaymentRepository is the persistence surface the payment workflow needs.
+// PaymentRepository (Interface): persistence surface for the payment workflow
 type PaymentRepository interface {
 	CreatePayment(ctx context.Context, payment *models.Payment) error
 	GetPaymentByProviderReference(ctx context.Context, tenantID int64, providerReference string) (models.Payment, error)
 	UpdatePaymentStatus(ctx context.Context, tenantID int64, providerReference string, status models.PaymentStatus, failureReason string) (models.Payment, error)
 }
 
-// PaymentOrderReader lets the payment service validate tenant-scoped order facts.
+// PaymentOrderReader (Interface): lets the payment service validate tenant-scoped order facts
 type PaymentOrderReader interface {
 	GetOrderByID(ctx context.Context, tenantID, orderID int64) (models.Order, error)
 }
 
-// PaymentOrderWorkflow is the order state machine seam used by payments.
+// PaymentOrderWorkflow (Interface): order state machine seam used by payments
 type PaymentOrderWorkflow interface {
 	TransitionOrder(ctx context.Context, req TransitionOrderRequest) (models.Order, error)
 }
 
-// PaymentServiceOptions allows configuring retries and timeouts for the payment gateway.
+// PaymentServiceOptions (Struct): configures retries and timeouts for the payment gateway
 type PaymentServiceOptions struct {
 	GatewayTimeout time.Duration
 	MaxAttempts    int
 }
 
-// ProcessPaymentResult differentiates a brand-new payment attempt from an idempotent replay.
+// ProcessPaymentResult (Struct): differentiates a brand-new payment attempt from an idempotent replay
 type ProcessPaymentResult struct {
 	Payment models.Payment
 	Created bool
 }
 
-// ReconcilePaymentInput carries data from external webhooks (e.g., Stripe) to update
-// the status of an asynchronous payment.
+// ReconcilePaymentInput (Struct): carries external webhook data to update asynchronous payment status
 type ReconcilePaymentInput struct {
 	TenantID          int64
 	ProviderReference string
@@ -66,7 +65,7 @@ type ReconcilePaymentInput struct {
 	FailureReason     string
 }
 
-// PaymentService owns duplicate protection, gateway calls, and payment-driven order transitions.
+// PaymentService (Struct): orchestrates duplicate protection, gateway calls, and payment-driven order transitions
 type PaymentService struct {
 	payments      PaymentRepository
 	orders        PaymentOrderReader
@@ -75,8 +74,7 @@ type PaymentService struct {
 	options       PaymentServiceOptions
 }
 
-// NewPaymentService initializes the core business logic for payment processing.
-// It orchestrates the order state machine, database persistence, and external gateway calls.
+// NewPaymentService (Constructor): initializes payment processing business logic with gateway, persistence, and order workflow
 func NewPaymentService(
 	payments PaymentRepository,
 	orders PaymentOrderReader,
@@ -100,9 +98,7 @@ func NewPaymentService(
 	}
 }
 
-// ProcessPayment is the primary entry point for charging a customer.
-// It verifies the order is payable, records a pending payment attempt in the DB,
-// calls the external gateway, and safely handles idempotent retries.
+// ProcessPayment (Method): charges a customer via gateway with idempotency, verification, and retries
 func (s *PaymentService) ProcessPayment(ctx context.Context, job paymentflow.Job) (ProcessPaymentResult, error) {
 	if s == nil || s.payments == nil || s.orders == nil || s.orderWorkflow == nil || s.gateway == nil {
 		return ProcessPaymentResult{}, fmt.Errorf("payment service is not configured")
@@ -173,8 +169,7 @@ func (s *PaymentService) ProcessPayment(ctx context.Context, job paymentflow.Job
 	return s.chargeGateway(ctx, payment, true)
 }
 
-// ReconcilePayment handles asynchronous updates from payment gateways (like Webhooks).
-// It updates the payment status and immediately propagates that status back to the parent order.
+// ReconcilePayment (Method): handles asynchronous gateway webhook updates and propagates to parent order
 func (s *PaymentService) ReconcilePayment(ctx context.Context, input ReconcilePaymentInput) (models.Payment, error) {
 	if s == nil || s.payments == nil || s.orderWorkflow == nil {
 		return models.Payment{}, fmt.Errorf("payment service is not configured")
@@ -214,6 +209,7 @@ func (s *PaymentService) ReconcilePayment(ctx context.Context, input ReconcilePa
 	return updated, nil
 }
 
+// chargeGateway (Method): executes gateway charge with retries and applies result to payment/order
 func (s *PaymentService) chargeGateway(ctx context.Context, current models.Payment, created bool) (ProcessPaymentResult, error) {
 	if err := s.moveOrderToProcessing(ctx, current); err != nil {
 		return ProcessPaymentResult{}, err
@@ -254,6 +250,7 @@ func (s *PaymentService) chargeGateway(ctx context.Context, current models.Payme
 	return ProcessPaymentResult{Payment: current, Created: created}, fmt.Errorf("charge payment: %w", lastErr)
 }
 
+// moveOrderToProcessing (Method): transitions the order to Processing status before charging
 func (s *PaymentService) moveOrderToProcessing(ctx context.Context, payment models.Payment) error {
 	_, err := s.orderWorkflow.TransitionOrder(ctx, TransitionOrderRequest{
 		TenantID: payment.TenantID,
@@ -267,6 +264,7 @@ func (s *PaymentService) moveOrderToProcessing(ctx context.Context, payment mode
 	return nil
 }
 
+// applyPaymentStatusToOrder (Method): propagates settled/failed payment status to the parent order
 func (s *PaymentService) applyPaymentStatusToOrder(ctx context.Context, payment models.Payment) error {
 	var target models.OrderStatus
 	switch payment.Status {
@@ -290,6 +288,7 @@ func (s *PaymentService) applyPaymentStatusToOrder(ctx context.Context, payment 
 	return nil
 }
 
+// syncPaymentToOrder (Method): ensures order status matches payment status on idempotent retry
 func (s *PaymentService) syncPaymentToOrder(ctx context.Context, payment models.Payment, order models.Order) error {
 	if payment.Status == models.PaymentStatusPending {
 		return nil
@@ -335,6 +334,7 @@ func (s *PaymentService) syncPaymentToOrder(ctx context.Context, payment models.
 	return nil
 }
 
+// normalizePaymentJob (Function): validates and normalizes a payment job input
 func normalizePaymentJob(job paymentflow.Job) (paymentflow.Job, error) {
 	job.ProviderReference = strings.TrimSpace(job.ProviderReference)
 
@@ -345,6 +345,7 @@ func normalizePaymentJob(job paymentflow.Job) (paymentflow.Job, error) {
 	return job, nil
 }
 
+// samePaymentTarget (Function): checks if a payment record matches a job's tenant/order/amount/reference
 func samePaymentTarget(payment models.Payment, job paymentflow.Job) bool {
 	return payment.TenantID == job.TenantID &&
 		payment.OrderID == job.OrderID &&
@@ -352,6 +353,7 @@ func samePaymentTarget(payment models.Payment, job paymentflow.Job) bool {
 		payment.AmountCents == job.AmountCents
 }
 
+// isKnownPaymentStatus (Function): checks if a payment status is a recognized enum value
 func isKnownPaymentStatus(status models.PaymentStatus) bool {
 	switch status {
 	case models.PaymentStatusPending,
@@ -365,6 +367,7 @@ func isKnownPaymentStatus(status models.PaymentStatus) bool {
 	}
 }
 
+// normalizeGatewayError (Function): converts gateway errors to canonical ErrGatewayTimeout/ErrGatewayUnavailable
 func normalizeGatewayError(err error) error {
 	if err == nil {
 		return nil
@@ -378,6 +381,7 @@ func normalizeGatewayError(err error) error {
 	return err
 }
 
+// isFinalPaymentStatus (Function): checks if a payment status is terminal (Settled, Failed, Refunded)
 func isFinalPaymentStatus(status models.PaymentStatus) bool {
 	switch status {
 	case models.PaymentStatusSettled, models.PaymentStatusFailed, models.PaymentStatusRefunded:

--- a/11-flagship/01-opslane/internal/services/validation.go
+++ b/11-flagship/01-opslane/internal/services/validation.go
@@ -10,18 +10,18 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/models"
 )
 
-// Package-level error definitions for the services package.
 var (
-	// ErrInvalidOrder is returned when order input validation fails.
+	// ErrInvalidOrder (Error): returned when order input validation fails
 	ErrInvalidOrder = errors.New("invalid order")
-	// ErrOrderNotFound is returned when a requested order does not exist.
+	// ErrOrderNotFound (Error): returned when a requested order does not exist
 	ErrOrderNotFound = errors.New("order not found")
-	// ErrInvalidStatusTransition is returned when an order status change is not allowed.
+	// ErrInvalidStatusTransition (Error): returned when an order status change is not allowed
 	ErrInvalidStatusTransition = errors.New("invalid order status transition")
-	// ErrInventoryUnavailable is returned when inventory reservation fails.
+	// ErrInventoryUnavailable (Error): returned when inventory reservation fails
 	ErrInventoryUnavailable = errors.New("inventory unavailable")
 )
 
+// normalizeCreateOrderInput (Function): validates and normalizes order creation input
 func normalizeCreateOrderInput(input CreateOrderInput) (CreateOrderInput, error) {
 	input.Currency = strings.ToUpper(strings.TrimSpace(input.Currency))
 	input.IdempotencyKey = strings.TrimSpace(input.IdempotencyKey)
@@ -37,6 +37,7 @@ func normalizeCreateOrderInput(input CreateOrderInput) (CreateOrderInput, error)
 	return input, nil
 }
 
+// validateTransitionTarget (Function): validates that a target order status is a known value
 func validateTransitionTarget(status models.OrderStatus) error {
 	if !isKnownOrderStatus(status) {
 		return ErrInvalidStatusTransition
@@ -45,6 +46,7 @@ func validateTransitionTarget(status models.OrderStatus) error {
 	return nil
 }
 
+// isKnownOrderStatus (Function): checks if an order status is a recognized enum value
 func isKnownOrderStatus(status models.OrderStatus) bool {
 	switch status {
 	case models.OrderStatusPending,
@@ -58,6 +60,7 @@ func isKnownOrderStatus(status models.OrderStatus) bool {
 	}
 }
 
+// canTransitionOrder (Function): determines if an order status transition is valid
 func canTransitionOrder(current, next models.OrderStatus) bool {
 	switch current {
 	case models.OrderStatusPending:
@@ -71,10 +74,12 @@ func canTransitionOrder(current, next models.OrderStatus) bool {
 	}
 }
 
+// shouldReserveForTransition (Function): determines if inventory reservation is needed before a transition
 func shouldReserveForTransition(current, next models.OrderStatus) bool {
 	return current == models.OrderStatusFailed && next == models.OrderStatusProcessing
 }
 
+// shouldReleaseForTransition (Function): determines if inventory release is needed after a transition
 func shouldReleaseForTransition(current, next models.OrderStatus) bool {
 	switch current {
 	case models.OrderStatusPending, models.OrderStatusProcessing:
@@ -84,6 +89,7 @@ func shouldReleaseForTransition(current, next models.OrderStatus) bool {
 	}
 }
 
+// shouldRetryReleaseForSameStatus (Function): determines if inventory should be released on idempotent same-status retry
 func shouldRetryReleaseForSameStatus(status models.OrderStatus) bool {
 	return status == models.OrderStatusFailed || status == models.OrderStatusCancelled
 }

--- a/11-flagship/01-opslane/internal/tracing/tracing.go
+++ b/11-flagship/01-opslane/internal/tracing/tracing.go
@@ -15,9 +15,7 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/logging"
 )
 
-// SpanContext holds timing and identity data for a named operation.
-// This is a lightweight teaching implementation - production systems
-// would use OpenTelemetry spans with trace/span IDs and sampling.
+// SpanContext (Struct): holds timing and identity data for a named tracing span
 type SpanContext struct {
 	Name          string
 	CorrelationID string
@@ -25,14 +23,10 @@ type SpanContext struct {
 }
 
 // spanContextKey is the context key for the current span.
+// spanContextKey (Struct): unexported context key type for the current span
 type spanContextKey struct{}
 
-// StartSpan begins a named operation span. It reads the correlation ID
-// from the context and records the start time. The returned context
-// carries the span so EndSpan can access it later.
-//
-// This pattern teaches the concept of span propagation without
-// requiring an external tracing library.
+// StartSpan (Function): begins a named operation span with correlation ID propagation
 func StartSpan(ctx context.Context, name string) (context.Context, *SpanContext) {
 	span := &SpanContext{
 		Name:          name,
@@ -43,8 +37,7 @@ func StartSpan(ctx context.Context, name string) (context.Context, *SpanContext)
 	return context.WithValue(ctx, spanContextKey{}, span), span
 }
 
-// EndSpan logs the span's duration. If logger is nil, the span is
-// silently completed (useful in tests).
+// EndSpan (Function): logs the span's duration; silently completes if logger is nil (useful in tests)
 func EndSpan(span *SpanContext, logger *slog.Logger) {
 	if span == nil || logger == nil {
 		return
@@ -58,24 +51,20 @@ func EndSpan(span *SpanContext, logger *slog.Logger) {
 	)
 }
 
-// SpanFromContext retrieves the current span from the context.
-// Returns nil if no span was started.
+// SpanFromContext (Function): retrieves the current span from context; returns nil if absent
 func SpanFromContext(ctx context.Context) *SpanContext {
 	span, _ := ctx.Value(spanContextKey{}).(*SpanContext)
 	return span
 }
 
-// InjectCorrelationHeader sets the X-Correlation-ID header on an
-// outbound HTTP request. Use this when making calls to downstream
-// services so the correlation ID propagates across service boundaries.
+// InjectCorrelationHeader (Function): sets X-Correlation-ID on outbound HTTP requests for trace propagation
 func InjectCorrelationHeader(r *http.Request, correlationID string) {
 	if correlationID != "" {
 		r.Header.Set("X-Correlation-ID", correlationID)
 	}
 }
 
-// ExtractCorrelationHeader reads the X-Correlation-ID from an inbound
-// HTTP request. Returns empty string if absent.
+// ExtractCorrelationHeader (Function): reads X-Correlation-ID from an inbound HTTP request
 func ExtractCorrelationHeader(r *http.Request) string {
 	return r.Header.Get("X-Correlation-ID")
 }

--- a/11-flagship/01-opslane/internal/workers/notification_worker.go
+++ b/11-flagship/01-opslane/internal/workers/notification_worker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/events"
 )
 
+// Notification (Struct): carries data for an outbound customer communication
 type Notification struct {
 	TenantID int64
 	EventID  string
@@ -18,14 +19,17 @@ type Notification struct {
 	Body     string
 }
 
+// NotificationSink (Interface): sends notifications through external channels (email, SMS, etc.)
 type NotificationSink interface {
 	Send(ctx context.Context, notification Notification) error
 }
 
+// NotificationWorker (Struct): handles TypeNotificationRequested events by sending through the notification sink
 type NotificationWorker struct {
 	Sink NotificationSink
 }
 
+// Handle (Method): processes a TypeNotificationRequested event through the notification sink
 func (w NotificationWorker) Handle(ctx context.Context, event events.Event) error {
 	if event.Type != events.TypeNotificationRequested {
 		return nil

--- a/11-flagship/01-opslane/internal/workers/order_processor.go
+++ b/11-flagship/01-opslane/internal/workers/order_processor.go
@@ -12,14 +12,17 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
+// OrderWorkflow (Interface): transitions order status through the order service
 type OrderWorkflow interface {
 	TransitionOrder(ctx context.Context, req services.TransitionOrderRequest) (models.Order, error)
 }
 
+// OrderProcessor (Struct): handles TypeOrderStatusChanged events by delegating to the order workflow
 type OrderProcessor struct {
 	Workflow OrderWorkflow
 }
 
+// Handle (Method): processes a TypeOrderStatusChanged event through the order workflow
 func (p OrderProcessor) Handle(ctx context.Context, event events.Event) error {
 	if event.Type != events.TypeOrderStatusChanged {
 		return nil

--- a/11-flagship/01-opslane/internal/workers/payment_processor.go
+++ b/11-flagship/01-opslane/internal/workers/payment_processor.go
@@ -12,14 +12,17 @@ import (
 	"github.com/swe-labs/the-go-engineer/11-flagship/01-opslane/internal/services"
 )
 
+// PaymentWorkflow (Interface): processes payment jobs through the payment service
 type PaymentWorkflow interface {
 	ProcessPayment(ctx context.Context, job paymentflow.Job) (services.ProcessPaymentResult, error)
 }
 
+// PaymentProcessor (Struct): handles TypePaymentRequested events by delegating to the payment workflow
 type PaymentProcessor struct {
 	Workflow PaymentWorkflow
 }
 
+// Handle (Method): processes a TypePaymentRequested event through the payment workflow
 func (p PaymentProcessor) Handle(ctx context.Context, event events.Event) error {
 	if event.Type != events.TypePaymentRequested {
 		return nil

--- a/11-flagship/01-opslane/internal/workers/pool.go
+++ b/11-flagship/01-opslane/internal/workers/pool.go
@@ -97,6 +97,7 @@ func NewPool(config PoolConfig) (*Pool, error) {
 	}, nil
 }
 
+// Start (Method): launches worker goroutines and begins processing events
 func (p *Pool) Start(ctx context.Context) error {
 	if p == nil {
 		return fmt.Errorf("worker pool is not configured")
@@ -134,6 +135,7 @@ func (p *Pool) Start(ctx context.Context) error {
 // Note: p.jobs is never closed while the pool is running, so there is no
 // risk of a "send on closed channel" panic here. Workers exit by watching
 // stopCh, not by channel closure.
+// Submit (Method): enqueues an event for processing, blocking until accepted, pool stopped, or context cancelled
 func (p *Pool) Submit(ctx context.Context, event events.Event) error {
 	if p == nil {
 		return fmt.Errorf("worker pool is not configured")
@@ -170,6 +172,7 @@ func (p *Pool) Submit(ctx context.Context, event events.Event) error {
 // that Stop (which holds the write-lock when it sets p.stopped) cannot sneak
 // in between the two operations. Because p.jobs is never closed while the pool
 // is running, the non-blocking send is safe.
+// TrySubmit (Method): non-blocking enqueue; returns ErrQueueFull or ErrPoolStopped immediately
 func (p *Pool) TrySubmit(event events.Event) error {
 	if p == nil {
 		return fmt.Errorf("worker pool is not configured")
@@ -195,6 +198,7 @@ func (p *Pool) TrySubmit(event events.Event) error {
 // Crucially, p.jobs is NOT closed here. Closing a channel that other
 // goroutines may still be sending to causes a panic. Instead workers
 // watch stopCh and drain any remaining buffered events before returning.
+// Stop (Method): signals all workers to exit and waits for them to finish draining buffered events
 func (p *Pool) Stop() {
 	if p == nil {
 		return
@@ -212,6 +216,7 @@ func (p *Pool) Stop() {
 	p.wg.Wait()
 }
 
+// QueueLength (Method): returns the number of events currently buffered in the job channel
 func (p *Pool) QueueLength() int {
 	if p == nil {
 		return 0
@@ -220,6 +225,7 @@ func (p *Pool) QueueLength() int {
 	return len(p.jobs)
 }
 
+// Name (Method): returns the pool's configured name
 func (p *Pool) Name() string {
 	if p == nil {
 		return ""
@@ -228,6 +234,7 @@ func (p *Pool) Name() string {
 	return p.name
 }
 
+// DurabilityMode (Method): returns the pool's configured durability mode
 func (p *Pool) DurabilityMode() DurabilityMode {
 	if p == nil {
 		return DurabilityInMemory
@@ -276,6 +283,7 @@ func (p *Pool) runWorker(ctx context.Context) {
 	}
 }
 
+// doHandle (Method): executes the handler with panic recovery
 func (p *Pool) doHandle(ctx context.Context, event events.Event) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Issue title format:
 [TYPE] short description
 ```
 
-Allowed types:
+Allowed types (match the branch prefix mapping below):
 
 ```text
 [FEAT] [FIX] [DOCS] [TEST] [CHORE] [REFACTOR] [SECURITY] [RELEASE]
@@ -76,13 +76,28 @@ Issue body should include:
 
 ## Branches
 
+Bracketed types are for human-facing surfaces (issues, PRs, commits). Branch names use the corresponding slash-prefixed type to avoid URL encoding and shell issues.
+
+| Type | Branch prefix | Example |
+| --- | --- | --- |
+| `[FEAT]` | `feat/` | `feat/s03-functions-basics` |
+| `[FIX]` | `fix/` | `fix/s06-tenant-scoping` |
+| `[DOCS]` | `docs/` | `docs/release-readiness` |
+| `[TEST]` | `test/` | `test/s08-benchmark-coverage` |
+| `[CHORE]` | `chore/` | `chore/tooling-update` |
+| `[REFACTOR]` | `refactor/` | `refactor/config-validation` |
+| `[SECURITY]` | `security/` | `security/input-sanitization` |
+| `[RELEASE]` | `release/` | `release/v2.1.2-prep` |
+
+Long-lived lines:
+
 | Branch | Purpose |
 | --- | --- |
 | `main` | active post-v2.1 implementation and integration line |
 | `release/v2` | stable v2.1.x maintenance line |
 | `release/v1` | stable v1 maintenance line |
 
-Branch from the line that should receive the change.
+Branch from the line that should receive the change. Include the lesson section number (`sNN`) when the change is specific to one section.
 
 Examples:
 
@@ -95,8 +110,18 @@ git switch -c docs/public-release-readiness
 ```bash
 git switch release/v2
 git pull --ff-only origin release/v2
-git switch -c release/v2.1.x-prep
+git switch -c release/v2.1.2-prep
 ```
+
+## Pull Requests
+
+PR titles use the same bracketed format as issues:
+
+```text
+[TYPE] short description
+```
+
+Open a draft PR early and link the issue with `Closes #<issue>`.
 
 ## Pull Requests
 


### PR DESCRIPTION
Closes #495
Closes #496
Closes #497
Closes #498
Closes #499
Closes #500
Closes #501
Closes #502

## Scope
- Section: s00, s11
- Lesson IDs: HC.1-HC.5, OPSL.1-OPSL.10
- Files: 14 files across 00-how-computers-work/ and 11-flagship/01-opslane/

## Type
- [x] [FIX]
- [x] [CHORE]
- [x] [DOCS]
- [x] [TEST]

## Summary
End-to-end quality improvements addressing 8 issues identified in an end-to-end project audit:

### Build and CI hygiene
- **.dockerignore** for Opslane to reduce Docker build context (Closes #495)
- **Non-root USER** in Dockerfile for security best practice (Closes #498)

### Configuration correctness
- **Centralized OTLP config**: Moved `otel.Config.FromEnv()` into `config.LoadFromLookup()` so all env var loading goes through the single validated pipeline. OTELConfig struct added with endpoint, timeout, insecure, sample rate. (Closes #496)
- **Added floatFromEnv** helper for float64 env var parsing

### Interface safety
- **Compile-time assertion** `var _ Store = (*db.Store)(nil)` in handlers to prevent silent interface drift (Closes #497)

### Documentation
- **PowerShell compatibility note** in Opslane Makefile (Closes #499)

### Machine Role comments
- **Section 00** (HC.1-HC.5): Added Machine Role comments to all main() and helper functions (Closes #500)
- **Opslane flagship**: Added Machine Role comments across config, environment, otel, handlers, and cmd/server packages (Closes #501)
- Fixed a **bug in context key mechanism**: struct{}{} literals share the same address in Go, causing traceIDKey/spanIDKey/spanKey to collide. Replaced with typed contextKey int constants.

### Test coverage
- **25 test cases** for internal/otel package covering span lifecycle, context propagation, trace parent parsing, OTLP serialization, sampling, ID generation, concurrency safety (Closes #502)
- **OTLP config tests** in config_test.go confirming defaults, overrides, and validation

## Validation
- [x] go build ./...
- [x] go vet ./...
- [x] gofmt check (all files formatted)
- [x] go mod tidy no-diff check
- [x] go test ./... (all passing)
- [x] go run ./scripts/validate_curriculum.go (601 files, 12 sections, 215 items - success)

## Risk
- Low. OTLP config change is backward-compatible (same env var names).
- Removed otel.Config.FromEnv() which had no external consumers in this monorepo.
- Dockerfile USER change may require volume permission adjustments for local development.
