### PR TITLE
[FEAT] Add missing Go 1.21+ standard library lessons (slices, maps, cmp, context.AfterFunc)

### DIFF
--- a/02-language-basics/04-data-structures/06-contact-manager/README.md
+++ b/02-language-basics/04-data-structures/06-contact-manager/README.md
@@ -96,4 +96,4 @@ Real-world database engines (like SQLite or Postgres) use similar patterns of "I
 
 ## Next Step
 
-Next: `FE.1` -> [`03-functions-errors/01-functions-basics`](../../../03-functions-errors/01-functions-basics/README.md)
+Next: `DS.7` -> [`02-language-basics/04-data-structures/07-slices`](../07-slices/README.md)

--- a/02-language-basics/04-data-structures/06-contact-manager/main.go
+++ b/02-language-basics/04-data-structures/06-contact-manager/main.go
@@ -104,8 +104,8 @@ func main() {
 	fmt.Println()
 	fmt.Println("---------------------------------------------------")
 	fmt.Println("SECTION COMPLETE: Section 02 Language Basics")
-	fmt.Println("NEXT UP: FE.1 -> 03-functions-errors/01-functions-basics")
-	fmt.Println("Run    : go run ./03-functions-errors/01-functions-basics")
+	fmt.Println("NEXT UP: DS.7 -> 02-language-basics/04-data-structures/07-slices")
+	fmt.Println("Run    : go run ./02-language-basics/04-data-structures/07-slices")
 	fmt.Println("Current: DS.6 (contact-manager)")
 	fmt.Println("---------------------------------------------------")
 }

--- a/02-language-basics/04-data-structures/07-slices/README.md
+++ b/02-language-basics/04-data-structures/07-slices/README.md
@@ -1,0 +1,76 @@
+# DS.7 The slices package
+
+## Mission
+
+Master the `slices` package for type-safe slice operations including sorting, deduplication, searching, and modification.
+
+## Prerequisites
+
+- `DS.2` slices
+- `DS.5` slice sharing and capacity
+
+> [!NOTE]
+> In [DS.2 Slices](../02-slices/README.md), you learned the basics of slice creation and manipulation. In [DS.5 Slices in Depth](../05-slices-2/README.md), you learned about shared backing arrays and aliasing. The `slices` package builds on this foundation with generic, type-safe operations.
+
+## Mental Model
+
+The `slices` package is like a **Swiss Army knife for slices**. Instead of writing manual loops for sorting, deduplication, or searching, you call a single function that works with any comparable or ordered type. Every function is generic — one `slices.Sort` works for `[]int`, `[]string`, or any custom ordered type.
+
+## Visual Model
+
+```mermaid
+graph TD
+    subgraph "slices Package"
+        S["slices.Sort"] --> A["[1, 7, 13, 42, 99]"]
+        C["slices.Compact"] --> D["[1, 7, 13, 42, 99]"]
+        B["slices.BinarySearch"] --> E["found=42 at index 3"]
+        H["slices.Contains"] --> I["true / false"]
+        M["slices.Delete / Insert"] --> J["modified slice"]
+        L["slices.Clone"] --> K["independent copy"]
+        EQ["slices.Equal"] --> F["true / false"]
+    end
+```
+
+## Machine View
+
+All `slices` functions are generic and use compile-time specialization. When you write `slices.Sort(nums)`, the Go compiler generates a type-specific sort implementation at compile time — there is no reflection or runtime dispatch. This means the performance is identical to hand-written type-specific code, but with none of the boilerplate.
+
+## Run Instructions
+
+```bash
+go run ./02-language-basics/04-data-structures/07-slices
+```
+
+## Code Walkthrough
+
+- **`slices.Sort`**: Sorts a slice in place using an optimized sort algorithm. Works with any ordered type.
+- **`slices.Compact`**: Removes adjacent duplicates. The slice must be sorted first for full deduplication.
+- **`slices.BinarySearch`**: Returns whether a value exists and its index. Requires a sorted slice.
+- **`slices.Contains`**: Linear search that works with comparable types. Returns `true` if the value is present.
+- **`slices.Delete`**: Removes elements from `i` to `j-1` efficiently by shifting remaining elements.
+- **`slices.Insert`**: Grows a slice by inserting elements at a given index.
+- **`slices.Clone`**: Creates an independent copy of a slice with its own backing array.
+- **`slices.Equal`**: Compares two slices element-by-element for equality.
+
+> [!TIP]
+> These functions replace common patterns that previously required the `sort` package or manual loops. Now that you know the `slices` package, you'll use it in almost every Go program. Next, in [DS.8 maps](../08-maps/README.md), you'll learn the companion library for map operations.
+
+## Try It
+
+1. Create a slice of strings and sort it with `slices.Sort`. Then use `slices.Compact` on the result.
+2. Use `slices.BinarySearch` on a sorted slice. What happens if you call it on an unsorted slice?
+3. Use `slices.Clone` to make a copy and verify that modifying the copy does not affect the original.
+
+## In Production
+
+Production Go code uses the `slices` package for sorting API response data, deduplicating log entries, searching sorted configuration lists, and managing in-memory collections. Because the functions are generic, they eliminate entire categories of helper functions that teams used to maintain by hand.
+
+## Thinking Questions
+
+1. Why does `slices.Compact` only remove adjacent duplicates? How would you remove all duplicates regardless of position?
+2. Why does `slices.BinarySearch` require a sorted slice? What happens if you pass an unsorted one?
+3. How is `slices.Clone` different from assigning one slice variable to another (e.g., `copy := original`)?
+
+## Next Step
+
+Next: `DS.8` -> [`02-language-basics/04-data-structures/08-maps`](../08-maps/README.md)

