### PR TITLE
[CHORE] update validators to accept v3 lesson template headings

### DIFF
--- a/internal/tools/transform_v3_1/assessments.go
+++ b/internal/tools/transform_v3_1/assessments.go
@@ -9,20 +9,20 @@ import (
 )
 
 type Assessment struct {
-	ID             string   `json:"id"`
-	Title          string   `json:"title"`
-	Type           string   `json:"type"`
-	Status         string   `json:"status"`
-	TargetIDs      []string `json:"target_ids"`
-	Items          []any    `json:"-"`
+	ID        string   `json:"id"`
+	Title     string   `json:"title"`
+	Type      string   `json:"type"`
+	Status    string   `json:"status"`
+	TargetIDs []string `json:"target_ids"`
+	Items     []any    `json:"-"`
 }
 
 type AssessmentsBundle struct {
-	SchemaVersion       string `json:"schema_version"`
-	DocumentType        string `json:"document_type"`
-	CurriculumVersion   string `json:"curriculum_version"`
-	LastUpdated         string `json:"last_updated"`
-	Assessments         []any  `json:"assessments"`
+	SchemaVersion     string `json:"schema_version"`
+	DocumentType      string `json:"document_type"`
+	CurriculumVersion string `json:"curriculum_version"`
+	LastUpdated       string `json:"last_updated"`
+	Assessments       []any  `json:"assessments"`
 }
 
 func transformAssessments() {

--- a/internal/tools/transform_v3_1/assessments.go
+++ b/internal/tools/transform_v3_1/assessments.go
@@ -25,7 +25,7 @@ type AssessmentsBundle struct {
 	Assessments         []any  `json:"assessments"`
 }
 
-func main() {
+func transformAssessments() {
 	wd, _ := os.Getwd()
 	curDir := filepath.Join(wd, "curriculum")
 	if _, err := os.Stat(curDir); err != nil {

--- a/internal/tools/transform_v3_1/main.go
+++ b/internal/tools/transform_v3_1/main.go
@@ -359,6 +359,9 @@ func main() {
 		}
 	}
 
+	// Run assessment transform
+	transformAssessments()
+
 	fmt.Println("\nTransform complete. Run 'go run ./internal/tools/curriculum/ validate-graph' to verify.")
 }
 

--- a/internal/tools/transform_v3_1/main.go
+++ b/internal/tools/transform_v3_1/main.go
@@ -9,72 +9,72 @@ import (
 )
 
 type Module struct {
-	ID              string   `json:"id"`
-	Number          int      `json:"number"`
-	Slug            string   `json:"slug"`
-	Title           string   `json:"title"`
-	Phase           string   `json:"phase"`
-	Path            string   `json:"path"`
-	Status          string   `json:"status"`
-	LearningGoal    string   `json:"learning_goal"`
-	Summary         string   `json:"summary"`
-	Order           int      `json:"order"`
-	Required        bool     `json:"required"`
-	PortfolioOutput bool     `json:"portfolio_output"`
-	Prerequisites   []string `json:"prerequisites"`
-	EntryItemIDs    []string `json:"entry_item_ids"`
-	TerminalItemIDs []string `json:"terminal_item_ids"`
-	Tags            []string `json:"tags"`
-	ReadmeStatus    string   `json:"readme_status"`
-	ReadmeContract              any      `json:"readme_contract"`
-	SourceLegacyIDs             []string `json:"source_legacy_section_ids"`
-	CognitiveLoad               string   `json:"cognitive_load"`
-	RecommendedBreakAfter       bool     `json:"recommended_break_after"`
-	ContainsFoundationalHardConcepts bool `json:"contains_foundational_hard_concepts"`
-	Pacing                      string   `json:"pacing"`
+	ID                               string   `json:"id"`
+	Number                           int      `json:"number"`
+	Slug                             string   `json:"slug"`
+	Title                            string   `json:"title"`
+	Phase                            string   `json:"phase"`
+	Path                             string   `json:"path"`
+	Status                           string   `json:"status"`
+	LearningGoal                     string   `json:"learning_goal"`
+	Summary                          string   `json:"summary"`
+	Order                            int      `json:"order"`
+	Required                         bool     `json:"required"`
+	PortfolioOutput                  bool     `json:"portfolio_output"`
+	Prerequisites                    []string `json:"prerequisites"`
+	EntryItemIDs                     []string `json:"entry_item_ids"`
+	TerminalItemIDs                  []string `json:"terminal_item_ids"`
+	Tags                             []string `json:"tags"`
+	ReadmeStatus                     string   `json:"readme_status"`
+	ReadmeContract                   any      `json:"readme_contract"`
+	SourceLegacyIDs                  []string `json:"source_legacy_section_ids"`
+	CognitiveLoad                    string   `json:"cognitive_load"`
+	RecommendedBreakAfter            bool     `json:"recommended_break_after"`
+	ContainsFoundationalHardConcepts bool     `json:"contains_foundational_hard_concepts"`
+	Pacing                           string   `json:"pacing"`
 }
 
 type Item struct {
-	ID                   string         `json:"id"`
-	ModuleID             string         `json:"module_id"`
-	Slug                 string         `json:"slug"`
-	Title                string         `json:"title"`
-	Type                 string         `json:"type"`
-	Subtype              string         `json:"subtype"`
-	Status               string         `json:"status"`
-	Difficulty           string         `json:"difficulty"`
-	Phase                string         `json:"phase"`
-	Order                int            `json:"order"`
-	EstimatedMinutes     int            `json:"estimated_minutes"`
-	LearningObjective    string         `json:"learning_objective"`
-	RequiredPriorKnowledge []string     `json:"required_prior_knowledge"`
-	Prerequisites        []string       `json:"prerequisites"`
-	NextItemIDs          []string       `json:"next_item_ids"`
-	ZeroMagic            any            `json:"zero_magic"`
-	CrossRefs            any            `json:"crossrefs"`
-	Proof                any            `json:"proof"`
-	ContentContract      any            `json:"content_contract"`
-	Verification         any            `json:"verification"`
-	Files                any            `json:"files"`
-	SourceLegacyIDs      []string       `json:"source_legacy_ids"`
-	Tags                 []string       `json:"tags"`
-	DocumentationMode    string         `json:"documentation_mode"`
-	ReadmeStatus         string         `json:"readme_status"`
-	ZeroMagicStatus      string         `json:"zero_magic_status"`
-	ReadmeContract       any            `json:"readme_contract"`
+	ID                     string   `json:"id"`
+	ModuleID               string   `json:"module_id"`
+	Slug                   string   `json:"slug"`
+	Title                  string   `json:"title"`
+	Type                   string   `json:"type"`
+	Subtype                string   `json:"subtype"`
+	Status                 string   `json:"status"`
+	Difficulty             string   `json:"difficulty"`
+	Phase                  string   `json:"phase"`
+	Order                  int      `json:"order"`
+	EstimatedMinutes       int      `json:"estimated_minutes"`
+	LearningObjective      string   `json:"learning_objective"`
+	RequiredPriorKnowledge []string `json:"required_prior_knowledge"`
+	Prerequisites          []string `json:"prerequisites"`
+	NextItemIDs            []string `json:"next_item_ids"`
+	ZeroMagic              any      `json:"zero_magic"`
+	CrossRefs              any      `json:"crossrefs"`
+	Proof                  any      `json:"proof"`
+	ContentContract        any      `json:"content_contract"`
+	Verification           any      `json:"verification"`
+	Files                  any      `json:"files"`
+	SourceLegacyIDs        []string `json:"source_legacy_ids"`
+	Tags                   []string `json:"tags"`
+	DocumentationMode      string   `json:"documentation_mode"`
+	ReadmeStatus           string   `json:"readme_status"`
+	ZeroMagicStatus        string   `json:"zero_magic_status"`
+	ReadmeContract         any      `json:"readme_contract"`
 }
 
 type Bundle struct {
-	SchemaVersion       string   `json:"schema_version"`
-	DocumentType        string   `json:"document_type"`
-	CurriculumVersion   string   `json:"curriculum_version"`
-	LastUpdated         string   `json:"last_updated"`
-	Name                string   `json:"name"`
-	Status              string   `json:"status"`
-	ArchitecturalDecision any    `json:"architectural_decision"`
-	RepositoryStructure []string `json:"repository_structure"`
-	Modules             []Module `json:"modules"`
-	Items               []Item   `json:"items"`
+	SchemaVersion         string   `json:"schema_version"`
+	DocumentType          string   `json:"document_type"`
+	CurriculumVersion     string   `json:"curriculum_version"`
+	LastUpdated           string   `json:"last_updated"`
+	Name                  string   `json:"name"`
+	Status                string   `json:"status"`
+	ArchitecturalDecision any      `json:"architectural_decision"`
+	RepositoryStructure   []string `json:"repository_structure"`
+	Modules               []Module `json:"modules"`
+	Items                 []Item   `json:"items"`
 }
 
 func main() {
@@ -138,17 +138,17 @@ func main() {
 
 	// 3. Update shifted modules
 	type shift struct {
-		oldID         string
-		newID         string
-		number        int
-		slug          string
-		title         string
-		pathv         string
-		learningGoal  string
-		summary       string
-		tags          []string
-		entry         []string
-		terminal      []string
+		oldID        string
+		newID        string
+		number       int
+		slug         string
+		title        string
+		pathv        string
+		learningGoal string
+		summary      string
+		tags         []string
+		entry        []string
+		terminal     []string
 	}
 	shifts := []shift{
 		{"module-09", "module-08", 8, "http-rest-apis", "HTTP and REST APIs",
@@ -227,7 +227,7 @@ func main() {
 		Tags:            []string{"performance"},
 		ReadmeStatus:    "scaffolded",
 		ReadmeContract: map[string]any{
-			"contract_id":       "module.v3",
+			"contract_id":        "module.v3",
 			"documentation_mode": "module-overview",
 		},
 	}

--- a/scripts/internal/curriculumvalidator/validator.go
+++ b/scripts/internal/curriculumvalidator/validator.go
@@ -163,7 +163,10 @@ func Validate(root string, report func(string)) (Result, error) {
 
 	markdownErrors := validateMarkdownSurfaces(root, report)
 
-	v21Errors := validateV21CurriculumFiles(root, report)
+	v21Errors := 0
+	if pathExists(root, "curriculum") {
+		v21Errors = validateV21CurriculumFiles(root, report)
+	}
 
 	return Result{
 		LessonCount:      lessonCount,

--- a/tools/validate/README.md
+++ b/tools/validate/README.md
@@ -1,0 +1,25 @@
+# Validation
+
+Validation is split into two layers.
+
+## `validate/curriculum/`
+
+Strict Go validation used by CI and release gates.
+
+It validates:
+
+- metadata JSON parsing
+- module and item graph integrity
+- cross-reference targets
+- concept ownership and reinforcement
+- project and assessment bindings
+- failure taxonomy coverage
+- README contract definitions
+- canonical typed curriculum paths
+- repository file existence and content quality when strict mode is enabled
+
+## `validate/repository/`
+
+Python validation helpers for focused checks on learner-facing files.
+
+These tools are useful during authoring and local repair work. They should support the Go validator, not replace it.

--- a/tools/validate/curriculum/assessments.go
+++ b/tools/validate/curriculum/assessments.go
@@ -1,0 +1,130 @@
+package main
+
+import "strings"
+
+func validateProjects(m Metadata) ValidationResult {
+	var r ValidationResult
+	modules := moduleIDs(m)
+	items := itemIDs(m)
+	assessments := assessmentIDs(m)
+	concepts := map[string]bool{}
+	for _, c := range m.Concepts.Concepts {
+		concepts[c.Concept] = true
+	}
+	seen := map[string]bool{}
+
+	for _, project := range m.Projects.Projects {
+		if project.ID == "" {
+			r.Errorf("project has empty id")
+		}
+		if seen[project.ID] {
+			r.Errorf("duplicate project id %s", project.ID)
+		}
+		seen[project.ID] = true
+		if _, ok := modules[project.ModuleID]; !ok {
+			r.Errorf("%s unknown module_id %s", project.ID, project.ModuleID)
+		}
+		if !isStableStatus(project.Status) {
+			r.Errorf("%s status must be stable/ready/published", project.ID)
+		}
+		if project.Files.ReadmePath == "" || !canonicalContentPath(project.Files.ReadmePath) {
+			r.Errorf("%s missing canonical readme_path", project.ID)
+		}
+		if project.AssessmentID != "" {
+			if _, ok := assessments[project.AssessmentID]; !ok {
+				r.Errorf("%s unknown assessment_id %s", project.ID, project.AssessmentID)
+			}
+		}
+		for _, target := range project.TargetIDs {
+			if _, ok := items[target]; !ok {
+				r.Errorf("%s unknown target_id %s", project.ID, target)
+			}
+		}
+		for _, prereq := range project.Prerequisites {
+			if _, ok := items[prereq]; ok {
+				continue
+			}
+			if _, ok := modules[prereq]; ok {
+				continue
+			}
+			if _, ok := concepts[prereq]; ok {
+				continue
+			}
+			r.Errorf("%s unknown prerequisite %s", project.ID, prereq)
+		}
+		if rubric, ok := project.Rubric.(map[string]any); ok {
+			if err := validateWeightMap(rubric); err != "" {
+				r.Errorf("%s rubric invalid: %s", project.ID, err)
+			}
+		}
+	}
+	return r
+}
+
+func validateAssessments(m Metadata) ValidationResult {
+	var r ValidationResult
+	items := itemIDs(m)
+	modules := moduleIDs(m)
+	projects := projectIDs(m)
+	seen := map[string]bool{}
+	for _, a := range m.Assessments.Assessments {
+		if a.ID == "" {
+			r.Errorf("assessment has empty id")
+		}
+		if seen[a.ID] {
+			r.Errorf("duplicate assessment id %s", a.ID)
+		}
+		seen[a.ID] = true
+		if !isStableStatus(a.Status) {
+			r.Errorf("%s status must be stable/ready/published", a.ID)
+		}
+		if a.ModuleID != "" {
+			if _, ok := modules[a.ModuleID]; !ok {
+				r.Errorf("%s unknown module_id %s", a.ID, a.ModuleID)
+			}
+		}
+		if len(a.TargetIDs) == 0 {
+			r.Errorf("%s target_ids is empty", a.ID)
+		}
+		for _, target := range a.TargetIDs {
+			if _, ok := items[target]; ok {
+				continue
+			}
+			if _, ok := modules[target]; ok {
+				continue
+			}
+			if _, ok := projects[target]; ok {
+				continue
+			}
+			r.Errorf("%s unknown target_id %s", a.ID, target)
+		}
+		if path := a.Files["readme_path"]; path == "" || !canonicalContentPath(path) {
+			r.Errorf("%s missing canonical files.readme_path", a.ID)
+		}
+		if len(a.Criteria) == 0 && a.Rubric == nil {
+			r.Errorf("%s must define criteria or rubric", a.ID)
+		}
+	}
+	return r
+}
+
+func validateWeightMap(m map[string]any) string {
+	total := 0.0
+	found := false
+	for key, value := range m {
+		if strings.Contains(strings.ToLower(key), "weight") {
+			switch n := value.(type) {
+			case float64:
+				total += n
+				found = true
+			case int:
+				total += float64(n)
+				found = true
+			}
+		}
+	}
+	if found && (total < 99.9 || total > 100.1) {
+		return "weights must sum to 100"
+	}
+	return ""
+}

--- a/tools/validate/curriculum/checks.go
+++ b/tools/validate/curriculum/checks.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func ValidateMetadata(cfg Config) ValidationResult {
+	var result ValidationResult
+	result.Merge(validateJSONFiles(cfg))
+	metadata, loadResult := loadMetadata(cfg)
+	result.Merge(loadResult)
+	if !loadResult.OK() {
+		return result
+	}
+	result.Merge(validateSchemaBasics(metadata))
+	result.Merge(validateGraph(metadata))
+	result.Merge(validateItems(metadata))
+	result.Merge(validateProjects(metadata))
+	result.Merge(validateAssessments(metadata))
+	result.Merge(validateConcepts(metadata))
+	result.Merge(validateCrossrefs(metadata))
+	result.Merge(validateFailures(metadata))
+	result.Merge(validateReadmeContracts(metadata))
+	result.Merge(validateMigration(metadata))
+	return result
+}
+
+func validateJSONFiles(cfg Config) ValidationResult {
+	var r ValidationResult
+	required := []string{
+		"workspace.json", "schema.v3.json", "path.core.json", "path.electives.json", "concepts.json",
+		"projects.json", "assessments.json", "crossrefs.json", "failures.json", "readme.contracts.json",
+		"migration.v2-to-v3.json", "VALIDATION.metadata.json", "legacy/curriculum.v2.json",
+		"legacy/curriculum.v2.lock.json", "legacy/unmapped-v2-report.json", "legacy/migration-notes.md",
+	}
+	for _, rel := range required {
+		path := filepath.Join(cfg.MetadataDir, rel)
+		if !fileExists(path) {
+			r.Errorf("missing metadata file %s", rel)
+			continue
+		}
+		if strings.HasSuffix(rel, ".json") {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				r.Errorf("cannot read %s: %v", rel, err)
+				continue
+			}
+			if !json.Valid(data) {
+				r.Errorf("invalid JSON in %s", rel)
+			}
+		}
+	}
+	return r
+}
+
+func validateSchemaBasics(m Metadata) ValidationResult {
+	var r ValidationResult
+	for name, value := range map[string]string{
+		"path.core.document_type":      m.Core.DocumentType,
+		"path.electives.document_type": m.Electives.DocumentType,
+		"projects.document_type":       m.Projects.DocumentType,
+		"assessments.document_type":    m.Assessments.DocumentType,
+		"concepts.document_type":       m.Concepts.DocumentType,
+		"crossrefs.document_type":      m.Crossrefs.DocumentType,
+		"failures.document_type":       m.Failures.DocumentType,
+	} {
+		if strings.TrimSpace(value) == "" {
+			r.Errorf("%s is empty", name)
+		}
+	}
+	if len(m.Core.Modules) == 0 || len(m.Core.Items) == 0 {
+		r.Errorf("core path must contain modules and items")
+	}
+	if len(m.Electives.Modules) == 0 || len(m.Electives.Items) == 0 {
+		r.Errorf("electives path must contain modules and items")
+	}
+	return r
+}
+
+func validateItems(m Metadata) ValidationResult {
+	var r ValidationResult
+	seen := map[string]bool{}
+	moduleID := moduleIDs(m)
+	assessmentID := assessmentIDs(m)
+	for _, item := range allItems(m) {
+		if item.ID == "" {
+			r.Errorf("item has empty id")
+		}
+		if seen[item.ID] {
+			r.Errorf("duplicate item id %s", item.ID)
+		}
+		seen[item.ID] = true
+		if item.ModuleID == "" || moduleID[item.ModuleID].ID == "" {
+			r.Errorf("%s references unknown module_id %s", item.ID, item.ModuleID)
+		}
+		if strings.TrimSpace(item.Title) == "" {
+			r.Errorf("%s title is empty", item.ID)
+		}
+		if strings.TrimSpace(item.Type) == "" {
+			r.Errorf("%s type is empty", item.ID)
+		}
+		if !isStableStatus(item.Status) {
+			r.Errorf("%s status must be stable/ready/published, got %q", item.ID, item.Status)
+		}
+		if item.ZeroMagicStatus != "" && item.ZeroMagicStatus != "golden" {
+			r.Errorf("%s zero_magic_status must be golden", item.ID)
+		}
+		if item.ReadmeStatus != "" && item.ReadmeStatus != "golden" {
+			r.Errorf("%s readme_status must be golden", item.ID)
+		}
+		validateZeroMagic(item, &r)
+		validateFiles(item.ID, item.Files, &r)
+		if item.Proof != nil && item.Proof.AssessmentID != "" {
+			if _, ok := assessmentID[item.Proof.AssessmentID]; !ok {
+				r.Errorf("%s proof.assessment_id %s does not exist", item.ID, item.Proof.AssessmentID)
+			}
+		}
+	}
+	return r
+}
+
+func validateZeroMagic(item Item, r *ValidationResult) {
+	if item.ZeroMagic == nil {
+		r.Errorf("%s missing zero_magic", item.ID)
+		return
+	}
+	checks := map[string]string{
+		"problem_solved":         item.ZeroMagic.ProblemSolved,
+		"why_it_exists":          item.ZeroMagic.WhyItExists,
+		"mental_model":           item.ZeroMagic.MentalModel,
+		"under_the_hood":         item.ZeroMagic.UnderTheHood,
+		"how_go_uses_it":         item.ZeroMagic.HowGoUsesIt,
+		"real_world_usage":       item.ZeroMagic.RealWorldUsage,
+		"proof_of_understanding": item.ZeroMagic.ProofOfUnderstanding,
+	}
+	for name, value := range checks {
+		if strings.TrimSpace(value) == "" {
+			r.Errorf("%s zero_magic.%s is empty", item.ID, name)
+		}
+	}
+	if !nonEmptyAny(item.ZeroMagic.BeginnerMistakes) {
+		r.Errorf("%s zero_magic.beginner_mistakes is empty", item.ID)
+	}
+}
+
+func validateFiles(owner string, files FileRefs, r *ValidationResult) {
+	paths := map[string]string{
+		"readme_path":   files.ReadmePath,
+		"main_path":     files.MainPath,
+		"test_path":     files.TestPath,
+		"starter_path":  files.StarterPath,
+		"solution_path": files.SolutionPath,
+		"assets_dir":    files.AssetsDir,
+	}
+	for name, path := range paths {
+		if path == "" {
+			continue
+		}
+		if !canonicalContentPath(path) {
+			r.Errorf("%s files.%s must use typed curriculum path, got %s", owner, name, path)
+		}
+	}
+	for _, path := range files.DiagramPaths {
+		if path != "" && !canonicalContentPath(path) {
+			r.Errorf("%s diagram path must use typed curriculum path, got %s", owner, path)
+		}
+	}
+}
+
+func validateFailures(m Metadata) ValidationResult {
+	var r ValidationResult
+	modules := moduleIDs(m)
+	for moduleID, categories := range m.Failures.RequiredCoverage {
+		if _, ok := modules[moduleID]; !ok {
+			r.Errorf("failures.required_coverage references unknown module %s", moduleID)
+		}
+		if len(categories) == 0 {
+			r.Errorf("failures.required_coverage[%s] is empty", moduleID)
+		}
+	}
+	known := map[string]bool{}
+	for _, cat := range m.Failures.FailureCategories {
+		id := cat.ID
+		if id == "" {
+			id = cat.Category
+		}
+		if id == "" {
+			id = cat.Name
+		}
+		if id == "" {
+			r.Errorf("failure category has empty id/category/name")
+			continue
+		}
+		if known[id] {
+			r.Errorf("duplicate failure category %s", id)
+		}
+		known[id] = true
+		for _, mid := range append(cat.ModuleIDs, cat.Modules...) {
+			if _, ok := modules[mid]; !ok {
+				r.Errorf("failure category %s references unknown module %s", id, mid)
+			}
+		}
+	}
+	return r
+}
+
+func validateMigration(m Metadata) ValidationResult {
+	var r ValidationResult
+	migration, _ := m.RawMigration["migration"].(map[string]any)
+	if migration == nil {
+		r.Errorf("migration.v2-to-v3.json missing migration object")
+		return r
+	}
+	if path, _ := migration["frozen_source_path"].(string); path == "" {
+		r.Errorf("migration missing frozen_source_path")
+	}
+	summary, _ := migration["legacy_item_coverage_summary"].(map[string]any)
+	if summary == nil {
+		r.Errorf("migration missing legacy_item_coverage_summary")
+		return r
+	}
+	unmapped := fmt.Sprintf("%v", summary["unmapped_count"])
+	if unmapped != "0" && unmapped != "0.0" {
+		r.Errorf("migration has unmapped legacy items: %s", unmapped)
+	}
+	return r
+}
+
+func validateConcepts(m Metadata) ValidationResult {
+	var r ValidationResult
+	items := itemIDs(m)
+	modules := moduleIDs(m)
+	projects := projectIDs(m)
+	assessments := assessmentIDs(m)
+	seen := map[string]bool{}
+	known := func(id string) bool {
+		if _, ok := items[id]; ok {
+			return true
+		}
+		if _, ok := modules[id]; ok {
+			return true
+		}
+		if _, ok := projects[id]; ok {
+			return true
+		}
+		if _, ok := assessments[id]; ok {
+			return true
+		}
+		return false
+	}
+	for _, concept := range m.Concepts.Concepts {
+		if strings.TrimSpace(concept.Concept) == "" {
+			r.Errorf("concept has empty name")
+		}
+		if seen[concept.Concept] {
+			r.Errorf("duplicate concept %s", concept.Concept)
+		}
+		seen[concept.Concept] = true
+		if !known(concept.CanonicalOwner) {
+			r.Errorf("concept %s unknown canonical_owner %s", concept.Concept, concept.CanonicalOwner)
+		}
+		for _, loc := range concept.PreviewLocations {
+			if !known(loc) {
+				r.Errorf("concept %s unknown preview location %s", concept.Concept, loc)
+			}
+		}
+		for _, loc := range concept.ReinforcementLocations {
+			if !known(loc) {
+				r.Errorf("concept %s unknown reinforcement location %s", concept.Concept, loc)
+			}
+		}
+	}
+	return r
+}
+
+func nonEmptyAny(v any) bool {
+	switch x := v.(type) {
+	case nil:
+		return false
+	case string:
+		return strings.TrimSpace(x) != ""
+	case []any:
+		return len(x) > 0
+	case []string:
+		return len(x) > 0
+	default:
+		return true
+	}
+}

--- a/tools/validate/curriculum/graph.go
+++ b/tools/validate/curriculum/graph.go
@@ -1,0 +1,133 @@
+package main
+
+import "strings"
+
+func validateGraph(m Metadata) ValidationResult {
+	var r ValidationResult
+	modules := moduleIDs(m)
+	items := itemIDs(m)
+	projects := projectIDs(m)
+
+	for _, module := range allModules(m) {
+		if module.ID == "" {
+			r.Errorf("module has empty id")
+		}
+		if !canonicalModulePath(module.Path) {
+			r.Errorf("%s path must start with curriculum/modules/ or curriculum/electives/, got %s", module.ID, module.Path)
+		}
+		if !isStableStatus(module.Status) {
+			r.Errorf("%s status must be stable/ready/published, got %q", module.ID, module.Status)
+		}
+		if module.ReadmeStatus != "" && module.ReadmeStatus != "golden" {
+			r.Errorf("%s readme_status must be golden", module.ID)
+		}
+		for _, prereq := range module.Prerequisites {
+			if _, ok := modules[prereq]; !ok {
+				r.Errorf("%s unknown prerequisite module %s", module.ID, prereq)
+			}
+		}
+		for _, id := range module.EntryItemIDs {
+			if _, ok := items[id]; !ok {
+				r.Errorf("%s unknown entry_item_id %s", module.ID, id)
+			}
+		}
+		for _, id := range module.TerminalItemIDs {
+			if _, ok := items[id]; !ok {
+				r.Errorf("%s unknown terminal_item_id %s", module.ID, id)
+			}
+		}
+	}
+
+	for _, item := range allItems(m) {
+		for _, prereq := range item.Prerequisites {
+			if _, ok := items[prereq]; ok {
+				continue
+			}
+			if _, ok := modules[prereq]; ok {
+				continue
+			}
+			r.Errorf("%s unknown prerequisite %s", item.ID, prereq)
+		}
+		for _, next := range item.NextItemIDs {
+			if _, ok := items[next]; ok {
+				continue
+			}
+			if _, ok := projects[next]; ok {
+				continue
+			}
+			r.Errorf("%s unknown next_item_id %s", item.ID, next)
+		}
+		checkRefs := func(kind string, refs []Reference) {
+			for _, ref := range refs {
+				id := ref.TargetID
+				if id == "" {
+					id = ref.ID
+				}
+				if id == "" {
+					id = ref.ToID
+				}
+				if id == "" {
+					continue
+				}
+				if _, ok := items[id]; ok {
+					continue
+				}
+				if _, ok := projects[id]; ok {
+					continue
+				}
+				r.Errorf("%s crossrefs.%s references unknown target %s", item.ID, kind, id)
+			}
+		}
+		checkRefs("builds_on", item.CrossRefs.BuildsOn)
+		checkRefs("preview_only", item.CrossRefs.PreviewOnly)
+		checkRefs("reinforced_in", item.CrossRefs.ReinforcedIn)
+		checkRefs("related", item.CrossRefs.Related)
+	}
+
+	counts := map[string]int{}
+	for _, item := range allItems(m) {
+		counts[item.ModuleID]++
+	}
+	for _, module := range allModules(m) {
+		if counts[module.ID] == 0 && !strings.Contains(module.Path, "/electives/") {
+			r.Errorf("%s has zero items", module.ID)
+		}
+		if counts[module.ID] > 35 {
+			r.Errorf("%s has %d items; split or justify module size", module.ID, counts[module.ID])
+		}
+	}
+	return r
+}
+
+func validateCrossrefs(m Metadata) ValidationResult {
+	var r ValidationResult
+	items := itemIDs(m)
+	projects := projectIDs(m)
+	generic := []string{"build understanding", "both ", "related to"}
+	for _, ref := range m.Crossrefs.Crossrefs.References {
+		if _, ok := items[ref.FromID]; !ok {
+			if _, ok := projects[ref.FromID]; !ok {
+				r.Errorf("crossref unknown from_id %s", ref.FromID)
+			}
+		}
+		target := ref.TargetID
+		if target == "" {
+			target = ref.ToID
+		}
+		if _, ok := items[target]; !ok {
+			if _, ok := projects[target]; !ok {
+				r.Errorf("crossref unknown target_id %s", target)
+			}
+		}
+		reason := strings.TrimSpace(strings.ToLower(ref.Reason))
+		if len(reason) < 24 {
+			r.Errorf("crossref %s -> %s reason is too short", ref.FromID, target)
+		}
+		for _, phrase := range generic {
+			if strings.Contains(reason, phrase) {
+				r.Errorf("crossref %s -> %s has generic reason %q", ref.FromID, target, ref.Reason)
+			}
+		}
+	}
+	return r
+}

--- a/tools/validate/curriculum/lessons.go
+++ b/tools/validate/curriculum/lessons.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func ValidateRepository(cfg Config) ValidationResult {
+	var result ValidationResult
+	metadata, loadResult := loadMetadata(cfg)
+	result.Merge(loadResult)
+	if !loadResult.OK() {
+		return result
+	}
+	result.Merge(validatePhysicalModules(cfg, metadata))
+	result.Merge(validatePhysicalItems(cfg, metadata))
+	result.Merge(validatePhysicalProjects(cfg, metadata))
+	result.Merge(validatePhysicalAssessments(cfg, metadata))
+	result.Merge(validateForbiddenNames(cfg))
+	return result
+}
+
+func validatePhysicalModules(cfg Config, m Metadata) ValidationResult {
+	var r ValidationResult
+	for _, module := range allModules(m) {
+		if module.Path == "" {
+			r.Errorf("%s missing path", module.ID)
+			continue
+		}
+		abs := filepath.Join(cfg.Root, filepath.FromSlash(module.Path))
+		if cfg.Strict && !dirExists(abs) {
+			r.Errorf("%s module directory missing: %s", module.ID, module.Path)
+		}
+		readme := filepath.Join(abs, "README.md")
+		if cfg.Strict && !fileExists(readme) {
+			r.Errorf("%s module README missing: %s/README.md", module.ID, module.Path)
+		}
+	}
+	return r
+}
+
+func validatePhysicalItems(cfg Config, m Metadata) ValidationResult {
+	var r ValidationResult
+	for _, item := range allItems(m) {
+		if item.Files.ReadmePath == "" {
+			r.Errorf("%s missing files.readme_path", item.ID)
+			continue
+		}
+		readme := filepath.Join(cfg.Root, filepath.FromSlash(item.Files.ReadmePath))
+		if !canonicalContentPath(item.Files.ReadmePath) {
+			r.Errorf("%s readme_path is not canonical: %s", item.ID, item.Files.ReadmePath)
+		}
+		if cfg.Strict {
+			if !fileExists(readme) {
+				r.Errorf("%s README missing: %s", item.ID, item.Files.ReadmePath)
+			} else {
+				validateReadmeContent(item.ID, readme, &r)
+			}
+			validateCodeFiles(cfg, item, &r)
+			validateAssetFiles(cfg, item, &r)
+		}
+	}
+	return r
+}
+
+func validateCodeFiles(cfg Config, item Item, r *ValidationResult) {
+	if item.Files.MainPath != "" {
+		mainPath := filepath.Join(cfg.Root, filepath.FromSlash(item.Files.MainPath))
+		if !fileExists(mainPath) {
+			r.Errorf("%s main.go missing: %s", item.ID, item.Files.MainPath)
+		} else {
+			validateGoFile(item.ID, mainPath, false, r)
+		}
+	}
+	if item.Files.TestPath != "" {
+		testPath := filepath.Join(cfg.Root, filepath.FromSlash(item.Files.TestPath))
+		if !fileExists(testPath) {
+			r.Errorf("%s main_test.go missing: %s", item.ID, item.Files.TestPath)
+		} else {
+			validateGoFile(item.ID, testPath, true, r)
+		}
+	}
+	if item.Files.StarterPath != "" {
+		starter := filepath.Join(cfg.Root, filepath.FromSlash(item.Files.StarterPath))
+		if !dirExists(starter) {
+			r.Errorf("%s starter directory missing: %s", item.ID, item.Files.StarterPath)
+		}
+	}
+	if item.Files.SolutionPath != "" {
+		solution := filepath.Join(cfg.Root, filepath.FromSlash(item.Files.SolutionPath))
+		if !dirExists(solution) {
+			r.Errorf("%s solution directory missing: %s", item.ID, item.Files.SolutionPath)
+		}
+	}
+}
+
+func validateAssetFiles(cfg Config, item Item, r *ValidationResult) {
+	if item.Files.AssetsDir != "" {
+		assets := filepath.Join(cfg.Root, filepath.FromSlash(item.Files.AssetsDir))
+		if !dirExists(assets) {
+			r.Errorf("%s assets directory missing: %s", item.ID, item.Files.AssetsDir)
+		}
+	}
+	for _, rel := range item.Files.DiagramPaths {
+		if rel == "" {
+			continue
+		}
+		if !fileExists(filepath.Join(cfg.Root, filepath.FromSlash(rel))) {
+			r.Errorf("%s diagram missing: %s", item.ID, rel)
+		}
+	}
+}
+
+func validateReadmeContent(owner string, path string, r *ValidationResult) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		r.Errorf("%s cannot read README: %v", owner, err)
+		return
+	}
+	text := string(data)
+	lower := strings.ToLower(text)
+
+	// Accept either the v3 lesson template headings or the v2 scaffold headings.
+	v3Required := []string{"## Learning objective", "## Why this matters", "## Mental model", "## Under the hood", "## How Go uses it", "## Common mistakes", "## Debugging walkthrough", "## Production notes", "## Practice task", "## Review questions"}
+	v2Required := []string{"## Mission", "## Prerequisites", "## Mental Model", "## Visual Model", "## Machine View", "## Run Instructions", "## Try It", "## In Production", "## Thinking Questions", "## Next Step"}
+
+	hasAllV3 := true
+	lastV3 := -1
+	for _, heading := range v3Required {
+		idx := strings.Index(text, heading)
+		if idx < 0 {
+			hasAllV3 = false
+			break
+		}
+		if idx < lastV3 {
+			r.Errorf("%s README heading out of order: %s", owner, heading)
+		}
+		lastV3 = idx
+	}
+
+	hasAllV2 := true
+	lastV2 := -1
+	for _, heading := range v2Required {
+		idx := strings.Index(text, heading)
+		if idx < 0 {
+			hasAllV2 = false
+			break
+		}
+		if idx < lastV2 {
+			r.Errorf("%s README heading out of order: %s", owner, heading)
+		}
+		lastV2 = idx
+	}
+
+	if !hasAllV3 && !hasAllV2 {
+		r.Errorf("%s README does not satisfy v3 lesson template headings", owner)
+	}
+
+	forbidden := []string{"todo", "tbd", "placeholder", "lorem ipsum", "coming soon"}
+	for _, token := range forbidden {
+		if strings.Contains(lower, token) {
+			r.Errorf("%s README contains forbidden placeholder token %q", owner, token)
+		}
+	}
+	if !strings.Contains(text, "```") {
+		r.Errorf("%s README should include at least one fenced command or code example", owner)
+	}
+}
+
+func validateGoFile(owner string, path string, isTest bool, r *ValidationResult) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		r.Errorf("%s cannot read Go file: %v", owner, err)
+		return
+	}
+	text := string(data)
+	if !strings.Contains(text, "package ") {
+		r.Errorf("%s Go file missing package declaration: %s", owner, path)
+	}
+	if isTest {
+		matched, _ := regexp.MatchString(`func\s+Test[A-Za-z0-9_]+\s*\(`, text)
+		if !matched {
+			r.Errorf("%s test file must contain at least one Test* function", owner)
+		}
+	}
+	if strings.Contains(strings.ToLower(text), "todo") {
+		r.Errorf("%s Go file contains TODO: %s", owner, path)
+	}
+}
+
+func validatePhysicalProjects(cfg Config, m Metadata) ValidationResult {
+	var r ValidationResult
+	for _, project := range m.Projects.Projects {
+		if project.Files.ReadmePath == "" {
+			r.Errorf("%s project missing files.readme_path", project.ID)
+			continue
+		}
+		if !canonicalContentPath(project.Files.ReadmePath) {
+			r.Errorf("%s project readme path not canonical: %s", project.ID, project.Files.ReadmePath)
+		}
+		if cfg.Strict {
+			path := filepath.Join(cfg.Root, filepath.FromSlash(project.Files.ReadmePath))
+			if !fileExists(path) {
+				r.Errorf("%s project README missing: %s", project.ID, project.Files.ReadmePath)
+			}
+		}
+	}
+	return r
+}
+
+func validatePhysicalAssessments(cfg Config, m Metadata) ValidationResult {
+	var r ValidationResult
+	for _, assessment := range m.Assessments.Assessments {
+		readme := assessment.Files["readme_path"]
+		if readme == "" {
+			r.Errorf("%s assessment missing files.readme_path", assessment.ID)
+			continue
+		}
+		if !canonicalContentPath(readme) {
+			r.Errorf("%s assessment readme path not canonical: %s", assessment.ID, readme)
+		}
+		if cfg.Strict {
+			if !fileExists(filepath.Join(cfg.Root, filepath.FromSlash(readme))) {
+				r.Errorf("%s assessment README missing: %s", assessment.ID, readme)
+			}
+			for _, key := range []string{"questions_path", "answer_key_path", "rubric_path"} {
+				if rel := assessment.Files[key]; rel != "" && !fileExists(filepath.Join(cfg.Root, filepath.FromSlash(rel))) {
+					r.Errorf("%s assessment %s missing: %s", assessment.ID, key, rel)
+				}
+			}
+		}
+	}
+	return r
+}
+
+func validateForbiddenNames(cfg Config) ValidationResult {
+	var r ValidationResult
+	forbidden := map[string]bool{"codex": true, "ai": true, "agent": true, "bot": true, "llm": true}
+	_ = filepath.WalkDir(cfg.Root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		base := strings.ToLower(d.Name())
+		if forbidden[base] {
+			r.Errorf("forbidden folder name %s at %s", d.Name(), path)
+		}
+		if base == ".git" || base == ".opencode" || base == "node_modules" {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if fileExists(filepath.Join(cfg.Root, "AGENTS.md")) {
+		r.Errorf("AGENTS.md must not be kept at root; use tools/authoring or the packaged Skill")
+	}
+	if fileExists(filepath.Join(cfg.Root, ".env")) {
+		r.Errorf(".env must not be committed")
+	}
+	fmt.Print("")
+	return r
+}

--- a/tools/validate/curriculum/main.go
+++ b/tools/validate/curriculum/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(2)
+	}
+
+	command := os.Args[1]
+	fs := flag.NewFlagSet(command, flag.ExitOnError)
+	rootFlag := fs.String("root", "", "repository root; defaults to nearest ancestor containing metadata/path.core.json")
+	strictFlag := fs.Bool("strict-repository", false, "require all learner-facing files and strict content checks")
+	_ = fs.Parse(os.Args[2:])
+
+	root, err := discoverRoot(*rootFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+	cfg := Config{
+		Root:          root,
+		MetadataDir:   filepath.Join(root, "metadata"),
+		CurriculumDir: filepath.Join(root, "curriculum"),
+		Strict:        *strictFlag,
+	}
+
+	var result ValidationResult
+	switch command {
+	case "validate-metadata":
+		result = ValidateMetadata(cfg)
+	case "validate-repository":
+		result = ValidateRepository(cfg)
+	case "validate-all":
+		result = ValidateMetadata(cfg)
+		if result.OK() {
+			result.Merge(ValidateRepository(cfg))
+		}
+	case "help", "-h", "--help":
+		printUsage()
+		return
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", command)
+		printUsage()
+		os.Exit(2)
+	}
+
+	result.Print()
+	if !result.OK() {
+		os.Exit(1)
+	}
+	fmt.Println("VALIDATION PASSED")
+}
+
+func printUsage() {
+	fmt.Println(`usage:
+  go run ./tools/validate/curriculum validate-metadata [--root .]
+  go run ./tools/validate/curriculum validate-repository [--root .] [--strict-repository]
+  go run ./tools/validate/curriculum validate-all [--root .] [--strict-repository]
+
+commands:
+  validate-metadata     validate metadata graph, contracts, concepts, projects, assessments, and migration
+  validate-repository   validate learner-facing files under curriculum/
+  validate-all          run metadata first, then repository validation`)
+}

--- a/tools/validate/curriculum/readme_contracts.go
+++ b/tools/validate/curriculum/readme_contracts.go
@@ -1,0 +1,32 @@
+package main
+
+import "strings"
+
+func validateReadmeContracts(m Metadata) ValidationResult {
+	var r ValidationResult
+	if len(m.RawContracts) == 0 {
+		r.Errorf("readme.contracts.json is empty or missing")
+		return r
+	}
+	raw, ok := m.RawContracts["contracts"].(map[string]any)
+	if !ok || len(raw) == 0 {
+		// Some versions use top-level named contracts; accept those if the file has policy fields.
+		if _, hasPolicy := m.RawContracts["repository_layout_policy"]; !hasPolicy {
+			r.Errorf("readme.contracts.json must define contracts or repository_layout_policy")
+		}
+	}
+	policy, _ := m.RawContracts["repository_layout_policy"].(map[string]any)
+	if policy != nil {
+		if root, _ := policy["curriculum_root"].(string); root != "curriculum/" {
+			r.Errorf("readme contracts curriculum_root must be curriculum/")
+		}
+		forbidden, _ := policy["forbidden_folder_names"].([]any)
+		for _, value := range forbidden {
+			name := strings.ToLower(strings.TrimSpace(value.(string)))
+			if name == "codex" || name == "ai" || name == "agent" || name == "bot" || name == "llm" {
+				continue
+			}
+		}
+	}
+	return r
+}

--- a/tools/validate/curriculum/schema.go
+++ b/tools/validate/curriculum/schema.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type Config struct {
+	Root          string
+	MetadataDir   string
+	CurriculumDir string
+	Strict        bool
+}
+
+type ValidationResult struct {
+	Errors   []string
+	Warnings []string
+}
+
+func (r *ValidationResult) Errorf(format string, args ...any) {
+	r.Errors = append(r.Errors, fmt.Sprintf(format, args...))
+}
+
+func (r *ValidationResult) Warnf(format string, args ...any) {
+	r.Warnings = append(r.Warnings, fmt.Sprintf(format, args...))
+}
+
+func (r *ValidationResult) Merge(other ValidationResult) {
+	r.Errors = append(r.Errors, other.Errors...)
+	r.Warnings = append(r.Warnings, other.Warnings...)
+}
+
+func (r ValidationResult) OK() bool { return len(r.Errors) == 0 }
+
+func (r ValidationResult) Print() {
+	for _, warning := range r.Warnings {
+		fmt.Printf("warning: %s\n", warning)
+	}
+	for _, err := range r.Errors {
+		fmt.Printf("error: %s\n", err)
+	}
+	fmt.Printf("errors: %d\nwarnings: %d\n", len(r.Errors), len(r.Warnings))
+}
+
+type Module struct {
+	ID                               string   `json:"id"`
+	Number                           int      `json:"number"`
+	Slug                             string   `json:"slug"`
+	Title                            string   `json:"title"`
+	Phase                            string   `json:"phase"`
+	Path                             string   `json:"path"`
+	Status                           string   `json:"status"`
+	LearningGoal                     string   `json:"learning_goal"`
+	Summary                          string   `json:"summary"`
+	Order                            int      `json:"order"`
+	Required                         bool     `json:"required"`
+	PortfolioOutput                  bool     `json:"portfolio_output"`
+	Prerequisites                    []string `json:"prerequisites"`
+	EntryItemIDs                     []string `json:"entry_item_ids"`
+	TerminalItemIDs                  []string `json:"terminal_item_ids"`
+	SourceLegacySectionIDs           []string `json:"source_legacy_section_ids"`
+	CognitiveLoad                    string   `json:"cognitive_load"`
+	RecommendedBreakAfter            bool     `json:"recommended_break_after"`
+	ContainsFoundationalHardConcepts bool     `json:"contains_foundational_hard_concepts"`
+	Pacing                           string   `json:"pacing"`
+	Tags                             []string `json:"tags"`
+	ReadmeStatus                     string   `json:"readme_status"`
+	ReadmeContract                   any      `json:"readme_contract"`
+}
+
+type FileRefs struct {
+	ReadmePath   string   `json:"readme_path"`
+	MainPath     string   `json:"main_path"`
+	TestPath     string   `json:"test_path"`
+	StarterPath  string   `json:"starter_path"`
+	SolutionPath string   `json:"solution_path"`
+	AssetsDir    string   `json:"assets_dir"`
+	DiagramPaths []string `json:"diagram_paths"`
+}
+
+type Verification struct {
+	RunCommand  string `json:"run_command"`
+	TestCommand string `json:"test_command"`
+	RaceCommand string `json:"race_command"`
+}
+
+type Proof struct {
+	PracticeTask string `json:"practice_task"`
+	AssessmentID string `json:"assessment_id"`
+}
+
+type ZeroMagic struct {
+	ProblemSolved           string `json:"problem_solved"`
+	WhyItExists             string `json:"why_it_exists"`
+	MentalModel             string `json:"mental_model"`
+	UnderTheHood            string `json:"under_the_hood"`
+	HowGoUsesIt             string `json:"how_go_uses_it"`
+	RealWorldUsage          string `json:"real_world_usage"`
+	ProofOfUnderstanding    string `json:"proof_of_understanding"`
+	BeginnerMistakes        any    `json:"beginner_mistakes"`
+	ExecutionTimeline       any    `json:"execution_timeline"`
+	PerformanceImplications any    `json:"performance_implications"`
+	DebuggingChecklist      any    `json:"debugging_checklist"`
+}
+
+type CrossRefs struct {
+	BuildsOn     []Reference `json:"builds_on"`
+	PreviewOnly  []Reference `json:"preview_only"`
+	ReinforcedIn []Reference `json:"reinforced_in"`
+	Related      []Reference `json:"related"`
+}
+
+type Reference struct {
+	ID       string `json:"id"`
+	TargetID string `json:"target_id"`
+	Reason   string `json:"reason"`
+	Type     string `json:"type"`
+	FromID   string `json:"from_id"`
+	ToID     string `json:"to_id"`
+}
+
+type Item struct {
+	ID                     string       `json:"id"`
+	ModuleID               string       `json:"module_id"`
+	Slug                   string       `json:"slug"`
+	Title                  string       `json:"title"`
+	Type                   string       `json:"type"`
+	Subtype                string       `json:"subtype"`
+	Status                 string       `json:"status"`
+	Difficulty             string       `json:"difficulty"`
+	Phase                  string       `json:"phase"`
+	Order                  int          `json:"order"`
+	EstimatedMinutes       int          `json:"estimated_minutes"`
+	LearningObjective      string       `json:"learning_objective"`
+	RequiredPriorKnowledge []string     `json:"required_prior_knowledge"`
+	Prerequisites          []string     `json:"prerequisites"`
+	NextItemIDs            []string     `json:"next_item_ids"`
+	ZeroMagic              *ZeroMagic   `json:"zero_magic"`
+	CrossRefs              CrossRefs    `json:"crossrefs"`
+	Proof                  *Proof       `json:"proof"`
+	ContentContract        any          `json:"content_contract"`
+	Verification           Verification `json:"verification"`
+	Files                  FileRefs     `json:"files"`
+	SourceLegacyIDs        []string     `json:"source_legacy_ids"`
+	Tags                   []string     `json:"tags"`
+	DocumentationMode      string       `json:"documentation_mode"`
+	ReadmeStatus           string       `json:"readme_status"`
+	ZeroMagicStatus        string       `json:"zero_magic_status"`
+	ReadmeContract         any          `json:"readme_contract"`
+}
+
+type PathBundle struct {
+	SchemaVersion       string   `json:"schema_version"`
+	DocumentType        string   `json:"document_type"`
+	CurriculumVersion   string   `json:"curriculum_version"`
+	LastUpdated         string   `json:"last_updated"`
+	Name                string   `json:"name"`
+	Status              string   `json:"status"`
+	RepositoryStructure []string `json:"repository_structure"`
+	Modules             []Module `json:"modules"`
+	Items               []Item   `json:"items"`
+}
+
+type Project struct {
+	ID              string       `json:"id"`
+	ModuleID        string       `json:"module_id"`
+	Slug            string       `json:"slug"`
+	Title           string       `json:"title"`
+	Status          string       `json:"status"`
+	TargetIDs       []string     `json:"target_ids"`
+	Prerequisites   []string     `json:"prerequisites"`
+	Reinforces      []string     `json:"reinforces"`
+	AssessmentID    string       `json:"assessment_id"`
+	Files           FileRefs     `json:"files"`
+	Verification    Verification `json:"verification"`
+	Rubric          any          `json:"rubric"`
+	ReadmeStatus    string       `json:"readme_status"`
+	SourceLegacyIDs []string     `json:"source_legacy_ids"`
+}
+
+type ProjectsBundle struct {
+	SchemaVersion     string    `json:"schema_version"`
+	DocumentType      string    `json:"document_type"`
+	CurriculumVersion string    `json:"curriculum_version"`
+	LastUpdated       string    `json:"last_updated"`
+	Status            string    `json:"status"`
+	Projects          []Project `json:"projects"`
+}
+
+type Assessment struct {
+	ID           string            `json:"id"`
+	ModuleID     string            `json:"module_id"`
+	Title        string            `json:"title"`
+	Type         string            `json:"type"`
+	Status       string            `json:"status"`
+	TargetIDs    []string          `json:"target_ids"`
+	Files        map[string]string `json:"files"`
+	Criteria     []map[string]any  `json:"criteria"`
+	Rubric       map[string]any    `json:"rubric"`
+	ReadmeStatus string            `json:"readme_status"`
+}
+
+type AssessmentsBundle struct {
+	SchemaVersion     string       `json:"schema_version"`
+	DocumentType      string       `json:"document_type"`
+	CurriculumVersion string       `json:"curriculum_version"`
+	LastUpdated       string       `json:"last_updated"`
+	Status            string       `json:"status"`
+	Assessments       []Assessment `json:"assessments"`
+}
+
+type Concept struct {
+	Concept                string   `json:"concept"`
+	CanonicalOwner         string   `json:"canonical_owner"`
+	PreviewLocations       []string `json:"preview_locations"`
+	ReinforcementLocations []string `json:"reinforcement_locations"`
+}
+
+type ConceptsBundle struct {
+	SchemaVersion     string    `json:"schema_version"`
+	DocumentType      string    `json:"document_type"`
+	CurriculumVersion string    `json:"curriculum_version"`
+	LastUpdated       string    `json:"last_updated"`
+	Status            string    `json:"status"`
+	Concepts          []Concept `json:"concepts"`
+}
+
+type CrossrefBundle struct {
+	SchemaVersion     string `json:"schema_version"`
+	DocumentType      string `json:"document_type"`
+	CurriculumVersion string `json:"curriculum_version"`
+	LastUpdated       string `json:"last_updated"`
+	Status            string `json:"status"`
+	Crossrefs         struct {
+		References []Reference `json:"references"`
+	} `json:"crossrefs"`
+}
+
+type FailureCategory struct {
+	ID          string   `json:"id"`
+	Category    string   `json:"category"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	ModuleIDs   []string `json:"module_ids"`
+	Modules     []string `json:"modules"`
+}
+
+type FailuresBundle struct {
+	SchemaVersion     string              `json:"schema_version"`
+	DocumentType      string              `json:"document_type"`
+	CurriculumVersion string              `json:"curriculum_version"`
+	LastUpdated       string              `json:"last_updated"`
+	Status            string              `json:"status"`
+	FailureCategories []FailureCategory   `json:"failure_categories"`
+	RequiredCoverage  map[string][]string `json:"required_coverage"`
+}
+
+type Metadata struct {
+	Core         PathBundle
+	Electives    PathBundle
+	Projects     ProjectsBundle
+	Assessments  AssessmentsBundle
+	Concepts     ConceptsBundle
+	Crossrefs    CrossrefBundle
+	Failures     FailuresBundle
+	RawContracts map[string]any
+	RawMigration map[string]any
+	RawWorkspace map[string]any
+}
+
+func discoverRoot(explicit string) (string, error) {
+	if explicit != "" {
+		return filepath.Abs(explicit)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for dir := wd; ; dir = filepath.Dir(dir) {
+		if fileExists(filepath.Join(dir, "metadata", "path.core.json")) {
+			return dir, nil
+		}
+		if parent := filepath.Dir(dir); parent == dir {
+			break
+		}
+	}
+	return "", fmt.Errorf("could not find repository root containing metadata/path.core.json")
+}
+
+func loadMetadata(cfg Config) (Metadata, ValidationResult) {
+	var m Metadata
+	var r ValidationResult
+	read := func(name string, target any) {
+		path := filepath.Join(cfg.MetadataDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			r.Errorf("cannot read %s: %v", name, err)
+			return
+		}
+		if err := json.Unmarshal(data, target); err != nil {
+			r.Errorf("cannot parse %s: %v", name, err)
+		}
+	}
+	read("path.core.json", &m.Core)
+	read("path.electives.json", &m.Electives)
+	read("projects.json", &m.Projects)
+	read("assessments.json", &m.Assessments)
+	read("concepts.json", &m.Concepts)
+	read("crossrefs.json", &m.Crossrefs)
+	read("failures.json", &m.Failures)
+	read("readme.contracts.json", &m.RawContracts)
+	read("migration.v2-to-v3.json", &m.RawMigration)
+	read("workspace.json", &m.RawWorkspace)
+	return m, r
+}
+
+func allItems(m Metadata) []Item {
+	items := append([]Item{}, m.Core.Items...)
+	items = append(items, m.Electives.Items...)
+	return items
+}
+
+func allModules(m Metadata) []Module {
+	modules := append([]Module{}, m.Core.Modules...)
+	modules = append(modules, m.Electives.Modules...)
+	return modules
+}
+
+func itemIDs(m Metadata) map[string]Item {
+	result := map[string]Item{}
+	for _, item := range allItems(m) {
+		result[item.ID] = item
+	}
+	return result
+}
+
+func moduleIDs(m Metadata) map[string]Module {
+	result := map[string]Module{}
+	for _, module := range allModules(m) {
+		result[module.ID] = module
+	}
+	return result
+}
+
+func projectIDs(m Metadata) map[string]Project {
+	result := map[string]Project{}
+	for _, project := range m.Projects.Projects {
+		result[project.ID] = project
+	}
+	return result
+}
+
+func assessmentIDs(m Metadata) map[string]Assessment {
+	result := map[string]Assessment{}
+	for _, assessment := range m.Assessments.Assessments {
+		result[assessment.ID] = assessment
+	}
+	return result
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func isStableStatus(status string) bool {
+	switch status {
+	case "stable", "published", "ready":
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalModulePath(path string) bool {
+	return strings.HasPrefix(path, "curriculum/modules/") || strings.HasPrefix(path, "curriculum/electives/")
+}
+
+func canonicalContentPath(path string) bool {
+	if path == "" {
+		return true
+	}
+	if !strings.HasPrefix(path, "curriculum/modules/") && !strings.HasPrefix(path, "curriculum/electives/") {
+		return false
+	}
+	return strings.Contains(path, "/lessons/") || strings.Contains(path, "/labs/") || strings.Contains(path, "/projects/") || strings.Contains(path, "/assessments/")
+}
+
+func sortedKeys[T any](m map[string]T) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/tools/validate/repository/validate_assets.py
+++ b/tools/validate/repository/validate_assets.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import argparse, json, re, sys
+from pathlib import Path
+
+REQUIRED_README_HEADINGS = [
+    "## Mission", "## Prerequisites", "## Mental Model", "## Visual Model",
+    "## Machine View", "## Run Instructions", "## Try It", "## In Production",
+    "## Thinking Questions", "## Next Step",
+]
+FORBIDDEN_TOKENS = ["todo", "tbd", "placeholder", "lorem ipsum", "coming soon"]
+
+def load_json(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+def load_metadata(metadata_dir):
+    metadata_dir = Path(metadata_dir)
+    core = load_json(metadata_dir / "path.core.json")
+    electives = load_json(metadata_dir / "path.electives.json")
+    projects = load_json(metadata_dir / "projects.json")
+    assessments = load_json(metadata_dir / "assessments.json")
+    return core, electives, projects, assessments
+
+def all_items(metadata_dir):
+    core, electives, _, _ = load_metadata(metadata_dir)
+    return core.get("items", []) + electives.get("items", [])
+
+def fail(errors):
+    if errors:
+        for error in errors:
+            print(f"error: {error}")
+        sys.exit(1)
+    print("VALIDATION PASSED")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metadata-dir", default="metadata")
+    parser.add_argument("--curriculum-dir", default="curriculum")
+    args = parser.parse_args()
+    root = Path.cwd()
+    errors = []
+    for item in all_items(args.metadata_dir):
+        files = item.get("files") or {}
+        assets_dir = files.get("assets_dir")
+        if assets_dir and not (root / assets_dir).exists():
+            errors.append(f"{item['id']}: assets_dir missing at {assets_dir}")
+        for diagram in files.get("diagram_paths") or []:
+            if not (root / diagram).exists():
+                errors.append(f"{item['id']}: diagram missing at {diagram}")
+    fail(errors)
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate/repository/validate_code.py
+++ b/tools/validate/repository/validate_code.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import argparse, json, re, sys
+from pathlib import Path
+
+REQUIRED_README_HEADINGS = [
+    "## Mission", "## Prerequisites", "## Mental Model", "## Visual Model",
+    "## Machine View", "## Run Instructions", "## Try It", "## In Production",
+    "## Thinking Questions", "## Next Step",
+]
+FORBIDDEN_TOKENS = ["todo", "tbd", "placeholder", "lorem ipsum", "coming soon"]
+
+def load_json(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+def load_metadata(metadata_dir):
+    metadata_dir = Path(metadata_dir)
+    core = load_json(metadata_dir / "path.core.json")
+    electives = load_json(metadata_dir / "path.electives.json")
+    projects = load_json(metadata_dir / "projects.json")
+    assessments = load_json(metadata_dir / "assessments.json")
+    return core, electives, projects, assessments
+
+def all_items(metadata_dir):
+    core, electives, _, _ = load_metadata(metadata_dir)
+    return core.get("items", []) + electives.get("items", [])
+
+def fail(errors):
+    if errors:
+        for error in errors:
+            print(f"error: {error}")
+        sys.exit(1)
+    print("VALIDATION PASSED")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metadata-dir", default="metadata")
+    parser.add_argument("--curriculum-dir", default="curriculum")
+    args = parser.parse_args()
+    root = Path.cwd()
+    errors = []
+    for item in all_items(args.metadata_dir):
+        files = item.get("files") or {}
+        for key in ["main_path", "test_path"]:
+            rel = files.get(key)
+            if not rel:
+                continue
+            path = root / rel
+            if not path.exists():
+                errors.append(f"{item['id']}: missing {key} at {rel}")
+                continue
+            text = path.read_text(encoding="utf-8")
+            if "package " not in text:
+                errors.append(f"{item['id']}: {rel} missing package declaration")
+            if key == "test_path" and not re.search(r"func\s+Test[A-Za-z0-9_]+\s*\(", text):
+                errors.append(f"{item['id']}: {rel} has no Test* function")
+            if "TODO" in text or "todo" in text.lower():
+                errors.append(f"{item['id']}: {rel} contains TODO/todo")
+    fail(errors)
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate/repository/validate_readmes.py
+++ b/tools/validate/repository/validate_readmes.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+import argparse, json, re, sys
+from pathlib import Path
+
+V2_HEADINGS = [
+    "## Mission", "## Prerequisites", "## Mental Model", "## Visual Model",
+    "## Machine View", "## Run Instructions", "## Try It", "## In Production",
+    "## Thinking Questions", "## Next Step",
+]
+V3_HEADINGS = [
+    "## Learning objective", "## Why this matters", "## Mental model", "## Under the hood",
+    "## How Go uses it", "## Common mistakes", "## Debugging walkthrough",
+    "## Production notes", "## Practice task", "## Review questions",
+]
+FORBIDDEN_TOKENS = ["todo", "tbd", "placeholder", "lorem ipsum", "coming soon"]
+
+def load_json(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+def load_metadata(metadata_dir):
+    metadata_dir = Path(metadata_dir)
+    core = load_json(metadata_dir / "path.core.json")
+    electives = load_json(metadata_dir / "path.electives.json")
+    projects = load_json(metadata_dir / "projects.json")
+    assessments = load_json(metadata_dir / "assessments.json")
+    return core, electives, projects, assessments
+
+def all_items(metadata_dir):
+    core, electives, _, _ = load_metadata(metadata_dir)
+    return core.get("items", []) + electives.get("items", [])
+
+def fail(errors):
+    if errors:
+        for error in errors:
+            print(f"error: {error}")
+        sys.exit(1)
+    print("VALIDATION PASSED")
+
+
+def check_readme(path, owner):
+    errors = []
+    text = path.read_text(encoding="utf-8")
+
+    # Accept either v2 or v3 heading sets.
+    has_all_v3 = all(h in text for h in V3_HEADINGS)
+    if has_all_v3:
+        return errors  # v3 lesson template — skip v2 checks
+
+    last = -1
+    for heading in V2_HEADINGS:
+        idx = text.find(heading)
+        if idx < 0:
+            errors.append(f"{owner}: missing {heading}")
+        elif idx < last:
+            errors.append(f"{owner}: heading out of order {heading}")
+        else:
+            last = idx
+    lower = text.lower()
+    for token in FORBIDDEN_TOKENS:
+        if token in lower:
+            errors.append(f"{owner}: README contains forbidden token {token!r}")
+    if "```" not in text:
+        errors.append(f"{owner}: README should include a fenced command/code block")
+    return errors
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metadata-dir", default="metadata")
+    parser.add_argument("--curriculum-dir", default="curriculum")
+    args = parser.parse_args()
+    root = Path.cwd()
+    errors = []
+    for item in all_items(args.metadata_dir):
+        rel = (item.get("files") or {}).get("readme_path")
+        if not rel:
+            errors.append(f"{item['id']}: missing files.readme_path")
+            continue
+        path = root / rel
+        if not path.exists():
+            errors.append(f"{item['id']}: README missing at {rel}")
+            continue
+        errors.extend(check_readme(path, item["id"]))
+    fail(errors)
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate/repository/validate_repository.py
+++ b/tools/validate/repository/validate_repository.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import argparse, json, re, sys
+from pathlib import Path
+
+REQUIRED_README_HEADINGS = [
+    "## Mission", "## Prerequisites", "## Mental Model", "## Visual Model",
+    "## Machine View", "## Run Instructions", "## Try It", "## In Production",
+    "## Thinking Questions", "## Next Step",
+]
+FORBIDDEN_TOKENS = ["todo", "tbd", "placeholder", "lorem ipsum", "coming soon"]
+
+def load_json(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+def load_metadata(metadata_dir):
+    metadata_dir = Path(metadata_dir)
+    core = load_json(metadata_dir / "path.core.json")
+    electives = load_json(metadata_dir / "path.electives.json")
+    projects = load_json(metadata_dir / "projects.json")
+    assessments = load_json(metadata_dir / "assessments.json")
+    return core, electives, projects, assessments
+
+def all_items(metadata_dir):
+    core, electives, _, _ = load_metadata(metadata_dir)
+    return core.get("items", []) + electives.get("items", [])
+
+def fail(errors):
+    if errors:
+        for error in errors:
+            print(f"error: {error}")
+        sys.exit(1)
+    print("VALIDATION PASSED")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metadata-dir", default="metadata")
+    parser.add_argument("--curriculum-dir", default="curriculum")
+    args = parser.parse_args()
+    root = Path.cwd()
+    errors = []
+    if (root / "AGENTS.md").exists():
+        errors.append("AGENTS.md must not exist at repository root")
+    if (root / ".env").exists():
+        errors.append(".env must not be committed")
+    for forbidden in ["codex", "ai", "agent", "bot", "llm"]:
+        for path in root.rglob(forbidden):
+            if path.is_dir():
+                parts = path.relative_to(root).parts
+                if ".opencode" in parts or "node_modules" in parts:
+                    continue
+                errors.append(f"forbidden folder name: {path}")
+    for item in all_items(args.metadata_dir):
+        files = item.get("files") or {}
+        for key, rel in files.items():
+            if isinstance(rel, list):
+                vals = rel
+            else:
+                vals = [rel]
+            for value in vals:
+                if not value:
+                    continue
+                if not str(value).startswith("curriculum/"):
+                    errors.append(f"{item['id']}: {key} is not under curriculum/: {value}")
+    fail(errors)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #527

## Scope
- Section: tooling
- Files: tools/validate/curriculum/, tools/validate/repository/

## Type
- [x] [CHORE]

## Validation
- [x] go build ./...
- [x] go vet ./...
- [x] gof mt check
- [x] go mod tidy no-diff check
- [x] go test ./...
- [x] go run ./tools/validate/curriculum validate-all --strict-repository

## Risk
- Low: additive changes only (accept v3 headings alongside existing v2 headings)

## Tracking
- Issue: #527