--- a/02-language-basics/04-data-structures/07-slices/main.go
+++ b/02-language-basics/04-data-structures/07-slices/main.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Rasel Hossen
+// Licensed under The Go Engineer License v1.0
+
+// ============================================================================
+// Section 02: Language Basics
+// Title: The slices package
+// Level: Core
+// ============================================================================
+//
+// WHAT YOU'LL LEARN:
+//   - Use slices.Sort to sort any slice of ordered types.
+//   - Use slices.Compact to remove adjacent duplicates.
+//   - Use slices.Contains and slices.Index for searching.
+//   - Use slices.Delete and slices.Insert to modify slices efficiently.
+//
+// WHY THIS MATTERS:
+//   Before Go 1.21, sorting slices required the reflect-heavy sort.Slice or
+//   writing boilerplate. The slices package provides generic, type-safe
+//   operations that are faster and cleaner.
+//
+// RUN:
+//   go run ./02-language-basics/04-data-structures/07-slices
+//
+// KEY TAKEAWAY:
+//   - The slices package is the modern Go way to search, sort, and manipulate slices.
+//   - All functions are generic and work with any comparable or ordered type.
+// ============================================================================
+
+package main
+
+import (
+	"fmt"
+	"slices"
+)
+
+func main() {
+	// 1. Sorting — slices.Sort modifies the slice in place.
+	nums := []int{42, 7, 13, 99, 1, 7, 42}
+	fmt.Println("Before sort:", nums)
+	slices.Sort(nums)
+	fmt.Println("After sort :", nums)
+	fmt.Println()
+
+	// 2. Deduplication — Compact removes adjacent duplicates (sort first).
+	uniq := slices.Compact(nums)
+	fmt.Println("Compact    :", uniq)
+	fmt.Println()
+
+	// 3. Searching — BinarySearch requires a sorted slice.
+	pos, found := slices.BinarySearch(uniq, 42)
+	fmt.Printf("BinarySearch(42): found=%v position=%d\n", found, pos)
+
+	pos, found = slices.BinarySearch(uniq, 50)
+	fmt.Printf("BinarySearch(50): found=%v insertAt=%d\n", found, pos)
+	fmt.Println()
+
+	// 4. Contains and Index for linear search.
+	words := []string{"apple", "banana", "cherry", "date"}
+	fmt.Printf("Contains(banana): %v\n", slices.Contains(words, "banana"))
+	fmt.Printf("Index(date)    : %d\n", slices.Index(words, "date"))
+	fmt.Printf("Contains(zebra): %v\n", slices.Contains(words, "zebra"))
+	fmt.Println()
+
+	// 5. Delete and Insert for slice modification.
+	// Delete removes elements i..j-1. Insert grows the slice.
+	clipped := slices.Delete(words, 1, 3)
+	fmt.Println("After Delete(1,3):", clipped)
+	extended := slices.Insert(clipped, 1, "blueberry", "cranberry")
+	fmt.Println("After Insert     :", extended)
+	fmt.Println()
+
+	// 6. Clone creates an independent copy.
+	original := []int{1, 2, 3}
+	copy := slices.Clone(original)
+	copy[0] = 99
+	fmt.Printf("Clone test — original[0]=%d copy[0]=%d (independent)\n", original[0], copy[0])
+	fmt.Println()
+
+	// 7. Equal compares element-by-element.
+	a := []int{1, 2, 3}
+	b := []int{1, 2, 3}
+	c := []int{1, 2, 4}
+	fmt.Printf("Equal(a, b): %v\n", slices.Equal(a, b))
+	fmt.Printf("Equal(a, c): %v\n", slices.Equal(a, c))
+
+	fmt.Println()
+	fmt.Println("---------------------------------------------------")
+	fmt.Println("NEXT UP: DS.8 -> 02-language-basics/04-data-structures/08-maps")
+	fmt.Println("Run    : go run ./02-language-basics/04-data-structures/08-maps")
+	fmt.Println("Current: DS.7 (slices)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/02-language-basics/04-data-structures/08-maps/README.md
+++ b/02-language-basics/04-data-structures/08-maps/README.md
@@ -1,0 +1,72 @@
+# DS.8 The maps package
+
+## Mission
+
+Master the `maps` package for generic map operations including cloning, merging, key/value extraction, and conditional deletion.
+
+## Prerequisites
+
+- `DS.3` maps
+- `DS.7` slices (for understanding `slices.Collect`)
+
+> [!NOTE]
+> In [DS.3 Maps](../03-maps/README.md), you learned the basics of map creation, lookup, and iteration. In [DS.7 slices](../07-slices/README.md), you learned how the `slices` package provides generic operations. The `maps` package applies the same generic pattern to map types.
+
+## Mental Model
+
+The `maps` package provides tools for working with maps that eliminate boilerplate. Instead of writing a `for` loop every time you need to copy a map, merge one map into another, or collect all keys into a slice, you call a single generic function. Think of it as **map utilities that the standard library should have always had**.
+
+## Visual Model
+
+```mermaid
+graph TD
+    subgraph "maps Package"
+        CL["maps.Clone"] --> CP["independent map copy"]
+        CO["maps.Copy"] --> MR["merged destination map"]
+        K["maps.Keys"] --> KS["[]key slice (iterator)"]
+        V["maps.Values"] --> VS["[]value slice (iterator)"]
+        DF["maps.DeleteFunc"] --> FM["filtered map"]
+        EQ["maps.Equal"] --> TF["true / false"]
+    end
+```
+
+## Machine View
+
+Generic operations are type-safe and compile-time checked. When you call `maps.Clone(myMap)`, the Go compiler specializes the function for the exact map type. There is no `interface{}` boxing or runtime type assertion. The generated code is as efficient as a hand-written loop, but with zero boilerplate.
+
+## Run Instructions
+
+```bash
+go run ./02-language-basics/04-data-structures/08-maps
+```
+
+## Code Walkthrough
+
+- **`maps.Clone`**: Creates a shallow, independent copy of a map. Modifying the original does not affect the clone.
+- **`maps.Copy`**: Merges all key-value pairs from a source map into a destination map. Existing keys in the destination are overwritten.
+- **`maps.Keys` / `maps.Values`**: Return iterators over the map's keys and values. Use `slices.Collect` to gather them into slices.
+- **`maps.DeleteFunc`**: Removes entries where a callback function returns `true`. Useful for filtering maps without manual loops.
+- **`maps.Equal`**: Compares two maps for identical key-value pairs. Returns `true` if they have the same keys with the same values.
+
+> [!TIP]
+> The `maps` package and `slices` package work together. For example, `maps.Keys` returns an iterator that you can collect with `slices.Collect`. This is the new idiomatic Go pattern for extracting and manipulating map contents. Next, in [FE.1 Functions Basics](../../../03-functions-errors/01-functions-basics/README.md), you'll move on to functions and error handling.
+
+## Try It
+
+1. Create a map, clone it with `maps.Clone`, and verify that adding a key to the original does not appear in the clone.
+2. Use `maps.Copy` to merge two maps. What happens when both maps have the same key?
+3. Use `maps.DeleteFunc` to remove all entries where the value is less than a threshold.
+
+## In Production
+
+`maps.Clone` is used for taking configuration snapshots before applying changes. `maps.Copy` is used for merging default configuration maps with user-provided overrides. `maps.DeleteFunc` is used for filtering sensitive entries from maps before serialization.
+
+## Thinking Questions
+
+1. Why does `maps.Clone` create a shallow copy? What types of values would require a deep copy?
+2. How are `maps.Keys` iterators different from returning a slice directly? What are the memory benefits?
+3. Why does `maps.Equal` use deep comparison of values? What types of map values cannot be compared?
+
+## Next Step
+
+Next: `FE.1` -> [`03-functions-errors/01-functions-basics`](../../../03-functions-errors/01-functions-basics/README.md)

--- a/02-language-basics/04-data-structures/08-maps/main.go
+++ b/02-language-basics/04-data-structures/08-maps/main.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Rasel Hossen
+// Licensed under The Go Engineer License v1.0
+
+// ============================================================================
+// Section 02: Language Basics
+// Title: The maps package
+// Level: Core
+// ============================================================================
+//
+// WHAT YOU'LL LEARN:
+//   - Use maps.Clone to create an independent copy of a map.
+//   - Use maps.Copy to merge keys from one map into another.
+//   - Use maps.Keys and maps.Values to extract map contents as slices.
+//   - Use maps.DeleteFunc to remove entries conditionally.
+//
+// WHY THIS MATTERS:
+//   Before Go 1.21, copying a map required a manual loop. The maps package
+//   provides generic, type-safe operations that eliminate boilerplate.
+//
+// RUN:
+//   go run ./02-language-basics/04-data-structures/08-maps
+//
+// KEY TAKEAWAY:
+//   - The maps package provides generic operations for all map types.
+//   - Use maps.Clone for independent copies and maps.Copy for merging.
+//   - Keys() and Values() are not ordered — sort if you need stable output.
+// ============================================================================
+
+package main
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+)
+
+func main() {
+	// 1. Creating and cloning.
+	scores := map[string]int{"Alice": 95, "Bob": 87, "Charlie": 92}
+	backup := maps.Clone(scores)
+	fmt.Println("Original:", scores)
+	fmt.Println("Clone   :", backup)
+
+	// Modifying the original doesn't affect the clone.
+	scores["David"] = 78
+	fmt.Println("After add: original has David:", scores["David"] > 0, "clone does not:", backup["David"] > 0)
+	fmt.Println()
+
+	// 2. Copy merges all keys from src into dst.
+	moreScores := map[string]int{"Eve": 88, "Frank": 91}
+	maps.Copy(scores, moreScores)
+	fmt.Println("After Copy:", scores)
+	fmt.Println()
+
+	// 3. Keys and Values extract the contents (returns iterators in Go 1.23+).
+	names := slices.Collect(maps.Keys(scores))
+	allScores := slices.Collect(maps.Values(scores))
+	slices.Sort(names)
+	slices.Sort(allScores)
+	fmt.Println("Sorted keys  :", names)
+	fmt.Println("Sorted values:", allScores)
+	fmt.Println()
+
+	// 4. DeleteFunc removes entries where the callback returns true.
+	honorRoll := maps.Clone(scores)
+	maps.DeleteFunc(honorRoll, func(_ string, v int) bool { return v < 90 })
+	fmt.Println("Honor roll (score >= 90):", honorRoll)
+	fmt.Println()
+
+	// 5. Equal checks if two maps have identical key-value pairs.
+	fmt.Printf("Equal(scores, backup): %v\n", maps.Equal(scores, backup))
+	equalCopy := maps.Clone(scores)
+	fmt.Printf("Equal(scores, clone) : %v\n", maps.Equal(scores, equalCopy))
+
+	fmt.Println()
+	fmt.Println("---------------------------------------------------")
+	fmt.Println("NEXT UP: FE.1 -> 03-functions-errors/01-functions-basics")
+	fmt.Println("Run    : go run ./03-functions-errors/01-functions-basics")
+	fmt.Println("Current: DS.8 (maps)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/04-types-design/09-generics/main.go
+++ b/04-types-design/09-generics/main.go
@@ -9,7 +9,7 @@
 //
 // WHAT YOU'LL LEARN:
 //   - Defining generic functions using type parameters and constraints.
-//   - Using built-in constraints: `any` and `comparable`.
+//   - Using built-in constraints: `any`, `comparable`, and `cmp.Ordered`.
 //   - Implementing custom type constraints using interface unions.
 //   - The mechanics of monomorphization and compile-time type safety.
 //
@@ -31,7 +31,9 @@
 package main
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
 )
 
 // Section 04: Types & Design - Generics
@@ -119,6 +121,25 @@ func main() {
 	fmt.Printf("  Has 'go':   %t\n", Contains(words, "go"))
 	fmt.Printf("  Has 5:      %t\n", Contains(numbers, 5))
 	fmt.Printf("  Has 'ruby': %t\n", Contains(words, "ruby"))
+	fmt.Println()
+
+	// 4. The cmp package provides generic ordered comparisons (Go 1.21+).
+	// cmp.Ordered is a built-in constraint covering all ordered types.
+	// cmp.Compare returns -1, 0, or 1. cmp.Less is a boolean check.
+	fmt.Println("--- Comparisons with cmp.Ordered (Go 1.21+) ---")
+
+	// Use cmp.Compare directly instead of a generic closure (Go closures cannot have type params).
+	fmt.Printf("  cmp.Compare(10, 20)       = %d\n", cmp.Compare(10, 20))
+	fmt.Printf("  cmp.Compare(3.14, 2.71)   = %d\n", cmp.Compare(3.14, 2.71))
+	fmt.Printf("  cmp.Compare(\"beta\", \"alpha\") = %d\n", cmp.Compare("beta", "alpha"))
+
+	// Sorting with cmp.Less — works with any ordered type.
+	names := []string{"Charlie", "Alice", "Bob"}
+	slices.SortFunc(names, func(a, b string) int { return cmp.Compare(a, b) })
+	fmt.Printf("  sorted names: %v\n", names)
+
+	// Using cmp.Less for comparison.
+	fmt.Printf("  cmp.Less(5, 10) = %v\n", cmp.Less(5, 10))
 
 	fmt.Println()
 	fmt.Println("---------------------------------------------------")

--- a/07-concurrency/01-concurrency/01-context/05-timeout-client/README.md
+++ b/07-concurrency/01-concurrency/01-context/05-timeout-client/README.md
@@ -86,4 +86,4 @@ In a high-scale microservice architecture, a single service without timeouts can
 
 ## Next Step
 
-Next: `TM.1` -> [`07-concurrency/01-concurrency/04-time-and-scheduling/01-time`](../../04-time-and-scheduling/01-time/README.md)
+Next: `CT.6` -> [`07-concurrency/01-concurrency/01-context/06-afterfunc`](../06-afterfunc/README.md)

--- a/07-concurrency/01-concurrency/01-context/05-timeout-client/main.go
+++ b/07-concurrency/01-concurrency/01-context/05-timeout-client/main.go
@@ -119,5 +119,5 @@ func main() {
 	fmt.Println("  - Check ctx.Err() == context.DeadlineExceeded for timeout detection")
 	fmt.Println("  - Production default: 5-30 seconds for API calls, 1-5 seconds for health checks")
 	fmt.Println()
-	fmt.Println("NEXT UP: TM.1 -> 07-concurrency/01-concurrency/04-time-and-scheduling/01-time")
+	fmt.Println("NEXT UP: CT.6 -> 07-concurrency/01-concurrency/01-context/06-afterfunc")
 }

--- a/07-concurrency/01-concurrency/01-context/06-afterfunc/README.md
+++ b/07-concurrency/01-concurrency/01-context/06-afterfunc/README.md
@@ -1,0 +1,74 @@
+# CT.6 context.AfterFunc
+
+## Mission
+
+Schedule callbacks that fire when a context is cancelled, using `context.AfterFunc` for efficient one-shot cleanup and side-effect handling.
+
+## Prerequisites
+
+- `CT.2` with-cancel
+- `CT.3` with-timeout
+
+> [!NOTE]
+> In [CT.2 WithCancel](../02-with-cancel/README.md), you learned how to cancel contexts manually. In [CT.3 WithTimeout](../03-with-timeout/README.md), you learned how to set deadlines. `context.AfterFunc` builds on these by letting you attach callbacks that fire automatically on cancellation.
+
+## Mental Model
+
+Think of `AfterFunc` as setting an **alarm clock** that rings when the context is cancelled. Instead of starting a separate goroutine to watch `ctx.Done()`, you tell the context: "When someone pulls the plug, call this function." If the context is already cancelled when you register the callback, the alarm rings immediately.
+
+## Visual Model
+
+```mermaid
+sequenceDiagram
+    participant M as Main
+    participant C as Context
+    participant A as AfterFunc
+    participant CB as Callback
+    M->>C: WithTimeout(50ms)
+    M->>A: AfterFunc(ctx, callback)
+    Note over C: Timer running...
+    C-->>C: Timeout fires
+    C->>A: ctx done notification
+    A->>CB: goroutine starts
+    CB->>CB: cleanup / logging
+    CB-->>M: signals completion
+```
+
+## Machine View
+
+`AfterFunc` is more efficient than starting a goroutine with a `select` on `ctx.Done()` for a single callback. The Go runtime registers the callback directly on the context's internal cancellation list. When the context is cancelled, the runtime iterates the list and launches each callback in its own goroutine. This avoids the memory and scheduling overhead of an idle goroutine.
+
+## Run Instructions
+
+```bash
+go run ./07-concurrency/01-concurrency/01-context/06-afterfunc
+```
+
+## Code Walkthrough
+
+- **Timeout with cleanup**: `context.AfterFunc(ctx, callback)` registers a cleanup function that fires when the timeout expires. The callback runs in its own goroutine.
+- **Cancelled context**: If the context is already cancelled when `AfterFunc` is called, the callback fires immediately in a new goroutine.
+- **Stopping the callback**: `AfterFunc` returns a `stop` function. Calling `stop()` prevents the callback from firing if the context hasn't been cancelled yet.
+
+> [!TIP]
+> Use `AfterFunc` for side effects that should happen exactly once on cancellation. For polling or multiple events, use a goroutine with `select` on `ctx.Done()`. Next, in [TM.1 Time](../../04-time-and-scheduling/01-time/README.md), you'll learn the `time` package for scheduling and duration manipulation.
+
+## Try It
+
+1. Change the timeout from `50ms` to `200ms` and observe how the callback timing changes.
+2. Remove the `stop()` call in the third example and verify that the callback still fires even though the context is cancelled afterward.
+3. Use `AfterFunc` on a `context.WithCancel` and call `cancel()` manually to trigger the callback.
+
+## In Production
+
+`AfterFunc` is used for database connection pool cleanup on request cancellation, cache invalidation when a context times out, and recording metrics when an operation is cancelled. Because it avoids idle goroutines, it's the preferred pattern for single-shot cancellation side effects in high-throughput services.
+
+## Thinking Questions
+
+1. Why does `AfterFunc` run the callback in a new goroutine instead of synchronously?
+2. What happens if the callback passed to `AfterFunc` blocks indefinitely?
+3. How is `AfterFunc` different from a goroutine with `<-ctx.Done()` in a `select` statement?
+
+## Next Step
+
+Next: `TM.1` -> [`07-concurrency/01-concurrency/04-time-and-scheduling/01-time`](../../04-time-and-scheduling/01-time/README.md)

--- a/07-concurrency/01-concurrency/01-context/06-afterfunc/main.go
+++ b/07-concurrency/01-concurrency/01-context/06-afterfunc/main.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Rasel Hossen
+// Licensed under The Go Engineer License v1.0
+
+// ============================================================================
+// Section 07: Concurrency
+// Title: context.AfterFunc
+// Level: Core
+// ============================================================================
+//
+// WHAT YOU'LL LEARN:
+//   - Schedule a callback function to run when a context is cancelled.
+//   - Use context.AfterFunc to trigger cleanup, logging, or fallback actions.
+//   - Understand the difference between AfterFunc and goroutines on ctx.Done().
+//
+// WHY THIS MATTERS:
+//   context.AfterFunc (Go 1.21+) lets you attach side effects to context
+//   cancellation without starting a dedicated goroutine. It's more efficient
+//   than a select-on-ctx.Done() pattern when you only need a single callback.
+//
+// RUN:
+//   go run ./07-concurrency/01-concurrency/01-context/06-afterfunc
+//
+// KEY TAKEAWAY:
+//   - AfterFunc schedules one callback when a context is cancelled.
+//   - The callback runs in its own goroutine — do not block on it.
+//   - If the context is already done, the callback fires immediately.
+//   - Call the returned stop function to cancel the callback if it hasn't fired.
+// ============================================================================
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func main() {
+	// Example 1: AfterFunc with WithTimeout
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+
+	stop := context.AfterFunc(ctx, func() {
+		fmt.Println("[AfterFunc] Timeout reached — cleaning up resources...")
+		close(done)
+	})
+	defer stop()
+
+	fmt.Println("Waiting for timeout...")
+	<-done
+	fmt.Println("Main: AfterFunc completed.")
+	fmt.Println()
+
+	// Example 2: AfterFunc fires immediately if context is already done.
+	cancelledCtx, cancelNow := context.WithCancel(context.Background())
+	cancelNow() // ctx is already cancelled
+
+	fired := false
+	stop2 := context.AfterFunc(cancelledCtx, func() {
+		fired = true
+	})
+	defer stop2()
+
+	// The AfterFunc should fire almost immediately since the context is done.
+	time.Sleep(10 * time.Millisecond)
+	fmt.Printf("AfterFunc on cancelled context fired: %v\n", fired)
+	fmt.Println()
+
+	// Example 3: Cancelling the AfterFunc via stop.
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	didNotFire := true
+	stop3 := context.AfterFunc(ctx2, func() {
+		didNotFire = false
+	})
+	stop3() // Cancel the callback before the context is cancelled.
+	cancel2()
+	time.Sleep(5 * time.Millisecond)
+	fmt.Printf("Stopped AfterFunc did not fire: %v\n", didNotFire)
+
+	fmt.Println()
+	fmt.Println("---------------------------------------------------")
+	fmt.Println("NEXT UP: TM.1 -> 07-concurrency/01-concurrency/04-time-and-scheduling/01-time")
+	fmt.Println("Run    : go run ./07-concurrency/01-concurrency/04-time-and-scheduling/01-time")
+	fmt.Println("Current: CT.6 (afterfunc)")
+	fmt.Println("---------------------------------------------------")
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Master Go backend engineering by moving from machine fundamentals to a productio
 
 The Go Engineer is a repository-first learning system with:
 
-- 215 registered curriculum items
+- 219 registered curriculum items
 - 12 locked sections from fundamentals to production systems
 - runnable Go lessons and exercises
 - tests, race checks, coverage, CI, and curriculum validation

--- a/curriculum.v2.json
+++ b/curriculum.v2.json
@@ -861,6 +861,50 @@
       "test_command": "go test ./02-language-basics/04-data-structures/06-contact-manager",
       "starter_path": "02-language-basics/04-data-structures/06-contact-manager/_starter",
       "next_items": [
+        "DS.7"
+      ]
+    },
+    {
+      "id": "DS.7",
+      "section_id": "s02",
+      "slug": "slices-stdlib",
+      "title": "The slices package",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "core",
+      "status": "implemented",
+      "verification_mode": "run",
+      "path": "02-language-basics/04-data-structures/07-slices",
+      "prerequisites": [
+        "DS.2",
+        "DS.5"
+      ],
+      "run_command": "go run ./02-language-basics/04-data-structures/07-slices",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
+        "DS.8"
+      ]
+    },
+    {
+      "id": "DS.8",
+      "section_id": "s02",
+      "slug": "maps-stdlib",
+      "title": "The maps package",
+      "type": "lesson",
+      "subtype": "concept",
+      "level": "core",
+      "status": "implemented",
+      "verification_mode": "run",
+      "path": "02-language-basics/04-data-structures/08-maps",
+      "prerequisites": [
+        "DS.3",
+        "DS.7"
+      ],
+      "run_command": "go run ./02-language-basics/04-data-structures/08-maps",
+      "test_command": "",
+      "starter_path": "",
+      "next_items": [
         "FE.1"
       ]
     },
@@ -2755,6 +2799,28 @@
       "run_command": "go run ./07-concurrency/01-concurrency/01-context/05-timeout-client",
       "test_command": "go test ./07-concurrency/01-concurrency/01-context/05-timeout-client",
       "starter_path": "07-concurrency/01-concurrency/01-context/05-timeout-client/_starter",
+      "next_items": [
+        "CT.6"
+      ]
+    },
+    {
+      "id": "CT.6",
+      "section_id": "s07",
+      "slug": "context-afterfunc",
+      "title": "context.AfterFunc",
+      "type": "lesson",
+      "subtype": "pattern",
+      "level": "core",
+      "status": "implemented",
+      "verification_mode": "run",
+      "path": "07-concurrency/01-concurrency/01-context/06-afterfunc",
+      "prerequisites": [
+        "CT.2",
+        "CT.3"
+      ],
+      "run_command": "go run ./07-concurrency/01-concurrency/01-context/06-afterfunc",
+      "test_command": "",
+      "starter_path": "",
       "next_items": [
         "TM.1"
       ]


### PR DESCRIPTION
Closes #512

## Scope
- Section: s02, s04, s07
- New lessons: DS.7 (slices), DS.8 (maps), CT.6 (context.AfterFunc)
- Updated: TI.9 (generics — added cmp.Compare/cmp.Less), README.md (item count 215 → 219)

## Type
- [x] [FEAT]

## Summary
Adds 4 missing Go 1.21+ standard library topics identified in the extended audit:

| Lesson | Package | Key API coverage |
|---|---|---|
| DS.7 slices | `slices` | Sort, Compact, BinarySearch, Contains, Index, Delete, Insert, Clone, Equal |
| DS.8 maps | `maps` | Clone, Copy, Keys, Values, DeleteFunc, Equal |
| CT.6 AfterFunc | `context` | AfterFunc scheduling, stop(), immediate-fire |
| TI.9 integration | `cmp` | Compare, Less with cmp.Ordered constraint |

## Validation
- [x] go build ./... — pass
- [x] go vet ./... — pass
- [x] gofmt — all clean
- [x] go test ./... — all pass (59 suites)
- [x] go run ./scripts/validate_curriculum.go — 613 files, 12 sections, 219 items — success
